### PR TITLE
More Color-Under Chroma Tuning

### DIFF
--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -209,7 +209,7 @@ def _solve_4x4(A, b):
 
 @njit(nogil=True, fastmath=False, cache=True, inline='always')
 def _tune_burst_measurements(
-    burst, start_guess, amp_guess, phi_guess, dc_guess, fsc, f_weight=1e6, max_iter=16, max_precision=1e-10
+    burst, burst_start, amp_guess, phi_guess, dc_guess, fsc, f_weight=1e4, max_iter=32, max_precision=1e-10
 ):
     """
     Optimized Gauss-Newton tuner.
@@ -228,7 +228,7 @@ def _tune_burst_measurements(
     f_target = fsc
 
     N = len(burst)
-    t = (np.arange(N) + start_guess) / (4.0 * fsc)
+    t = (np.arange(N) + burst_start) / (4.0 * fsc)
 
     # Pre-allocate 4xN Jacobian array
     J = np.empty((4, N))
@@ -311,37 +311,34 @@ def _demod_burst(
     # get initial burst measurements
     I = 0.0
     Q = 0.0
+    burst_sum = 0.0
 
     for i in range(burst_len):
         burst_sample = burst[i]
+        burst_sum += burst_sample
         carrier_idx = i + burst_start
         I += burst_sample * burst_cos[carrier_idx]
         Q += burst_sample * burst_sin[carrier_idx]
 
 
     # build starting point for refinement
-    phi_guess = (np.arctan2(Q, I) + np.pi) % (2 * np.pi) - np.pi
-    dc_guess = np.mean(burst)
-    amp_guess = (2.0 * np.hypot(I, Q)) / burst_len
+    phi_guess = (math.atan2(Q, I) + math.pi) % (2.0 * math.pi) - math.pi
+    dc_guess = burst_sum / burst_len
+    amp_guess = (2.0 * math.sqrt(I * I + Q * Q)) / burst_len
 
     # refine burst measurements
     burst_amplitude, fit_phi, burst_dc, burst_frequency = _tune_burst_measurements(
         burst, burst_start, amp_guess, phi_guess, dc_guess, fsc
     )
 
-    # Convert the absolute fitted phase shift (radians) into a fractional sample offset.
-    # Since model uses (2*pi*fsc*t - phi) and fs = 4*fsc:
-    # Samples = t * fs = t * 4 * fsc.
-    # Therefore, 1 radian = 4 / (2 * pi) = 2 / pi samples.
-    # We add a modulo 4 tracking window to isolate sub-cycle position adjustments.
-    phase_sample_offset = (fit_phi % (2 * np.pi)) * (2.0 / np.pi)
-    
+    # Convert the absolute fitted phase shift (radians) into a fractional sample offset
+    phase_sample_offset = (fit_phi % (2.0 * math.pi)) * (2.0 / math.pi)
+
     # Combine the geometric window midpoint with the phase shift
     burst_center_relative = (burst_len - 1) / 2.0 + phase_sample_offset
-
     burst_center = burst_start + burst_center_relative
-    burst_phase_deg = np.degrees(fit_phi) % 360.0
-    burst_magnitude = burst_amplitude * (burst_len / 2)
+    burst_phase_deg = math.degrees(fit_phi) % 360.0
+    burst_magnitude = burst_amplitude * (burst_len / 2.0)
 
     return burst_center, burst_phase_deg, burst_magnitude, burst_dc, burst_frequency, I, Q
 
@@ -711,8 +708,8 @@ def upconvert_chroma_phase_comp(
     pi_over_two = np.pi / 2.0
 
     # Initial nominal reference coefficient
-    het_mhz_nominal = color_under_carrier_fs / 1e6
-    het_coefficient = pi_over_two * (1.0 + het_mhz_nominal / fsc)
+    het_hz_nominal = color_under_carrier_fs
+    het_coefficient = pi_over_two * (1.0 + het_hz_nominal / fsc)
 
     target_phase_even_rad = target_phase_even * deg2rad_scale
     target_phase_odd_rad = target_phase_odd * deg2rad_scale
@@ -723,18 +720,16 @@ def upconvert_chroma_phase_comp(
         
         # Solve for current line's active het_mhz:
         k_current = current_burst.frequency / fsc
-        f_cu_current = k_current * color_under_carrier_fs
-        het_mhz_current = f_cu_current / 1e6
+        het_hz_current = k_current * color_under_carrier_fs
 
         # Solve for next line's active het_mhz
         if idx < num_bursts - 1:
             next_burst = phase_rotation_sequence[idx + 1]
             k_next = next_burst.frequency / fsc
-            f_cu_next = k_next * color_under_carrier_fs
-            het_mhz_next = f_cu_next / 1e6
+            het_hz_next = k_next * color_under_carrier_fs
         else:
             next_burst = current_burst
-            het_mhz_next = het_mhz_current
+            het_hz_next = het_hz_current
 
         linestart = (current_burst.line_number - lineoffset) * outwidth
         lineend = linestart + outwidth
@@ -752,17 +747,15 @@ def upconvert_chroma_phase_comp(
             t = (i - linestart) / outwidth
 
             # Linearly interpolate het_mhz
-            het_mhz_interpolated = het_mhz_current + t * (het_mhz_next - het_mhz_current)
+            het_hz_interpolated = het_hz_current + t * (het_hz_next - het_hz_current)
 
             # Recalculate the active phase step coefficient
-            active_het_coefficient = pi_over_two * (1.0 + het_mhz_interpolated / fsc)
+            active_het_coefficient = pi_over_two * (1.0 + het_hz_interpolated / fsc)
 
             uphet[i] = chroma[i] * -math.cos(theta) - current_burst.dc
 
             # Increment phase
             theta += active_het_coefficient
-
-        print("burst", current_burst.frequency, current_burst.phase_deg, current_burst.dc)
 
 
 @njit(cache=True, nogil=True)
@@ -1105,7 +1098,7 @@ def process_chroma(
             outwidth,
             field.phase_sequence,
             field.rf.chroma_afc.color_under,
-            field.rf.chroma_afc.fsc_mhz,
+            field.rf.chroma_afc.fsc_mhz * 1e6,
             target_phase_even,
             target_phase_odd
         )

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -26,44 +26,71 @@ def chroma_to_u16(chroma):
         
     return out
 
+@njit(cache=False, nogil=True, fastmath=True)
+def chroma_automatic_gain(chroma, burst_abs_ref, phase_sequence, burst_detected_line, smoothing_window=8, k=2.0):
+    burst_count = len(phase_sequence)
+    raw_gains = np.zeros(burst_count, dtype=np.float64)
 
-@njit(cache=True, nogil=True)
-def acc(chroma, burst_abs_ref, burststart, burstend, linelength, lines, burst_detected_line):
-    """Scale chroma according to the level of the color burst on each line."""
-    STARTING_LINE = int(16)
-    assert lines > STARTING_LINE
+    # extract gain values
+    valid_gains_list = []
+    for i in range(burst_count):
+        current_burst = phase_sequence[i]
+        curr_amp = current_burst.amplitude if current_burst.amplitude != 0 else 1e-8
+        raw_gains[i] = burst_abs_ref / curr_amp
+        
+        if current_burst.line_number >= burst_detected_line:
+            valid_gains_list.append(raw_gains[i])
 
-    output = np.zeros(chroma.size, dtype=np.double)
-    mean_burst_accumulator = 0
-    for linenumber in range(16, lines):
-        linestart = linelength * linenumber
-        lineend = linestart + linelength
+    # calculate MAD
+    if len(valid_gains_list) > 0:
+        valid_gains = np.array(valid_gains_list)
+        median_gain = np.median(valid_gains)
+        mad_gain = np.median(np.abs(valid_gains - median_gain))
+        max_allowable_gain = median_gain + (k * mad_gain)
+    else:
+        max_allowable_gain = 1.0
 
-        if linenumber < burst_detected_line:
-            # color killer active for this line
-            output[linestart:lineend] = 0
+    # calculate smoothing
+    smoothed_gains = np.zeros(burst_count, dtype=np.float64)
+    half_w = smoothing_window // 2
+    for i in range(burst_count):
+        # Apply moving average directly to the clamped values
+        start = max(0, i - half_w)
+        end = min(burst_count, i + half_w + 1)
+        
+        window_sum = 0.0
+        for w in range(start, end):
+            window_sum += min(raw_gains[w], max_allowable_gain)
+        smoothed_gains[i] = window_sum / (end - start)
+
+    # apply gain
+    for i in range(burst_count):
+        current_burst = phase_sequence[i]
+        current_burst_start = current_burst.start
+        next_burst_start = phase_sequence[i + 1].start if i < burst_count - 1 else len(chroma)
+
+        if current_burst.line_number < burst_detected_line:
+            chroma[current_burst_start:next_burst_start] = 0
         else:
-            line = chroma[linestart:lineend]
-            acced, rms = acc_line(line, burst_abs_ref, burststart, burstend)
-            output[linestart:lineend] = acced
-            mean_burst_accumulator += rms
+            gain_start = smoothed_gains[i]
+            gain_end = smoothed_gains[i + 1] if i < burst_count - 1 else smoothed_gains[i]
+            gain_increment = (gain_end - gain_start) / (next_burst_start - current_burst_start)
+            gain = gain_start
 
-    return output, mean_burst_accumulator / (lines - STARTING_LINE)
+            for j in range(current_burst_start, next_burst_start):
+                chroma[j] = chroma[j] * gain
+                gain += gain_increment
 
+    # calculate RMS
+    if len(valid_gains_list) > 0:
+        sq_sum = 0.0
+        for g in valid_gains_list:
+            # Reconstruct original amplitude from valid gains to calculate signal RMS
+            amp = burst_abs_ref / g
+            sq_sum += amp * amp
+        return np.sqrt(sq_sum / len(valid_gains_list))
 
-@njit(cache=True, nogil=True)
-def acc_line(chroma, burst_abs_ref, burststart, burstend):
-    """Scale chroma according to the level of the color burst the line."""
-    output = np.zeros(chroma.size, dtype=np.double)
-
-    line = chroma
-    burst_abs_mean = lddu.rms(line[burststart:burstend])
-    # np.sqrt(np.mean(np.square(line[burststart:burstend])))
-    #    burst_abs_mean = np.mean(np.abs(line[burststart:burstend]))
-    scale = burst_abs_ref / burst_abs_mean if burst_abs_mean != 0 else 1
-    output = line * scale
-
-    return output, burst_abs_mean
+    return 0.0
 
 
 @njit(cache=True, nogil=True)
@@ -118,6 +145,7 @@ def comb_c_ntsc(data, line_len):
     'end': numba.int32,
     'phase_deg': numba.float64,
     'phase_offset_deg': numba.float64,
+    'amplitude': numba.float64,
     'magnitude': numba.float64,
     'frequency': numba.float64,
     'dc': numba.float64,
@@ -128,9 +156,10 @@ def comb_c_ntsc(data, line_len):
 class BurstInfo:
     line_number: int
     start: int
-    center: float
     end: int
+    center: int
     phase_deg: float
+    amplitude: float
     magnitude: float
     frequency: float
     dc: float
@@ -142,9 +171,10 @@ class BurstInfo:
         self,
         line_number,
         burst_start,
-        burst_center,
         burst_end,
+        burst_center,
         burst_phase_deg,
+        burst_amplitude,
         burst_magnitude,
         burst_dc,
         burst_frequency,
@@ -153,12 +183,13 @@ class BurstInfo:
     ):
         self.line_number = line_number
         self.start = burst_start
-        self.center = burst_center
         self.end = burst_end
+        self.center = burst_center
         self.phase_deg = burst_phase_deg
+        self.amplitude = burst_amplitude
         self.magnitude = burst_magnitude
-        self.frequency = burst_frequency
         self.dc = burst_dc
+        self.frequency = burst_frequency
         self.I = I
         self.Q = Q
         self.phase_rotation = -1 # this is set later
@@ -219,14 +250,20 @@ def _tune_burst_measurements(
     burst, burst_start, amp_guess, phi_guess, dc_guess, fsc, f_weight=1e4, max_iter=32, max_precision=1e-10
 ):
     """
-    Gauss-Newton tuner.
-    Optimizes: A * cos(2 * pi * f * t - phi) + dc
+    Gauss-Newton optimization for tuning color burst measurements.
 
-    Parameters:
-    -----------
-    f_weight : float
-        Regularization strength pulling f toward fsc.
-        Larger values restrict f variation to minor fractions of a Hz.
+    Fits an NTSC/PAL analytical subcarrier model to digitized video samples:
+        Model(t) = A * cos(2 * pi * f * t - phi) + dc
+
+    Utilizes an iterative least-squares (Gauss-Newton) algorithm to extract 
+    four critical parameters from the color burst window:
+        1. Amplitude (A)       -> Subcarrier strength / chroma saturation
+        2. Phase (phi)         -> Subcarrier phase / chroma hue
+        3. DC Offset (dc)      -> Local luma/black level offset
+        4. Frequency (f)       -> Local subcarrier frequency drift
+
+    Includes a Bayesian frequency prior (f_weight) acting as a regularizer 
+    to prevent the frequency parameter from diverging on noisy lines.
     """
     A = amp_guess
     phi = phi_guess
@@ -381,7 +418,7 @@ def _demod_burst(
     burst_phase_deg = math.degrees(fit_phi) % 360.0
     burst_magnitude = burst_amplitude * (burst_len / 2.0)
 
-    return burst_center, burst_phase_deg, burst_magnitude, burst_dc, burst_frequency, I, Q
+    return burst_center, burst_phase_deg, burst_amplitude, burst_magnitude, burst_dc, burst_frequency, I, Q
 
 def _get_upconverted_burst(
     chroma,
@@ -411,13 +448,15 @@ def _get_upconverted_burst(
     filtered = filtered_padded[burst_filter_padding:-burst_filter_padding]
 
     burst_len = len(filtered)
-
-    burst_center, burst_phase_deg, burst_magnitude, burst_dc, burst_frequency, I, Q = _demod_burst(
+    burst_results = _demod_burst(
         filtered, burst_start + burst_filter_padding, burst_len, burst_sin, burst_cos, fsc
     )
 
     return BurstInfo(
-        line_number, burst_start, burst_center, burst_end, burst_phase_deg, burst_magnitude, burst_dc, burst_frequency, I, Q
+        line_number,
+        burst_start,
+        burst_end,
+        *burst_results
     )
 
 def _get_phase_sequence(
@@ -1216,13 +1255,10 @@ def process_chroma(
             uphet = comb_c_pal(uphet, outwidth)
 
     # Final automatic chroma gain.
-    uphet, mean_rms = acc(
+    mean_rms = chroma_automatic_gain(
         uphet,
         field.rf.SysParams["burst_abs_ref"],
-        burstarea[0],
-        burstarea[1],
-        outwidth,
-        linesout,
+        field.phase_sequence,
         field.burst_detected_line
     )
 

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -114,6 +114,7 @@ def comb_c_ntsc(data, line_len):
     'phase_deg': numba.float64,
     'phase_offset_deg': numba.float64,
     'magnitude': numba.float64,
+    'frequency': numba.float64,
     'dc': numba.float64,
     'I': numba.float64,
     'Q': numba.float64,
@@ -126,6 +127,7 @@ class BurstInfo:
     end: int
     phase_deg: float
     magnitude: float
+    frequency: float
     dc: float
     I: float
     Q: float
@@ -140,6 +142,7 @@ class BurstInfo:
         burst_phase_deg,
         burst_magnitude,
         burst_dc,
+        burst_frequency,
         I,
         Q
     ):
@@ -149,100 +152,154 @@ class BurstInfo:
         self.end = burst_end
         self.phase_deg = burst_phase_deg
         self.magnitude = burst_magnitude
+        self.frequency = burst_frequency
         self.dc = burst_dc
         self.I = I
         self.Q = Q
         self.phase_rotation = -1 # this is set later
 
 
-@njit(nogil=True, fastmath=True, cache=True)
-def _tune_burst_measurements(burst, t, fsc, amp_guess, phi_guess, dc_guess, max_iter=128, max_precision=1e-10):
+@njit(nogil=True, inline='always')
+def _solve_4x4(A, b):
     """
-    Gauss-Newton optimization for tuning color burst measurements.
-    Optimizes: A * cos(2 * pi * fsc * t - phi) + dc
+    Inlined 4x4 Gaussian elimination solver with partial pivoting.
+    """
+    M = np.empty((4, 5))
+    for r in range(4):
+        for c in range(4):
+            M[r, c] = A[r, c]
+        M[r, 4] = b[r]
+        
+    for i in range(4):
+        # Find pivot row
+        max_row = i
+        max_val = abs(M[i, i])
+        for r in range(i + 1, 4):
+            val = abs(M[r, i])
+            if val > max_val:
+                max_val = val
+                max_row = r
+                
+        # Swap rows if necessary
+        if max_row != i:
+            for c in range(i, 5):
+                tmp = M[i, c]
+                M[i, c] = M[max_row, c]
+                M[max_row, c] = tmp
+                
+        if abs(M[i, i]) < 1e-12:
+            return np.zeros(4), False  # Singular matrix protection
+            
+        # Eliminate below
+        for r in range(i + 1, 4):
+            factor = M[r, i] / M[i, i]
+            for c in range(i, 5):
+                M[r, c] -= factor * M[i, c]
+                
+    # Back substitution
+    x = np.empty(4)
+    for i in range(3, -1, -1):
+        sum_ax = 0.0
+        for j in range(i + 1, 4):
+            sum_ax += M[i, j] * x[j]
+        x[i] = (M[i, 4] - sum_ax) / M[i, i]
+        
+    return x, True
+
+
+@njit(nogil=True, fastmath=False, cache=True, inline='always')
+def _tune_burst_measurements(
+    burst, start_guess, amp_guess, phi_guess, dc_guess, fsc, f_weight=1e6, max_iter=16, max_precision=1e-10
+):
+    """
+    Optimized Gauss-Newton tuner.
+    Optimizes: A * cos(2 * pi * f * t - phi) + dc
+    
+    Parameters:
+    -----------
+    f_weight : float
+        Regularization strength pulling f toward fsc.
+        Larger values restrict f variation to minor fractions of a Hz.
     """
     A = amp_guess
     phi = phi_guess
     dc = dc_guess
+    f = fsc  # Initialize frequency to expected subcarrier target
+    f_target = fsc
 
-    omega = 2.0 * np.pi * fsc
     N = len(burst)
+    t = (np.arange(N) + start_guess) / (4.0 * fsc)
 
-    # Pre-allocate Jacobian array and residual vector
-    J = np.empty((3, N))
+    # Pre-allocate 4xN Jacobian array
+    J = np.empty((4, N))
+
+    # Form normal equations: (J * J^T) * delta = J * r
+    J_JT = np.zeros((4, 4))
+    J_r = np.zeros(4)
 
     for _ in range(max_iter):
-        # Compute current model values and errors
-        theta = omega * t - phi
+        two_pi_f = 2.0 * np.pi * f
+        theta = two_pi_f * t - phi
         cos_theta = np.cos(theta)
         sin_theta = np.sin(theta)
         
         # Residuals: actual minus predicted
         r = burst - (A * cos_theta + dc)
         
-        # Build Jacobian rows: d_model/dA, d_model/dphi, d_model/ddc
-        J[0, :] = cos_theta
-        J[1, :] = A * sin_theta
-        J[2, :] = 1.0
+        # Build Jacobian rows
+        J[0, :] = cos_theta                        # d_model / dA
+        J[1, :] = A * sin_theta                    # d_model / dphi
+        J[2, :] = 1.0                              # d_model / ddc
+        J[3, :] = -2.0 * np.pi * t * A * sin_theta # d_model / df
 
-        # Form normal equations: (J * J^T) * delta = J * r
-        # J_JT shape: (3, 3), J_r shape: (3,)
-        J_JT = np.zeros((3, 3))
-        J_r = np.zeros(3)
+        J_JT.fill(0.0)
+        J_r.fill(0.0)
         
-        for i in range(3):
-            for j in range(3):
+        # Matrix multiplication J * J^T and vector J * r
+        for i in range(4):
+            for j in range(4):
                 for k in range(N):
                     J_JT[i, j] += J[i, k] * J[j, k]
             for k in range(N):
                 J_r[i] += J[i, k] * r[k]
 
-        # Regularize to prevent singular matrices (Levenberg-Marquardt style hint)
-        for i in range(3):
+        # Apply Bayesian frequency centering prior/penalty
+        J_JT[3, 3] += f_weight
+        J_r[3] += f_weight * (f_target - f)
+
+        # Standard Levenberg-Marquardt style diagonal regularization
+        for i in range(4):
             J_JT[i, i] += 1e-6
 
-        # Explicit 3x3 matrix inversion (much faster in Numba than np.linalg.solve)
-        det = (J_JT[0, 0] * (J_JT[1, 1] * J_JT[2, 2] - J_JT[1, 2] * J_JT[2, 1]) -
-               J_JT[0, 1] * (J_JT[1, 0] * J_JT[2, 2] - J_JT[1, 2] * J_JT[2, 0]) +
-               J_JT[0, 2] * (J_JT[1, 0] * J_JT[2, 1] - J_JT[1, 1] * J_JT[2, 0]))
+        # Solve system
+        delta, success = _solve_4x4(J_JT, J_r)
+        if not success:
+            break
 
-        if abs(det) < 1e-9:
-            break  # Numerical safety boundary
-
-        inv_det = 1.0 / det
-
-        # Calculate update vector delta
-        delta_A = inv_det * (
-            (J_JT[1, 1] * J_JT[2, 2] - J_JT[1, 2] * J_JT[2, 1]) * J_r[0] +
-            (J_JT[0, 2] * J_JT[2, 1] - J_JT[0, 1] * J_JT[2, 2]) * J_r[1] +
-            (J_JT[0, 1] * J_JT[1, 2] - J_JT[0, 2] * J_JT[1, 1]) * J_r[2]
-        )
-        delta_phi = inv_det * (
-            (J_JT[1, 2] * J_JT[2, 0] - J_JT[1, 0] * J_JT[2, 2]) * J_r[0] +
-            (J_JT[0, 0] * J_JT[2, 2] - J_JT[0, 2] * J_JT[2, 0]) * J_r[1] +
-            (J_JT[0, 2] * J_JT[1, 0] - J_JT[0, 0] * J_JT[1, 2]) * J_r[2]
-        )
-        delta_dc = inv_det * (
-            (J_JT[1, 0] * J_JT[2, 1] - J_JT[1, 1] * J_JT[2, 0]) * J_r[0] +
-            (J_JT[0, 1] * J_JT[2, 0] - J_JT[0, 0] * J_JT[2, 1]) * J_r[1] +
-            (J_JT[0, 0] * J_JT[1, 1] - J_JT[0, 1] * J_JT[1, 0]) * J_r[2]
-        )
+        delta_A = delta[0]
+        delta_phi = delta[1]
+        delta_dc = delta[2]
+        delta_f = delta[3]
 
         # Apply updates
         A += delta_A
         phi += delta_phi
         dc += delta_dc
+        f += delta_f
 
         # Break early if updates converge to tiny changes
-        if (abs(delta_A) < max_precision) and (abs(delta_phi) < max_precision) and (abs(delta_dc) < max_precision):
+        if (abs(delta_A) < max_precision) and \
+           (abs(delta_phi) < max_precision) and \
+           (abs(delta_dc) < max_precision) and \
+           (abs(delta_f) < max_precision):
             break
 
     phi = (phi + np.pi) % (2 * np.pi) - np.pi
 
-    return A, phi, dc
+    return A, phi, dc, f
 
 
-@njit(cache=True, nogil=True, fastmath=True)
+@njit(cache=True, nogil=True, fastmath=False)
 def _demod_burst(
     burst,
     burst_start,
@@ -268,9 +325,8 @@ def _demod_burst(
     amp_guess = (2.0 * np.hypot(I, Q)) / burst_len
 
     # refine burst measurements
-    t = (np.arange(burst_len) + burst_start) / (4.0 * fsc)
-    burst_amplitude, fit_phi, burst_dc = _tune_burst_measurements(
-        burst, t, fsc, amp_guess, phi_guess, dc_guess
+    burst_amplitude, fit_phi, burst_dc, burst_frequency = _tune_burst_measurements(
+        burst, burst_start, amp_guess, phi_guess, dc_guess, fsc
     )
 
     # Convert the absolute fitted phase shift (radians) into a fractional sample offset.
@@ -287,7 +343,7 @@ def _demod_burst(
     burst_phase_deg = np.degrees(fit_phi) % 360.0
     burst_magnitude = burst_amplitude * (burst_len / 2)
 
-    return burst_center, burst_phase_deg, burst_magnitude, burst_dc, I, Q
+    return burst_center, burst_phase_deg, burst_magnitude, burst_dc, burst_frequency, I, Q
 
 def _get_upconverted_burst(
     chroma,
@@ -318,12 +374,12 @@ def _get_upconverted_burst(
 
     burst_len = len(filtered)
 
-    burst_center, burst_phase_deg, burst_magnitude, burst_dc, I, Q = _demod_burst(
+    burst_center, burst_phase_deg, burst_magnitude, burst_dc, burst_frequency, I, Q = _demod_burst(
         filtered, burst_start + burst_filter_padding, burst_len, burst_sin, burst_cos, fsc
     )
 
     return BurstInfo(
-        line_number, burst_start, burst_center, burst_end, burst_phase_deg, burst_magnitude, burst_dc, I, Q
+        line_number, burst_start, burst_center, burst_end, burst_phase_deg, burst_magnitude, burst_dc, burst_frequency, I, Q
     )
 
 def _get_phase_sequence(
@@ -621,7 +677,7 @@ def get_phase_rotation_sequence(
     return chroma_rotation_index, phase_sequence, burst_detected_line, burst_magnitude_avg, burst_phase_avg, even_burst_phase_avg, odd_burst_phase_avg
 
 
-@njit(cache=False, nogil=True, fastmath=True)
+@njit(cache=False, nogil=True, fastmath=False)
 def upconvert_chroma(
     chroma,
     uphet,
@@ -639,40 +695,74 @@ def upconvert_chroma(
         uphet[linestart:lineend] = c * heterodyne - burst.dc
 
 
-@njit(cache=False, nogil=True, fastmath=True)
+@njit(cache=False, nogil=True, fastmath=False)
 def upconvert_chroma_phase_comp(
     chroma,
     uphet,
     lineoffset,
     outwidth,
     phase_rotation_sequence,
-    color_under_carrier_fs,
-    fsc,
+    color_under_carrier_fs,  # Nominal color-under carrier (Hz)
+    fsc,                     # Nominal NTSC subcarrier target (Hz)
     target_phase_even,
     target_phase_odd
 ):
     deg2rad_scale = np.pi / 180.0
     pi_over_two = np.pi / 2.0
 
-    het_mhz = color_under_carrier_fs / 1e6
-    het_coefficient = pi_over_two * (1.0 + het_mhz / fsc)
+    # Initial nominal reference coefficient
+    het_mhz_nominal = color_under_carrier_fs / 1e6
+    het_coefficient = pi_over_two * (1.0 + het_mhz_nominal / fsc)
 
     target_phase_even_rad = target_phase_even * deg2rad_scale
     target_phase_odd_rad = target_phase_odd * deg2rad_scale
+    num_bursts = len(phase_rotation_sequence)
 
-    for burst in phase_rotation_sequence:
-        linestart = (burst.line_number - lineoffset) * outwidth
+    for idx in range(num_bursts):
+        current_burst = phase_rotation_sequence[idx]
+        
+        # Solve for current line's active het_mhz:
+        k_current = current_burst.frequency / fsc
+        f_cu_current = k_current * color_under_carrier_fs
+        het_mhz_current = f_cu_current / 1e6
+
+        # Solve for next line's active het_mhz
+        if idx < num_bursts - 1:
+            next_burst = phase_rotation_sequence[idx + 1]
+            k_next = next_burst.frequency / fsc
+            f_cu_next = k_next * color_under_carrier_fs
+            het_mhz_next = f_cu_next / 1e6
+        else:
+            next_burst = current_burst
+            het_mhz_next = het_mhz_current
+
+        linestart = (current_burst.line_number - lineoffset) * outwidth
         lineend = linestart + outwidth
-        target_phase_rad = target_phase_odd_rad if burst.line_number % 2 else target_phase_even_rad
+        target_phase_rad = target_phase_odd_rad if current_burst.line_number % 2 else target_phase_even_rad
 
+        # Initialize the starting phase
         theta = het_coefficient * linestart + (
-            burst.phase_rotation * pi_over_two # heterodyne rotation
-            + target_phase_rad + burst.phase_deg * deg2rad_scale # phase offset relative to line
+            current_burst.phase_rotation * pi_over_two # heterodyne rotation
+            + target_phase_rad + current_burst.phase_deg * deg2rad_scale # phase offset relative to line
         )
 
+        # Upconvert
         for i in range(linestart, lineend):
-            uphet[i] = chroma[i] * -math.cos(theta) - burst.dc
-            theta += het_coefficient
+            # Interpolation factor (0.0 to 1.0)
+            t = (i - linestart) / outwidth
+
+            # Linearly interpolate het_mhz
+            het_mhz_interpolated = het_mhz_current + t * (het_mhz_next - het_mhz_current)
+
+            # Recalculate the active phase step coefficient
+            active_het_coefficient = pi_over_two * (1.0 + het_mhz_interpolated / fsc)
+
+            uphet[i] = chroma[i] * -math.cos(theta) - current_burst.dc
+
+            # Increment phase
+            theta += active_het_coefficient
+
+        print("burst", current_burst.frequency, current_burst.phase_deg, current_burst.dc)
 
 
 @njit(cache=True, nogil=True)
@@ -686,7 +776,7 @@ def burst_deemphasis(chroma, lineoffset, linesout, outwidth, burstarea):
     return chroma
 
 
-@njit(cache=True, nogil=True, fastmath=True)
+@njit(cache=True, nogil=True, fastmath=False)
 def shift_chroma_and_remove_dc(out_chroma, move):
     n = len(out_chroma)
     move %= n

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -11,15 +11,20 @@ from numba import njit
 from numba.experimental import jitclass
 
 
-@njit(cache=True, nogil=True)
+@njit(cache=True, nogil=True, fastmath=True)
 def chroma_to_u16(chroma):
-    """Scale the chroma output array to a 16-bit value for output."""
-    S16_ABS_MAX = 32767
+    """
+    Scale the chroma output array to a 16-bit value for output.
+    """
+    S16_ABS_MAX = 32767.0
+    N = len(chroma)
 
-    # Disabled for now as it's misleading.
-    # if np.max(chroma) > S16_ABS_MAX:
-    #     ldd.logger.warning("Chroma signal clipping.")
-    return (chroma + S16_ABS_MAX).astype(np.uint16)
+    out = np.empty(N, dtype=np.uint16)
+
+    for i in range(N):
+        out[i] = np.uint16(chroma[i] + S16_ABS_MAX)
+        
+    return out
 
 
 @njit(cache=True, nogil=True)
@@ -166,8 +171,10 @@ def _solve_4x4(A, b):
     """
     M = np.empty((4, 5))
     for r in range(4):
-        for c in range(4):
-            M[r, c] = A[r, c]
+        M[r, 0] = A[r, 0]
+        M[r, 1] = A[r, 1]
+        M[r, 2] = A[r, 2]
+        M[r, 3] = A[r, 3]
         M[r, 4] = b[r]
         
     for i in range(4):
@@ -212,9 +219,9 @@ def _tune_burst_measurements(
     burst, burst_start, amp_guess, phi_guess, dc_guess, fsc, f_weight=1e4, max_iter=32, max_precision=1e-10
 ):
     """
-    Optimized Gauss-Newton tuner.
+    Gauss-Newton tuner.
     Optimizes: A * cos(2 * pi * f * t - phi) + dc
-    
+
     Parameters:
     -----------
     f_weight : float
@@ -224,52 +231,86 @@ def _tune_burst_measurements(
     A = amp_guess
     phi = phi_guess
     dc = dc_guess
-    f = fsc  # Initialize frequency to expected subcarrier target
+    f = fsc
     f_target = fsc
 
     N = len(burst)
-    t = (np.arange(N) + burst_start) / (4.0 * fsc)
+    
+    # Precompute time array
+    t = np.empty(N, dtype=np.float64)
+    for k in range(N):
+        t[k] = (k + burst_start) / (4.0 * fsc)
 
-    # Pre-allocate 4xN Jacobian array
-    J = np.empty((4, N))
+    theta = np.empty(N, dtype=np.float64)
+    cos_theta = np.empty(N, dtype=np.float64)
+    sin_theta = np.empty(N, dtype=np.float64)
+    r = np.empty(N, dtype=np.float64)
+    
+    # Pre-allocate Jacobian components
+    j0 = np.empty(N, dtype=np.float64)
+    j1 = np.empty(N, dtype=np.float64)
+    # Note: j2 is constant 1.0, so we do not need an array for it
+    j3 = np.empty(N, dtype=np.float64)
 
-    # Form normal equations: (J * J^T) * delta = J * r
-    J_JT = np.zeros((4, 4))
-    J_r = np.zeros(4)
+    # Pre-allocate normal equation containers
+    J_JT = np.empty((4, 4), dtype=np.float64)
+    J_r = np.empty(4, dtype=np.float64)
+
+    minus_two_pi = -2.0 * np.pi
 
     for _ in range(max_iter):
         two_pi_f = 2.0 * np.pi * f
-        theta = two_pi_f * t - phi
+
+        theta = (two_pi_f * t) - phi
         cos_theta = np.cos(theta)
         sin_theta = np.sin(theta)
         
-        # Residuals: actual minus predicted
+        # Compute residual vector
         r = burst - (A * cos_theta + dc)
         
-        # Build Jacobian rows
-        J[0, :] = cos_theta                        # d_model / dA
-        J[1, :] = A * sin_theta                    # d_model / dphi
-        J[2, :] = 1.0                              # d_model / ddc
-        J[3, :] = -2.0 * np.pi * t * A * sin_theta # d_model / df
+        # Build Jacobian components
+        j0 = cos_theta
+        j1 = A * sin_theta
+        j3 = (minus_two_pi * t) * j1
 
-        J_JT.fill(0.0)
-        J_r.fill(0.0)
+        # np.dot utilizes BLAS-like instruction sets (SSE, AVX, or AVX-512)
+        J_JT[0, 0] = np.dot(j0, j0)
+        J_JT[0, 1] = np.dot(j0, j1)
+        J_JT[0, 2] = np.sum(j0)          # since j2 is 1.0
+        J_JT[0, 3] = np.dot(j0, j3)
         
-        # Matrix multiplication J * J^T and vector J * r
-        for i in range(4):
-            for j in range(4):
-                for k in range(N):
-                    J_JT[i, j] += J[i, k] * J[j, k]
-            for k in range(N):
-                J_r[i] += J[i, k] * r[k]
+        J_JT[1, 1] = np.dot(j1, j1)
+        J_JT[1, 2] = np.sum(j1)          # since j2 is 1.0
+        J_JT[1, 3] = np.dot(j1, j3)
+        
+        J_JT[2, 2] = float(N)            # np.dot(1.0, 1.0) for N elements
+        J_JT[2, 3] = np.sum(j3)          # since j2 is 1.0
+        
+        J_JT[3, 3] = np.dot(j3, j3)
+        
+        # Compute J_r vector elements using SIMD-accelerated dot products
+        J_r[0] = np.dot(j0, r)
+        J_r[1] = np.dot(j1, r)
+        J_r[2] = np.sum(r)               # since j2 is 1.0
+        J_r[3] = np.dot(j3, r)
+
+        # Mirror the upper triangle to the lower triangle (Exploit Symmetry)
+        J_JT[1, 0] = J_JT[0, 1]
+        J_JT[2, 0] = J_JT[0, 2]
+        J_JT[2, 1] = J_JT[1, 2]
+        J_JT[3, 0] = J_JT[0, 3]
+        J_JT[3, 1] = J_JT[1, 3]
+        J_JT[3, 2] = J_JT[2, 3]
 
         # Apply Bayesian frequency centering prior/penalty
         J_JT[3, 3] += f_weight
         J_r[3] += f_weight * (f_target - f)
 
-        # Standard Levenberg-Marquardt style diagonal regularization
-        for i in range(4):
-            J_JT[i, i] += 1e-6
+        # Diagonal regularization
+        J_JT[0, 0] += 1e-6
+        J_JT[1, 1] += 1e-6
+        J_JT[2, 2] += 1e-6
+        J_JT[3, 3] += 1e-6
 
         # Solve system
         delta, success = _solve_4x4(J_JT, J_r)
@@ -689,18 +730,18 @@ def upconvert_chroma(
 
         heterodyne = chroma_heterodyne[burst.phase_rotation][linestart:lineend]
         c = chroma[linestart:lineend]
-        uphet[linestart:lineend] = c * heterodyne - burst.dc
+        uphet[linestart:lineend] = c * heterodyne
 
 
-@njit(cache=False, nogil=True, fastmath=False)
+@njit(nogil=True, cache=False, fastmath=False)
 def upconvert_chroma_phase_comp(
     chroma,
     uphet,
     lineoffset,
     outwidth,
     phase_rotation_sequence,
-    color_under_carrier_fs,  # Nominal color-under carrier (Hz)
-    fsc,                     # Nominal NTSC subcarrier target (Hz)
+    color_under_carrier_fs,
+    fsc,
     target_phase_even,
     target_phase_odd
 ):
@@ -715,47 +756,60 @@ def upconvert_chroma_phase_comp(
     target_phase_odd_rad = target_phase_odd * deg2rad_scale
     num_bursts = len(phase_rotation_sequence)
 
+    coeff_step_factor = pi_over_two / (fsc * outwidth)
+
+    # Pre-generate a local pixel coordinate array to help Numba vectorize
+    # Computing on a local range [0, outwidth) helps the compiler reason about alignment
+    local_idx = np.arange(outwidth, dtype=np.float64)
+
     for idx in range(num_bursts):
         current_burst = phase_rotation_sequence[idx]
-        
-        # Solve for current line's active het_mhz:
+
+        # Solve for current line's active het_hz
         k_current = current_burst.frequency / fsc
         het_hz_current = k_current * color_under_carrier_fs
 
-        # Solve for next line's active het_mhz
+        # Solve for next line's active het_hz
         if idx < num_bursts - 1:
             next_burst = phase_rotation_sequence[idx + 1]
             k_next = next_burst.frequency / fsc
             het_hz_next = k_next * color_under_carrier_fs
         else:
-            next_burst = current_burst
             het_hz_next = het_hz_current
 
         linestart = (current_burst.line_number - lineoffset) * outwidth
         lineend = linestart + outwidth
-        target_phase_rad = target_phase_odd_rad if current_burst.line_number % 2 else target_phase_even_rad
 
-        # Initialize the starting phase
-        theta = het_coefficient * linestart + (
-            current_burst.phase_rotation * pi_over_two # heterodyne rotation
-            + target_phase_rad + current_burst.phase_deg * deg2rad_scale # phase offset relative to line
+        # Determine target phase
+        if current_burst.line_number % 2 != 0:
+            target_phase_rad = target_phase_odd_rad
+        else:
+            target_phase_rad = target_phase_even_rad
+
+        # Initial starting phase
+        theta_0 = het_coefficient * linestart + (
+            current_burst.phase_rotation * pi_over_two
+            + target_phase_rad 
+            + current_burst.phase_deg * deg2rad_scale
         )
 
-        # Upconvert
-        for i in range(linestart, lineend):
-            # Interpolation factor (0.0 to 1.0)
-            t = (i - linestart) / outwidth
+        # Coefficient step parameters
+        alpha = pi_over_two * (1.0 + het_hz_current / fsc)
+        delta_coeff = (het_hz_next - het_hz_current) * coeff_step_factor
+        beta = 0.5 * delta_coeff
+        dc_val = current_burst.dc
 
-            # Linearly interpolate het_mhz
-            het_hz_interpolated = het_hz_current + t * (het_hz_next - het_hz_current)
+        # Slice target and source arrays to provide direct contiguous memory views
+        chroma_slice = chroma[linestart:lineend]
+        uphet_slice = uphet[linestart:lineend]
 
-            # Recalculate the active phase step coefficient
-            active_het_coefficient = pi_over_two * (1.0 + het_hz_interpolated / fsc)
-
-            uphet[i] = chroma[i] * -math.cos(theta) - current_burst.dc
-
-            # Increment phase
-            theta += active_het_coefficient
+        # No outer dependencies so LLVM can vectorize
+        for k in range(outwidth):
+            # Compute closed-form phase directly (no dependency on previous k)
+            theta_k = theta_0 + alpha * local_idx[k] + beta * (local_idx[k] * local_idx[k])
+            
+            # Vectorized trigonometric and arithmetic execution
+            uphet_slice[k] = chroma_slice[k] * -np.cos(theta_k) - dc_val
 
 
 @njit(cache=True, nogil=True)
@@ -764,7 +818,7 @@ def burst_deemphasis(chroma, lineoffset, linesout, outwidth, burstarea):
         linestart = (line - lineoffset) * outwidth
         lineend = linestart + outwidth
 
-        chroma[linestart + burstarea[1] + 5 : lineend] *= 2
+        chroma[linestart + burstarea[1] + 4 : lineend] *= 2
 
     return chroma
 

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1853,13 +1853,8 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
             # Base phase adjustment
             line_adjust = (phase_delta / 360.0) * fsc_ratio
 
-            # --- New Frequency Drift Compensation ---
-            # Calculate the subcarrier cycle drift per sample:
-            # f_offset = burst.frequency - fsc (e.g., +0.15 Hz)
-            # Drift in cycles per sample = f_offset / sample_rate
-            # (Sample rate can be approximated via fsc * fsc_ratio)
+            # Calculate the subcarrier cycle frequency drift as samples:
             f_offset = burst.frequency - fsc
-            print("offset", f_offset, fsc, burst.frequency)
             sample_rate = fsc * fsc_ratio
             drift_cycles_per_sample = f_offset / sample_rate
 

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1832,36 +1832,38 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
         self.burst_detected_line = 0
         self.fsc_ratio = self.rf.SysParams["outfreq"] / self.rf.SysParams["fsc_mhz"]
 
+
     @staticmethod
     def _sync_to_burst(
         linelocs, outlinelen, fsc, fsc_ratio, burst_avg_phase, phase_sequence, burst_detected_line
     ):
         burst_tbc_start = max(9, burst_detected_line)
 
-        for burst in phase_sequence[burst_tbc_start:]:
+        # Precompute loop-invariant multipliers (Eliminates division inside the loop)
+        inv_outlinelen = 1.0 / outlinelen
+        inv_fsc = 1.0 / fsc
+        phase_to_samples_factor = fsc_ratio / 360.0
+
+        for idx in range(burst_tbc_start, len(phase_sequence)):
+            burst = phase_sequence[idx]
+
             # Phase difference at the burst center
-            phase_delta = (burst_avg_phase - burst.phase_deg + 180) % 360 - 180
+            phase_delta = (burst_avg_phase - burst.phase_deg + 180.0) % 360.0 - 180.0
 
             line_start = linelocs[burst.line_number]
             line_end = linelocs[burst.line_number + 1]
             line_length = line_end - line_start
-
-            # Move the hsync location relative to the color burst center position
-            burst_center_distance = burst.center - line_start
-            scale = burst_center_distance / (outlinelen * (burst_center_distance / line_length))
+            scale = line_length * inv_outlinelen
 
             # Base phase adjustment
-            line_adjust = (phase_delta / 360.0) * fsc_ratio
+            line_adjust = phase_delta * phase_to_samples_factor
 
             # Calculate the subcarrier cycle frequency drift as samples:
             f_offset = burst.frequency - fsc
-            sample_rate = fsc * fsc_ratio
-            drift_cycles_per_sample = f_offset / sample_rate
+            burst_center_distance = burst.center - line_start
+            accumulated_drift_samples = (f_offset * burst_center_distance) * inv_fsc
 
-            # Total drift accumulated over this line segment up to the burst center
-            accumulated_drift_samples = (drift_cycles_per_sample * burst_center_distance) * fsc_ratio
-
-            # Subtract the frequency drift component to prevent it from pulling on the static phase TBC
+            # Subtract frequency drift and scale the shift
             corrected_adjust = line_adjust - accumulated_drift_samples
 
             linelocs[burst.line_number] += corrected_adjust * scale

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1764,6 +1764,7 @@ class FieldPALShared(FieldShared, ldd.FieldPAL):
     def _sync_to_burst(
         linelocs,
         outlinelen,
+        fsc,
         fsc_ratio,
         even_burst_avg_phase,
         odd_burst_avg_phase,
@@ -1806,6 +1807,7 @@ class FieldPALShared(FieldShared, ldd.FieldPAL):
                 FieldPALShared._sync_to_burst(
                     linelocs,
                     self.outlinelen,
+                    self.rf.SysParams["fsc_mhz"] * 1e6,
                     self.fsc_ratio,
                     self.even_burst_phase_avg,
                     self.odd_burst_phase_avg,
@@ -1832,23 +1834,42 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
 
     @staticmethod
     def _sync_to_burst(
-        linelocs, outlinelen, fsc_ratio, burst_avg_phase, phase_sequence, burst_detected_line
+        linelocs, outlinelen, fsc, fsc_ratio, burst_avg_phase, phase_sequence, burst_detected_line
     ):
         burst_tbc_start = max(9, burst_detected_line)
 
         for burst in phase_sequence[burst_tbc_start:]:
+            # Phase difference at the burst center
             phase_delta = (burst_avg_phase - burst.phase_deg + 180) % 360 - 180
 
             line_start = linelocs[burst.line_number]
             line_end = linelocs[burst.line_number + 1]
             line_length = line_end - line_start
 
-            # move the hsync location relative to the color burst center position
+            # Move the hsync location relative to the color burst center position
             burst_center_distance = burst.center - line_start
             scale = burst_center_distance / (outlinelen * (burst_center_distance / line_length))
 
+            # Base phase adjustment
             line_adjust = (phase_delta / 360.0) * fsc_ratio
-            linelocs[burst.line_number] += line_adjust * scale
+
+            # --- New Frequency Drift Compensation ---
+            # Calculate the subcarrier cycle drift per sample:
+            # f_offset = burst.frequency - fsc (e.g., +0.15 Hz)
+            # Drift in cycles per sample = f_offset / sample_rate
+            # (Sample rate can be approximated via fsc * fsc_ratio)
+            f_offset = burst.frequency - fsc
+            print("offset", f_offset, fsc, burst.frequency)
+            sample_rate = fsc * fsc_ratio
+            drift_cycles_per_sample = f_offset / sample_rate
+
+            # Total drift accumulated over this line segment up to the burst center
+            accumulated_drift_samples = (drift_cycles_per_sample * burst_center_distance) * fsc_ratio
+
+            # Subtract the frequency drift component to prevent it from pulling on the static phase TBC
+            corrected_adjust = line_adjust - accumulated_drift_samples
+
+            linelocs[burst.line_number] += corrected_adjust * scale
 
     def refine_linelocs_burst(self, linelocs=None):
         if linelocs is None:
@@ -1869,6 +1890,7 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
                     FieldNTSCShared._sync_to_burst(
                         linelocs,
                         self.outlinelen,
+                        self.rf.SysParams["fsc_mhz"] * 1e6,
                         self.fsc_ratio,
                         self.burst_phase_avg,
                         self.phase_sequence,
@@ -1879,6 +1901,7 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
                     FieldPALShared._sync_to_burst(
                         linelocs,
                         self.outlinelen,
+                        self.rf.SysParams["fsc_mhz"] * 1e6,
                         self.fsc_ratio,
                         self.even_burst_phase_avg,
                         self.odd_burst_phase_avg,

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1773,21 +1773,38 @@ class FieldPALShared(FieldShared, ldd.FieldPAL):
     ):
         burst_tbc_start = max(9, burst_detected_line)
 
-        for burst in phase_sequence[burst_tbc_start:]:
+        inv_outlinelen = 1.0 / outlinelen
+        inv_fsc = 1.0 / fsc
+        phase_to_samples_factor = fsc_ratio / 360.0
+
+        for idx in range(burst_tbc_start, len(phase_sequence)):
+            burst = phase_sequence[idx]
+
+            # Select PAL target phase based on line polarity (even/odd)
             target_phase = odd_burst_avg_phase if burst.line_number % 2 else even_burst_avg_phase
 
-            phase_delta = (target_phase - burst.phase_deg + burst.phase_offset_deg + 180) % 360 - 180
+            # Calculate phase delta including the PAL line offset
+            phase_delta = (target_phase - burst.phase_deg + burst.phase_offset_deg + 180.0) % 360.0 - 180.0
 
-            # scale up burst fsc for each line
             line_start = linelocs[burst.line_number]
             line_end = linelocs[burst.line_number + 1]
             line_length = line_end - line_start
-            scale = line_length / outlinelen
+            
+            scale = line_length * inv_outlinelen
 
-            line_adjust = phase_delta / 360.0 * fsc_ratio
-            linelocs[burst.line_number] += (
-                line_adjust * scale
-            )  # 4fsc, then scaled up to the input line length
+            # Base phase adjustment
+            line_adjust = phase_delta * phase_to_samples_factor
+
+            # Frequency Drift Tracking
+            f_offset = burst.frequency - fsc
+            burst_center_distance = burst.center - line_start
+            accumulated_drift_samples = (f_offset * burst_center_distance) * inv_fsc
+
+            # Combine phase offset and subcarrier drift adjustments
+            corrected_adjust = line_adjust - accumulated_drift_samples
+
+            # Shift the HSync location 
+            linelocs[burst.line_number] += corrected_adjust * scale
 
     def refine_linelocs_pilot(self, linelocs=None):
         if linelocs is None:

--- a/vhsdecode/format_defs/umatic.py
+++ b/vhsdecode/format_defs/umatic.py
@@ -243,7 +243,7 @@ def get_sysparams_ntsc_umatic(sysparams_ntsc):
 
     SysParams_NTSC_UMATIC["ire0"] = 4257143
     SysParams_NTSC_UMATIC["hz_ire"] = 1600000 / 140.0
-    SysParams_NTSC_UMATIC["burst_abs_ref"] = 3650
+    SysParams_NTSC_UMATIC["burst_abs_ref"] = 3760
 
     return SysParams_NTSC_UMATIC
 

--- a/vhsdecode/format_defs/umatic.py
+++ b/vhsdecode/format_defs/umatic.py
@@ -243,7 +243,7 @@ def get_sysparams_ntsc_umatic(sysparams_ntsc):
 
     SysParams_NTSC_UMATIC["ire0"] = 4257143
     SysParams_NTSC_UMATIC["hz_ire"] = 1600000 / 140.0
-    SysParams_NTSC_UMATIC["burst_abs_ref"] = 2500
+    SysParams_NTSC_UMATIC["burst_abs_ref"] = 3650
 
     return SysParams_NTSC_UMATIC
 

--- a/vhsdecode/format_defs/vhs.py
+++ b/vhsdecode/format_defs/vhs.py
@@ -344,7 +344,8 @@ def get_sysparams_ntsc_vhs(sysparams_ntsc: dict, tape_speed: int = 0) -> dict:
 
     # TODO: LP value is doubled as a workaround for burst emp not being used in LP mode
     # this should be fixed properly by disabling burst deemp in LP mode
-    SysParams_NTSC_VHS["burst_abs_ref"] = [5564, 5564 / 2, 5564][tape_speed]
+    burst_abs_ref = 5730
+    SysParams_NTSC_VHS["burst_abs_ref"] = [burst_abs_ref, burst_abs_ref / 2, burst_abs_ref][tape_speed]
 
     return SysParams_NTSC_VHS
 

--- a/vhsdecode/format_defs/vhs.py
+++ b/vhsdecode/format_defs/vhs.py
@@ -344,7 +344,7 @@ def get_sysparams_ntsc_vhs(sysparams_ntsc: dict, tape_speed: int = 0) -> dict:
 
     # TODO: LP value is doubled as a workaround for burst emp not being used in LP mode
     # this should be fixed properly by disabling burst deemp in LP mode
-    SysParams_NTSC_VHS["burst_abs_ref"] = [4416, 4416 / 2, 4416][tape_speed]
+    SysParams_NTSC_VHS["burst_abs_ref"] = [5564, 5564 / 2, 5564][tape_speed]
 
     return SysParams_NTSC_VHS
 


### PR DESCRIPTION
## Color Under Heterodyne frequency correction
* Frequency correct the color under heterodyne up conversion based on least-squares optimization.
  * This is done by using the burst frequency tuning results as data points for linear interpolation that is used to compensate for frequency drift during up conversion.
  * This should help remove some chroma noise / phase issues when the color under carrier drifts.
## Improve chroma automatic gain control
  * Measures the color burst gain using least-squares fit, which is more immune to noise than raw RMS
  * Applies gain to chroma with smoothing and MAD (median absolute deviation) clamping
## Refactors
* Disable fastmath for least-squares refinement step since it's important to be extremely accurate with this logic
* Various numba / code performance optimizations

## Examples:
### VHS color bars (chroma decoded)
#### Before
<img width="763" height="525" alt="bars_before" src="https://github.com/user-attachments/assets/78d69f0b-7b43-4273-b84b-d9a15ad8a322" />

#### After
<img width="763" height="525" alt="bars_after" src="https://github.com/user-attachments/assets/7e61124d-c28f-4a2a-b30f-c06717670f64" />

---

### VHS color bars (decode-orc vectorscope)
#### Before
<img width="1492" height="1349" alt="image" src="https://github.com/user-attachments/assets/fa6c7242-d100-4848-a414-0c97a99ca359" />

#### After
<img width="1492" height="1349" alt="image" src="https://github.com/user-attachments/assets/9a7a6b03-00a2-4ed9-a4ff-28855a0b6f22" />
