### PR TITLE
Restore studio-spec SECAM subcarriers from ME-SECAM VHS

### DIFF
--- a/tests/unit/test_secam_chroma.py
+++ b/tests/unit/test_secam_chroma.py
@@ -1,0 +1,185 @@
+"""Tests for the SECAM/MESECAM chroma up-conversion.
+
+ME-SECAM (IEC 60774-1 Annex E) is recorded like PAL colour-under with an
+inverting mix against the PAL converter LO of 5060571.875 Hz, so up-converting
+with that same LO must put the rest carriers back on the studio frequencies
+foR = 4406250 Hz and foB = 4250000 Hz (ITU-R BT.470/BT.1700).
+"""
+
+import logging
+
+import numpy as np
+import scipy.signal as sps
+
+import vhsdecode.process as process
+import vhsdecode.formats as vhs_formats
+from vhsdecode.addons.chromaAFC import ChromaAFC
+from vhsdecode.chroma import measure_secam_under_carrier_offset
+
+FOR = 4406250.0
+FOB = 4250000.0
+CONVERSION_LO = 5060571.875
+DR_UNDER = CONVERSION_LO - FOR  # 654321.875 Hz
+DB_UNDER = CONVERSION_LO - FOB  # 810571.875 Hz
+
+LINES = 313
+
+
+def _get_params():
+    return vhs_formats.get_format_params(
+        "MESECAM", "VHS", 0, logging.getLogger("test")
+    )
+
+
+def _make_afc(sys_params, rf_params):
+    return ChromaAFC(
+        40e6,
+        rf_params["chroma_bpf_upper"] / rf_params["color_under_carrier"],
+        sys_params,
+        rf_params["color_under_carrier"],
+        tape_format="VHS",
+        do_cafc=False,
+        conversion_lo_freq=rf_params["chroma_conversion_lo"],
+    )
+
+
+def _make_under_signal(outlinelen, true_rate, crystal_error_hz):
+    """Line-alternating colour-under rest carriers as they come off the TBC."""
+    num_samples = LINES * outlinelen
+    t = np.arange(num_samples) / true_rate
+    sig = np.zeros(num_samples)
+    for line in range(LINES):
+        start, end = line * outlinelen, (line + 1) * outlinelen
+        freq = (DR_UNDER if line % 2 else DB_UNDER) + crystal_error_hz
+        sig[start:end] = np.sin(2 * np.pi * freq * t[start:end])
+    return sig
+
+
+def _measure_restored_carriers(afc, uphet, outlinelen, true_rate):
+    """Median instantaneous frequency of the mixed+filtered signal per line parity."""
+    filtered = sps.sosfiltfilt(afc.get_chroma_bandpass_final(True), uphet)
+    analytic = sps.hilbert(filtered)
+    f_inst = np.diff(np.unwrap(np.angle(analytic))) * true_rate / (2 * np.pi)
+    odd, even = [], []
+    for line in range(20, LINES - 20):
+        start = line * outlinelen + 200
+        end = (line + 1) * outlinelen - 200
+        (odd if line % 2 else even).append(np.median(f_inst[start:end]))
+    return np.median(odd), np.median(even)
+
+
+class TestMESECAMUpconversion:
+    def test_format_params(self):
+        sys_params, rf_params = _get_params()
+
+        assert rf_params["chroma_conversion_lo"] == CONVERSION_LO
+        # fsc must stay at the PAL value so it is consistent with outlinelen
+        # and the true TBC output rate.
+        assert sys_params["fsc_mhz"] == 4.43361875
+        assert rf_params["color_under_carrier"] == (DR_UNDER + DB_UNDER) / 2
+
+    def test_carriers_restored_to_studio_frequencies(self):
+        sys_params, rf_params = _get_params()
+        afc = _make_afc(sys_params, rf_params)
+        outlinelen = sys_params["outlinelen"]
+        true_rate = outlinelen * sys_params["FPS"] * sys_params["frame_lines"]
+        num_samples = LINES * outlinelen
+
+        sig = _make_under_signal(outlinelen, true_rate, 0.0)
+        het = afc.getChromaHet()[0][:num_samples]
+        restored_dr, restored_db = _measure_restored_carriers(
+            afc, sig * het, outlinelen, true_rate
+        )
+
+        # The old code restored the carriers about 110 kHz high.
+        np.testing.assert_allclose(restored_dr, FOR, atol=5)
+        np.testing.assert_allclose(restored_db, FOB, atol=5)
+
+    def test_servo_measures_crystal_error(self):
+        sys_params, rf_params = _get_params()
+        afc = _make_afc(sys_params, rf_params)
+        outlinelen = sys_params["outlinelen"]
+        true_rate = outlinelen * sys_params["FPS"] * sys_params["frame_lines"]
+        num_samples = LINES * outlinelen
+
+        error = 1500.0
+        sig = _make_under_signal(outlinelen, true_rate, error)
+
+        active_start_px = int(10.5e-6 * true_rate)
+        window = (active_start_px - 65, active_start_px - 5)
+        measured = measure_secam_under_carrier_offset(
+            sig, LINES, outlinelen, window, true_rate, afc.color_under
+        )
+
+        assert measured is not None
+        # Single-field accuracy is on the order of +-100 Hz.
+        np.testing.assert_allclose(measured, error, atol=150)
+
+        # Applying the measurement as LO trim must bring the restored
+        # carriers back near nominal.
+        afc.updateConversion(measured, 0)
+        het = afc.getChromaHet()[0][:num_samples]
+        restored_dr, restored_db = _measure_restored_carriers(
+            afc, sig * het, outlinelen, true_rate
+        )
+        np.testing.assert_allclose(restored_dr, FOR, atol=200)
+        np.testing.assert_allclose(restored_db, FOB, atol=200)
+
+    def test_servo_rejects_signal_without_carrier_pair(self):
+        sys_params, rf_params = _get_params()
+        afc = _make_afc(sys_params, rf_params)
+        outlinelen = sys_params["outlinelen"]
+        true_rate = outlinelen * sys_params["FPS"] * sys_params["frame_lines"]
+
+        rng = np.random.default_rng(1234)
+        noise = rng.normal(0, 1, LINES * outlinelen)
+        active_start_px = int(10.5e-6 * true_rate)
+        window = (active_start_px - 65, active_start_px - 5)
+        measured = measure_secam_under_carrier_offset(
+            noise, LINES, outlinelen, window, true_rate, afc.color_under
+        )
+
+        assert measured is None
+
+    def test_heterodyne_phase_continuous_across_fields(self):
+        sys_params, rf_params = _get_params()
+        afc = _make_afc(sys_params, rf_params)
+        outlinelen = sys_params["outlinelen"]
+        num_samples = LINES * outlinelen
+
+        afc.updateConversion(0.0, 0)
+        field0 = afc.getChromaHet()[0][:num_samples].copy()
+        afc.updateConversion(0.0, num_samples)
+        field1 = afc.getChromaHet()[0][:outlinelen].copy()
+
+        joined = np.concatenate([field0, field1])
+        # A phase step shows up as a spike in the second difference.
+        second_diff = np.abs(np.diff(joined, 2))
+        boundary = second_diff[num_samples - 10 : num_samples + 10].max()
+        assert boundary <= second_diff[: num_samples // 2].max() * 1.01
+
+
+class TestMESECAMDecoderConstruction:
+    def test_construct(self):
+        decoder = process.VHSRFDecode(inputfreq=40, system="MESECAM")
+
+        # SECAM has no phase-locked burst, so burst-locked hsync must be off.
+        assert decoder.options.disable_burst_hsync
+        # cafc peak measurement is meaningless on the two-carrier SECAM signal.
+        assert not decoder.do_cafc
+        assert decoder.chroma_afc.conversion_lo == CONVERSION_LO
+        # No trim seed given, so the servo average starts empty and no trim
+        # is applied until enough fields have been measured.
+        assert not decoder.secam_servo_avg.has_values()
+
+    def test_lo_trim_seed(self):
+        decoder = process.VHSRFDecode(
+            inputfreq=40,
+            system="MESECAM",
+            rf_options={"secam_lo_trim": 2000.0},
+        )
+
+        # Seeded (e.g. by the two-pass calibration) so the trim applies from
+        # the first field.
+        assert decoder.secam_servo_avg.has_values()
+        np.testing.assert_allclose(decoder.secam_servo_avg.pull(), 2000.0)

--- a/tools/mesecam-decode/README.md
+++ b/tools/mesecam-decode/README.md
@@ -28,7 +28,7 @@ Download the Graph & Script here:
 ## Graphs
 
 
-Colour values are set to properly decode colour of TBC files who were decoded by using the MESECAM option in vhs-decode. 
+The Color Blue/Red values default to the studio SECAM subcarrier rest frequencies (foB = 4.25 MHz, foR = 4.40625 MHz, i.e. 4.25e6/350e3 and 4.40625e6/350e3), matching TBC files decoded with the MESECAM option in current vhs-decode. For TBC files made with older vhs-decode versions, whose restored carriers sat about 108 kHz high, use the previous values of 12.45 and 12.90 instead.
 
 Also MESECAM option should be the preferred one for decoding, as there are less colour streaks in the decoded video.
 

--- a/tools/mesecam-decode/secam_to_yuv.grc
+++ b/tools/mesecam-decode/secam_to_yuv.grc
@@ -630,9 +630,9 @@ blocks:
       \ndf0B = 230 \xB17kHz [nominal deviation of B-Y subcarrier]"
     decim: '1'
     gain: '1'
-    high_cutoff_freq: 4250000+1000000
+    high_cutoff_freq: 4250000+750000
     interp: '1'
-    low_cutoff_freq: 4250000-1000000
+    low_cutoff_freq: 4250000-750000
     maxoutbuf: '0'
     minoutbuf: '0'
     samp_rate: round(samp_rate*1.0009)
@@ -656,9 +656,9 @@ blocks:
       \ndf0R = 280 \xB19kHz [nominal deviation of R-Y subcarrier]"
     decim: '1'
     gain: '1'
-    high_cutoff_freq: 4406250+1000000
+    high_cutoff_freq: 4406250+750000
     interp: '1'
-    low_cutoff_freq: 4406250-1000000
+    low_cutoff_freq: 4406250-750000
     maxoutbuf: '0'
     minoutbuf: '0'
     samp_rate: round(samp_rate*1.0009)

--- a/tools/mesecam-decode/secam_to_yuv.grc
+++ b/tools/mesecam-decode/secam_to_yuv.grc
@@ -43,9 +43,9 @@ blocks:
     orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '10'
-    step: '0.05'
+    step: '0.005'
     stop: '14'
-    value: '12.45'
+    value: 4.25e6/350e3
     widget: counter_slider
   states:
     bus_sink: false
@@ -64,9 +64,9 @@ blocks:
     orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '10'
-    step: '0.05'
+    step: '0.005'
     stop: '14'
-    value: '12.90'
+    value: 4.40625e6/350e3
     widget: counter_slider
   states:
     bus_sink: false
@@ -652,13 +652,13 @@ blocks:
     affinity: ''
     alias: ''
     beta: '0'
-    comment: "Dr = V\nf0R = 4 406 260 \xB12 000Hz [B-Y subcarrier rest frequency]\r\
+    comment: "Dr = V\nf0R = 4 406 250 \xB12 000Hz [R-Y subcarrier rest frequency]\r\
       \ndf0R = 280 \xB19kHz [nominal deviation of R-Y subcarrier]"
     decim: '1'
     gain: '1'
-    high_cutoff_freq: 4406260+1000000
+    high_cutoff_freq: 4406250+1000000
     interp: '1'
-    low_cutoff_freq: 4406260-1000000
+    low_cutoff_freq: 4406250-1000000
     maxoutbuf: '0'
     minoutbuf: '0'
     samp_rate: round(samp_rate*1.0009)

--- a/vhsdecode/addons/chromaAFC.py
+++ b/vhsdecode/addons/chromaAFC.py
@@ -26,11 +26,23 @@ class ChromaAFC:
         tape_format="VHS",
         do_cafc=False,
         chroma_bpf_lower=60000,
+        conversion_lo_freq=None,
     ):
         self.tape_format = tape_format
         self.fv = sys_params["FPS"] * 2
         self.fh = sys_params["FPS"] * sys_params["frame_lines"]
         self.color_under = color_under_carrier_f
+        # Explicit colour-under conversion LO (Hz). When set (ME-SECAM), the
+        # up-conversion mixes against this frequency instead of
+        # fsc + color under carrier, referenced to the true TBC output rate
+        # so the restored carriers land exactly on their studio frequencies.
+        self.conversion_lo = conversion_lo_freq
+        self.conversion_lo_trim = 0.0
+        self.het_sample_offset = 0
+        # The rate the TBC output is actually clocked at (outlinelen samples
+        # per line period), as opposed to samp_rate = 4 * fsc which outlinelen
+        # only approximates after rounding to whole samples.
+        self.true_samp_rate = sys_params["outlinelen"] * self.fh
         self.cc_phase = 0
         self.power_threshold = 1 / 3
         self.transition_expand = 12
@@ -166,6 +178,22 @@ class ChromaAFC:
         Which is a -cosine of fcc + fsc frequency, and
         phase_cc phase, assuming phase_sc = 0
         """
+        if self.conversion_lo is not None:
+            # ME-SECAM: mix against the recorder's conversion LO directly.
+            # The heterodyne phases are never rotated for SECAM, so a single
+            # wave is generated and reused for all four phase slots.
+            het_wave_scale = (
+                self.conversion_lo + self.conversion_lo_trim
+            ) / self.true_samp_rate
+            # Continue the carrier phase from where the previous fields left
+            # off so the restored FM carrier has no phase step (heard by a
+            # SECAM decoder as a chroma click) at field boundaries.
+            phase_offset = twopi * ((het_wave_scale * self.het_sample_offset) % 1.0)
+            wave = -np.cos(
+                (twopi * het_wave_scale * self.samples) + phase_offset
+            ).astype(np.float32)
+            return np.array([wave, wave, wave, wave])
+
         het_freq = self.fsc_mhz + self.cc_freq_mhz
         het_wave_scale = het_freq / self.out_sample_rate_mhz
 
@@ -231,6 +259,21 @@ class ChromaAFC:
     #                sps.sosfiltfilt(het_filter, cc_wave_270 * self.fsc_wave),
     #            ]
     #        )
+
+    # Updates the conversion LO trim (Hz) and the absolute output sample
+    # position of the start of the current field, regenerating the heterodyne
+    # table when either changed. Only used when conversion_lo is set (ME-SECAM).
+    def updateConversion(self, lo_trim_hz, het_sample_offset):
+        if (
+            lo_trim_hz != self.conversion_lo_trim
+            or het_sample_offset != self.het_sample_offset
+        ):
+            self.conversion_lo_trim = lo_trim_hz
+            self.het_sample_offset = het_sample_offset
+            self.genHetC()
+
+    def getConversionTrim(self):
+        return self.conversion_lo_trim
 
     # Returns the chroma heterodyning wave table/array computed after genHetC()
     def getChromaHet(self):

--- a/vhsdecode/addons/chromaAFC.py
+++ b/vhsdecode/addons/chromaAFC.py
@@ -512,20 +512,29 @@ class ChromaAFC:
     # Needs tweaking.
     # Note: order will be doubled since we use filtfilt.
     def get_chroma_bandpass_final(self, color_under_format=True):
-        if color_under_format:
-            lower = (self.color_under / 1e6) * 0.9
-            upper = (self.color_under / 1e6) * 0.75
+        if color_under_format and self.conversion_lo is not None:
+            # ME-SECAM: place the band around the restored chroma block
+            # rather than around fsc. A tight top edge matters: it suppresses
+            # high-side FM splatter from saturated transitions, which
+            # otherwise reaches downstream discriminators with wide take-off
+            # filters and turns into clicks/streaks at color edges.
+            center = (self.conversion_lo - self.color_under) / 1e6
+            band_low = center - 0.67
+            band_high = center + 0.55
+        elif color_under_format:
+            band_low = self.fsc_mhz - (self.color_under / 1e6) * 0.9
+            band_high = self.fsc_mhz + (self.color_under / 1e6) * 0.75
         else:
             # Using a narrow filter atm as this is just used for
             # picking out burst signal in this case.
-            lower = 0.1
-            upper = 0.1
+            band_low = self.fsc_mhz - 0.1
+            band_high = self.fsc_mhz + 0.1
 
         return sps.butter(
             4,
             [
-                (self.fsc_mhz - lower) / self.out_frequency_half,
-                (self.fsc_mhz + upper) / self.out_frequency_half,
+                band_low / self.out_frequency_half,
+                band_high / self.out_frequency_half,
             ],
             btype="bandpass",
             output="sos",

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -3,6 +3,7 @@ import numpy as np
 import lddecode.utils as lddu
 import lddecode.core as ldd
 import scipy.signal as sps
+import scipy.fft as sps_fft
 from vhsdecode.rust_utils import sosfiltfilt_rust
 
 from numba import njit
@@ -647,6 +648,86 @@ def decode_chroma_phase_rotation(
 
     return track_phase, phase_sequence, burst_detected_line, burst_magnitude_avg, burst_phase_avg, even_burst_phase_avg, odd_burst_phase_avg
 
+
+def measure_secam_under_carrier_offset(
+    chroma,
+    linesout,
+    outwidth,
+    window,
+    samp_rate,
+    pair_center,
+):
+    """Measure how far the ME-SECAM colour-under rest carrier pair sits from
+    its nominal position, using the undeviated subcarrier on the late back
+    porch of each line (the early porch is still sweeping from the previous
+    line's carrier switch). This picks up the recording VCR's down-conversion
+    crystal error, which otherwise ends up as an offset of both restored
+    subcarriers. (SECAM method 1 has no conversion crystal, so this only
+    applies to the heterodyne method.)
+
+    Returns the offset in Hz of the measured pair midpoint from pair_center,
+    or None if no reliable measurement could be made. Single-field accuracy
+    is on the order of +-100 Hz (ringing from the per-line carrier switch
+    beats across the short porch window); averaging across fields washes
+    this out. Crystal errors being chased are in the kHz range.
+    """
+    # Stay clear of the vertical interval and head switch area.
+    SKIP_LINES = 20
+    MIN_LINES_PER_CLUSTER = 8
+    # The carriers are nominally 156.25 kHz apart; reject measurements where
+    # the two clusters land somewhere else entirely.
+    MIN_SEPARATION = 90e3
+    MAX_SEPARATION = 230e3
+
+    window_start, window_end = window
+    freq_scale = samp_rate / (2 * np.pi)
+
+    # Analytic signal over the whole field so the short per-line windows are
+    # free of transform edge effects (a windowed transform of just the porch
+    # would bias the frequency estimate by hundreds of Hz).
+    n_fft = sps_fft.next_fast_len(len(chroma))
+    analytic = sps.hilbert(chroma, N=n_fft)[: len(chroma)]
+
+    freqs = []
+    envs = []
+
+    for linenumber in range(SKIP_LINES, linesout - SKIP_LINES):
+        line_start = linenumber * outwidth
+        start = line_start + window_start
+        end = line_start + window_end
+        if start < 0 or end > len(chroma):
+            continue
+
+        window_analytic = analytic[start:end]
+        # Instantaneous frequency; median rejects FM clicks and noise spikes.
+        f_inst = np.diff(np.unwrap(np.angle(window_analytic))) * freq_scale
+        freqs.append(np.median(f_inst))
+        envs.append(np.median(np.abs(window_analytic)))
+
+    if not freqs:
+        return None
+
+    freqs = np.asarray(freqs)
+    envs = np.asarray(envs)
+
+    # Ignore lines where the porch carrier is too weak to measure
+    # (dropouts, colour killed lines).
+    valid = envs > (np.median(envs) * 0.25)
+    low = freqs[valid & (freqs < pair_center)]
+    high = freqs[valid & (freqs >= pair_center)]
+
+    if len(low) < MIN_LINES_PER_CLUSTER or len(high) < MIN_LINES_PER_CLUSTER:
+        return None
+
+    low_carrier = np.median(low)
+    high_carrier = np.median(high)
+    separation = high_carrier - low_carrier
+    if separation < MIN_SEPARATION or separation > MAX_SEPARATION:
+        return None
+
+    return ((low_carrier + high_carrier) / 2) - pair_center
+
+
 ntsc_color_framing_phase_shift = 33
 ntsc_color_framing_map = {
     # Color Frame I
@@ -723,6 +804,29 @@ def process_chroma(
                     % (meas / 1e3, offset, cphase * 360 / (2 * np.pi))
                 )
 
+        if (
+            field.rf.color_system == "MESECAM"
+            and field.rf.options.secam_carrier_servo
+        ):
+            # Measure the rest carrier pair on the late back porch,
+            # 3.7 to 0.3 us before active video starts.
+            active_start_px = field.usectooutpx(field.rf.SysParams["activeVideoUS"][0])
+            porch_window = (int(active_start_px) - 65, int(active_start_px) - 5)
+
+            carrier_offset = measure_secam_under_carrier_offset(
+                chroma,
+                linesout,
+                outwidth,
+                porch_window,
+                field.rf.chroma_afc.true_samp_rate,
+                field.rf.chroma_afc.color_under,
+            )
+            if carrier_offset is not None:
+                field.rf.secam_servo_avg.push(carrier_offset)
+                ldd.logger.debug(
+                    "SECAM carrier servo: measured offset %.02f Hz" % carrier_offset
+                )
+
         field.rf.chroma_tbc_buffer = chroma
         field.chroma_tbc_buffer = chroma
     else:
@@ -767,12 +871,32 @@ def process_chroma(
             target_phase_odd
         )
     else:
-        chroma_heterodyne = (
-            field.rf.chroma_afc.getChromaHet()
-            if (field.rf.do_cafc and not disable_tracking_cafc)
-            else field.rf.chroma_heterodyne
-        )
-    
+        if field.rf.chroma_afc.conversion_lo is not None:
+            # Explicit conversion LO (ME-SECAM): trim it by the smoothed
+            # measured carrier offset (cancelling the recording VCR's
+            # converter crystal error), and keep the heterodyne phase
+            # continuous across fields.
+            lo_trim = 0.0
+            # Holds either live servo measurements or a seeded/fixed trim
+            # (secam_lo_trim); with the servo disabled and no seed it's empty.
+            if field.rf.secam_servo_avg.has_values():
+                # Quantize so measurement noise doesn't dither the LO.
+                lo_trim = np.clip(
+                    round(field.rf.secam_servo_avg.pull() / 10.0) * 10.0,
+                    -10e3,
+                    10e3,
+                )
+            field.rf.chroma_afc.updateConversion(
+                lo_trim, field.field_number * linesout * outwidth
+            )
+            chroma_heterodyne = field.rf.chroma_afc.getChromaHet()
+        else:
+            chroma_heterodyne = (
+                field.rf.chroma_afc.getChromaHet()
+                if (field.rf.do_cafc and not disable_tracking_cafc)
+                else field.rf.chroma_heterodyne
+            )
+
         upconvert_chroma(
             chroma,
             uphet,

--- a/vhsdecode/format_defs/vhs.py
+++ b/vhsdecode/format_defs/vhs.py
@@ -430,9 +430,18 @@ def get_sysparams_palm_vhs(sysparams_ntsc: dict, tape_speed: int = 0) -> dict:
 def get_rfparams_mesecam_vhs(rfparams_pal: dict, tape_speed: int = 0) -> dict:
     params = get_rfparams_pal_vhs(rfparams_pal, tape_speed)
 
-    # Average of the two carriers specified, need to check if this works correctly
-    # and calculate exact value
-    params["color_under_carrier"] = (654300 + 810500) / 2
+    # ME-SECAM records the SECAM FM chroma block the same way as PAL colour-under
+    # (IEC 60774-1 Annex E / 6.3.1) but without carrier phase rotation and with the
+    # APC disabled: an inverting mix against the PAL converter LO of
+    # fsc + (40 * fh + 1953) = 4433618.75 + 626953.125 = 5060571.875 Hz.
+    # That puts the rest carriers on tape at:
+    #   D'r: 5060571.875 - 4406250 = 654321.875 Hz
+    #   D'b: 5060571.875 - 4250000 = 810571.875 Hz
+    # color_under_carrier is only used for band-pass centering; the up-conversion
+    # mixes against chroma_conversion_lo so the restored carriers land back on the
+    # studio frequencies (ITU-R BT.470: foR 4406250 Hz, foB 4250000 Hz).
+    params["color_under_carrier"] = (654321.875 + 810571.875) / 2
+    params["chroma_conversion_lo"] = 5060571.875
     params["chroma_rotation"] = None
 
     return params
@@ -441,13 +450,8 @@ def get_rfparams_mesecam_vhs(rfparams_pal: dict, tape_speed: int = 0) -> dict:
 def get_sysparams_mesecam_vhs(sysparams_pal: dict, tape_speed: int = 0) -> dict:
     """Get system params for MESECAM VHS"""
 
-    # This will be the same as PAL other than chroma
-    sysparams = get_sysparams_pal_vhs(sysparams_pal, tape_speed)
-
-    # FSC specified in Panasonic NV-F55/95 handbook, need to check if this is correct
-    # This differs from normal SECAM, possibly it's done like this to put the upconverted
-    # subcarriers at the correct frequencies.
-    # TODO: Needs testing
-    sysparams["fsc_mhz"] = 4.406
-
-    return sysparams
+    # Same as PAL, including fsc_mhz, so the TBC output stays at standard PAL 4fsc
+    # and stays consistent with outlinelen (which is derived from the PAL fsc before
+    # this function runs). The restored SECAM subcarriers are placed by
+    # chroma_conversion_lo rather than by fsc + color under carrier.
+    return get_sysparams_pal_vhs(sysparams_pal, tape_speed)

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -5,6 +5,7 @@ import signal
 import traceback
 import json
 import shutil
+import tempfile
 import time
 import faulthandler
 import math
@@ -335,6 +336,22 @@ def main(args=None, use_gui=False):
         help="Disables using the color burst phase to refine hsync.",
     )
     chroma_group.add_argument(
+        "--secam_servo_passes",
+        dest="secam_servo_passes",
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        help="SECAM carrier servo mode: 0 disables measuring the rest carrier pair to fine-tune the chroma up-conversion, 1 measures and adapts during the decode (default), 2 runs a short calibration decode first and applies the converged LO trim from the first field. (ME-SECAM only; method 1 SECAM has no conversion crystal to correct for)",
+    )
+    chroma_group.add_argument(
+        "--secam_lo_trim",
+        dest="secam_lo_trim",
+        type=float,
+        default=None,
+        metavar="hz",
+        help="Seeds the SECAM chroma conversion LO trim in Hz (e.g. a converged servo value from a previous run) so it applies from the first field. With --secam_servo_passes 0 the value is used as a fixed trim. (ME-SECAM only)",
+    )
+    chroma_group.add_argument(
         "--ck",
         "--enable_color_killer",
         dest="enable_color_killer",
@@ -570,16 +587,20 @@ def main(args=None, use_gui=False):
     if not args.no_resample:
         sample_freq = 40
 
+    def build_loader():
+        made_loader = lddu.make_loader(filename, loader_input_freq)
+
+        # Note: Fallback to ffmpeg, not .lds format
+        # Temporary workaround until this is sorted upstream.
+        if made_loader is lddu.load_packed_data_4_40 and not filename.endswith(".lds"):
+            made_loader = lddu.LoadFFmpeg()
+        return made_loader
+
     try:
-        loader = lddu.make_loader(filename, loader_input_freq)
+        loader = build_loader()
     except ValueError as e:
         print(e)
         sys.exit(1)
-
-    # Note: Fallback to ffmpeg, not .lds format
-    # Temporary workaround until this is sorted upstream.
-    if loader is lddu.load_packed_data_4_40 and not filename.endswith(".lds"):
-        loader = lddu.LoadFFmpeg()
 
     dod_threshold_p = f.DEFAULT_THRESHOLD_P_DDD
     # Guesstimate a sample rate of around 28 is cx card and use different doc threshold
@@ -616,6 +637,8 @@ def main(args=None, use_gui=False):
     rf_options["enable_color_killer"] = args.enable_color_killer
     rf_options["disable_burst_hsync"] = args.disable_burst_hsync
     rf_options["disable_phase_correction"] = args.disable_phase_correction
+    rf_options["secam_carrier_servo"] = args.secam_servo_passes >= 1
+    rf_options["secam_lo_trim"] = args.secam_lo_trim
     rf_options["gnrc_afe"] = args.gnrc_afe
 
     extra_options = get_extra_options(args, not use_gui)
@@ -640,6 +663,71 @@ def main(args=None, use_gui=False):
 
     if args.cxadc:
         logger.warning("--cxadc is deprecated! use -f 8fsc instead!")
+
+    if (
+        args.secam_servo_passes == 2
+        and system == "MESECAM"
+        and rf_options.get("secam_lo_trim") is None
+    ):
+        # First pass: decode a bounded stretch to converge the SECAM carrier
+        # servo, then seed the real decode with the converged LO trim so it
+        # applies from the very first field.
+        calib_frames = int(min(req_frames, 30))
+        calib_dir = tempfile.mkdtemp(prefix="vhs_decode_secam_calib_")
+        logger.info(
+            "SECAM servo two-pass: calibration decode of %d frame(s)...",
+            calib_frames,
+        )
+        try:
+            # The loader can hold streaming decode state (ffmpeg/flac), so the
+            # calibration instance gets its own rather than sharing the main one.
+            calib = VHSDecode(
+                filename,
+                os.path.join(calib_dir, "calibration"),
+                build_loader(),
+                logger,
+                system=system,
+                tape_format=tape_format,
+                doDOD=False,
+                threads=args.threads,
+                inputfreq=sample_freq,
+                level_adjust=args.level_adjust,
+                rf_options=rf_options,
+                extra_options=extra_options,
+                field_order_action=args.field_order_action,
+            )
+            if args.start_fileloc != -1:
+                calib.roughseek(args.start_fileloc, False)
+            else:
+                calib.roughseek(firstframe * 2)
+
+            while calib.fields_written < (calib_frames * 2):
+                f = calib.readfield()
+                if f is None:
+                    break
+                f.prevfield = None
+
+            lo_trim = calib.rf.secam_servo_avg.pull()
+            calib.close()
+
+            if lo_trim is not None:
+                rf_options["secam_lo_trim"] = lo_trim
+                logger.info(
+                    "SECAM servo two-pass: converged LO trim %.0f Hz, starting decode",
+                    lo_trim,
+                )
+            else:
+                logger.warning(
+                    "SECAM servo two-pass: no usable carrier measurements, "
+                    "starting decode without a seeded trim"
+                )
+        except KeyboardInterrupt:
+            print("\nTerminated during servo calibration, exiting")
+            sys.exit(1)
+        except Exception as err:
+            logger.warning("SECAM servo two-pass calibration failed: %s", err)
+        finally:
+            shutil.rmtree(calib_dir, ignore_errors=True)
 
     # Initialize VHS decoder
     # Note, we pass 40 as sample frequency, as any other will be resampled by the

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -668,11 +668,21 @@ class VHSRFDecode(ldd.RFDecode):
         self.useAGC = extra_options.get("useAGC", False)
         self.debug = extra_options.get("debug", False)
 
+        # cafc measures a single carrier peak, which doesn't exist in the
+        # line-alternating two-carrier SECAM FM chroma signal.
+        requested_cafc = rf_options.get("cafc", False)
+        if requested_cafc and is_secam(system):
+            ldd.logger.warning(
+                "cafc is not supported for SECAM systems, ignoring. "
+                "(For ME-SECAM, the carrier servo tunes the conversion LO instead.)"
+            )
+            requested_cafc = False
+
         # Enable cafc for betamax until proper track detection for it is implemented.
         self._do_cafc = (
             True
             if (tape_format == "BETAMAX" and system != "NTSC")
-            else rf_options.get("cafc", False)
+            else requested_cafc
         )
 
         self.track_phase = None
@@ -758,6 +768,7 @@ class VHSRFDecode(ldd.RFDecode):
                 "enable_color_killer",
                 "disable_burst_hsync",
                 "disable_phase_correction",
+                "secam_carrier_servo",
             ],
         )(
             self.iretohz(100) * 2,
@@ -798,8 +809,12 @@ class VHSRFDecode(ldd.RFDecode):
             rf_options.get("relaxed_line0", False),
             rf_options.get("detect_chroma_track_phase", False),
             rf_options.get("enable_color_killer", False),
-            rf_options.get("disable_burst_hsync", False),
+            # SECAM has no phase-locked burst; the "burst" is an FM carrier
+            # whose phase carries no timing information, so locking hsync to
+            # it just injects sub-pixel jitter into both planes.
+            rf_options.get("disable_burst_hsync", False) or is_secam(system),
             rf_options.get("disable_phase_correction", False),
+            rf_options.get("secam_carrier_servo", True),
         )
 
         # As agc can alter these sysParams values, store a copy to then
@@ -853,6 +868,7 @@ class VHSRFDecode(ldd.RFDecode):
             tape_format=tape_format,
             do_cafc=self._do_cafc,
             chroma_bpf_lower=self.DecoderParams.get("chroma_bpf_lower", 60000),
+            conversion_lo_freq=self.DecoderParams.get("chroma_conversion_lo", None),
         )
 
         self.Filters["FVideoBurst"] = (
@@ -916,6 +932,17 @@ class VHSRFDecode(ldd.RFDecode):
         if is_color_under:
             self.chroma_heterodyne = self._chroma_afc.getChromaHet()
             self.fsc_wave, self.fsc_cos_wave = self._chroma_afc.getFSCWaves()
+
+        # Long-term average of the measured ME-SECAM rest carrier pair offset,
+        # used to trim the chroma up-conversion LO.
+        self.secam_servo_avg = utils.StackableMA(min_watermark=2, window_average=60)
+        lo_trim_seed = rf_options.get("secam_lo_trim", None)
+        if lo_trim_seed is not None and system == "MESECAM":
+            # Seed with a known trim (e.g. from a two-pass calibration decode)
+            # so it applies from the first field. With the servo enabled it
+            # keeps adapting from here; with it disabled this is a fixed trim.
+            for _ in range(3):
+                self.secam_servo_avg.push(float(lo_trim_seed))
 
         # Increase the cutoff at the end of blocks to avoid edge distortion from filters
         # making it through.


### PR DESCRIPTION
### Checklist
- [X] I have searched the open pull requests to confirm this change has not already been submitted.
- [X] My branch is up to date with the target branch.
- [X] I have tested my changes and all existing tests pass.
- [X] I have updated documentation where necessary.
- [X] My code follows the project's coding standards (see [CONTRIBUTING.md](CONTRIBUTING.md)).

### Description
The current ME-SECAM up-conversion mixes against fsc_mhz + color_under_carrier with fsc_mhz guessed as 4.406 MHz and the colour-under carrier averaged from rounded values, and generates the heterodyne against 4 * 4.406 MHz while the TBC output is _actually_ clocked at `outlinelen` per line period (17.734375 MHz). Together this restored the SECAM subcarriers about 110 kHz above their studio rest frequencies (foR 4406250 Hz, foB 4250000 Hz), forcing downstream decoders to re-center on the noncompliant signal.

ME-SECAM (IEC 60774-1 Annex E, 6.3.1) is recorded like PAL colour-under without phase rotation: an inverting mix against the PAL converter LO of fsc + 40.125 fh = 5060571.875 Hz. Restoring it is the same mix in reverse, which these changes aim to do with greater accuracy and with more ability to configure.

On a color-bars test sample, the restored rest carriers now land within about 1 kHz of nominal (previously ~+110 kHz), with the two-pass servo bringing the first field's carrier pair midpoint from about -2 kHz to under 0.1 kHz of nominal.

### Motivation
I built a downstream chroma decoder for SECAM only to find that output from vhs-decode was severely out of compliance.

### Related Issues
* oyvindln/vhs-decode#18
* oyvindln/vhs-decode#20

### Changes Made
- Mix against an explicit chroma_conversion_lo of 5060571.875 Hz, referenced to the true TBC output rate, instead of deriving the heterodyne from fsc + colour under carrier. fsc_mhz stays at the PAL value so output timing stays standard PAL 4fsc.
- Keep the heterodyne phase continuous across field boundaries so the restored FM carrier has no per-field phase steps (chroma clicks).
- Add a carrier servo that measures the rest carrier pair on the late back porch and trims the conversion LO, cancelling the recording VCR's down-converter crystal error. `--secam_servo_passes` selects the mode: `0` disables the servo, `1` measures and adapts during the decode (default), `2` runs a short calibration decode first and applies the converged LO trim from the very first field. `--secam_lo_trim <hz>` seeds the trim manually, and acts as a fixed trim with passes 0. The calibration pass gets its own loader instance since ffmpeg/flac loaders hold streaming decode state. The servo is ME-SECAM-specific: method 1 SECAM is a divide/multiply-by-4 chain with no conversion crystal to correct for.
- Disable burst-locked hsync for SECAM systems; the "burst" is an FM carrier whose phase carries no timing information and only injects jitter. Ignore `cafc` for SECAM since a single-peak measurement is meaningless on the line-alternating two-carrier signal.
- Retune the mesecam-decode flowgraph discriminator neutral points to the studio rest frequencies (they were empirically tuned to the ~+108 kHz offset signal).

### Testing
- [X] All existing tests pass (`pytest --output-on-failure`)
- [X] Tested manually with ME-SECAM sample RF files provided by @r3dfx080.
- [X] New test added for heterodyne process correctness

### Additional Notes
This is a precursor to regular SECAM recording method support (aka SECAM Method 1). I wanted to ensure that both recording methods would yield standard studio outputs for downstream chroma decoders.