### PR TITLE
Guard --ire0_adjust hsync against a degenerate field (ZeroDivisionError aborts the decode)

### DIFF
--- a/tests/unit/test_ire0_adjust.py
+++ b/tests/unit/test_ire0_adjust.py
@@ -1,0 +1,100 @@
+"""Tests for the --ire0_adjust hsync submode's per-field hz_ire.
+
+On a degenerate field (dropout / severe sync collapse) the backporch and hsync
+measurement windows read the same level, so
+
+    hz_ire = (ire0 - hsync_level) / -vsync_ire
+
+comes out exactly 0. hz_to_output_array then divides out_scale by it; numba's
+default error model raises rather than returning inf, so an unguarded field
+aborts the entire decode with ZeroDivisionError.
+"""
+
+import logging
+import types
+
+import numpy as np
+import pytest
+
+import vhsdecode.field as vf
+from vhsdecode.field import FieldShared
+
+OUTLINECOUNT = 263
+OUTLINELEN = 910
+GLOBAL_HZ_IRE = 8571.43
+
+
+@pytest.fixture(autouse=True)
+def _logger():
+    if getattr(vf.ldd, "logger", None) is None:
+        vf.ldd.logger = logging.getLogger("test")
+
+
+def _field(ire0_adjust="backporch,hsync"):
+    """A field stub carrying only what hz_to_output touches."""
+    rf = types.SimpleNamespace(
+        DecoderParams={
+            "ire0": 4_542_857.0,
+            "hz_ire": GLOBAL_HZ_IRE,
+            "vsync_ire": -40.0,
+            "track_ire0_offset": [0.0, 0.0],
+        },
+        SysParams={"outputZero": 1024.0},
+        options=types.SimpleNamespace(ire0_adjust=ire0_adjust, export_raw_tbc=False),
+        track_phase=None,
+    )
+    return types.SimpleNamespace(
+        rf=rf,
+        ire0_backporch=[74, 124],
+        outlinecount=OUTLINECOUNT,
+        outlinelen=OUTLINELEN,
+        out_scale=358.4,
+        field_number=0,
+    )
+
+
+def _flat_input(level=5_000_000.0):
+    """A flat field: every measurement window reads the identical level."""
+    return np.full(OUTLINECOUNT * OUTLINELEN, level, dtype=np.float32)
+
+
+def test_degenerate_field_does_not_abort_the_decode():
+    """ire0 == hsync_level -> hz_ire == 0. Previously ZeroDivisionError."""
+    out = FieldShared.hz_to_output(_field(), _flat_input())
+
+    assert out.dtype == np.uint16
+    assert len(out) == OUTLINECOUNT * OUTLINELEN
+
+
+def test_degenerate_field_falls_back_to_the_global_hz_ire():
+    """The guarded field decodes as if the hsync adjustment were unavailable.
+
+    Same flat input through the backporch-only submode never computes a per-field
+    hz_ire at all, so it already uses the global one. If the fallback works, the
+    two must agree.
+    """
+    guarded = FieldShared.hz_to_output(_field("backporch,hsync"), _flat_input())
+    backporch_only = FieldShared.hz_to_output(_field("backporch"), _flat_input())
+
+    np.testing.assert_array_equal(guarded, backporch_only)
+
+
+def test_healthy_field_still_uses_its_own_hz_ire():
+    """The guard must not disturb a field whose windows read different levels.
+
+    hz_to_output measures hsync over [4, ire0_backporch[0] - 4) and black over
+    [ire0_backporch[0] + 4, ire0_backporch[1] - 4), so the sync level has to
+    cover the whole first window to move the median.
+    """
+    inp = _flat_input()
+    for line in range(OUTLINECOUNT):
+        base = line * OUTLINELEN
+        inp[base : base + 74] = 4_000_000.0
+
+    # hz_ire = (5e6 - 4e6) / 40 = 25000, which is not the global 8571.43 --
+    # so a field that never hits the guard must not decode like one that does.
+    out = FieldShared.hz_to_output(_field(), inp)
+    backporch_only = FieldShared.hz_to_output(_field("backporch"), inp)
+
+    assert out.dtype == np.uint16
+    assert not np.array_equal(out, backporch_only)

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1075,6 +1075,20 @@ class FieldShared:
 
                         ldd.logger.debug("calculated hz_ire: %.02f", hz_ire)
 
+                        # Guard: on a degenerate field (dropout / sync loss) the
+                        # backporch and hsync measurement windows can read the same
+                        # level, so hz_ire becomes 0 (or non-finite) and
+                        # hz_to_output_array divides out_scale by it -> ZeroDivisionError
+                        # aborts the whole decode. Fall back to the global hz_ire.
+                        if not np.isfinite(hz_ire) or hz_ire == 0:
+                            ldd.logger.warning(
+                                "ire0_adjust(hsync): degenerate hz_ire "
+                                "(ire0=%.2f, hsync_level=%.2f) -> using global hz_ire",
+                                ire0,
+                                hsync_level,
+                            )
+                            hz_ire = self.rf.DecoderParams["hz_ire"]
+
                 if self.rf.track_phase is not None:
                     ire0 += self.rf.DecoderParams["track_ire0_offset"][
                         self.rf.track_phase ^ (self.field_number % 2)


### PR DESCRIPTION
### Checklist

- [x] I have searched the open pull requests to confirm this change has not already been submitted.
- [x] My branch is up to date with the target branch.
- [x] I have tested my changes and all existing tests pass.
- [ ] I have updated documentation where necessary.
- [x] My code follows the project's coding standards (see [CONTRIBUTING.md](CONTRIBUTING.md)).

### Description

In `FieldShared.hz_to_output`'s `hsync` submode, a degenerate field makes the backporch and hsync
windows read the same level, so `hz_ire = (ire0 - hsync_level) / -vsync_ire` becomes `0`
([`field.py:1074`](https://github.com/oyvindln/vhs-decode/blob/e1ff49186618e2545fa2238fcdb4ec3546951bbd/vhsdecode/field.py#L1074)).
`hz_to_output_array` then divides `out_scale` by it
([`utils.py:1111`](https://github.com/oyvindln/vhs-decode/blob/e1ff49186618e2545fa2238fcdb4ec3546951bbd/lddecode/utils.py#L1111))
and raises `ZeroDivisionError`, aborting the decode. This guards the per-field `hz_ire`: if `0` or
non-finite, warn and fall back to the calibrated `DecoderParams["hz_ire"]`.

### Motivation

A single degenerate field currently discards an arbitrarily long decode with no partial output — mine
died at frame 94056 after ~14.6h. It's the exact tape condition the `hsync` submode exists to help
with (out-of-spec / AGC tapes with dropouts; cf. #314, #318).

### Related Issues

Fixes #339

### Changes Made

- `vhsdecode/field.py`: in `hz_to_output`'s `hsync` submode, if the computed `hz_ire` is non-finite
  or `0`, log a warning and fall back to `self.rf.DecoderParams["hz_ire"]` for that field.

### Testing

- [x] All existing tests pass
- [x] New tests: `tests/unit/test_ire0_adjust.py` — 3 tests; 2 fail unpatched (ZeroDivisionError at
  `hz_to_output`), all pass with the guard. Also a full from-frame-0 decode past the failure point.

The fallback reuses the global `hz_ire` (the value used when the submode is off), so a degenerate
field degrades to "as if hsync adjustment weren't available here" rather than crashing. Happy to take
a different remedy. A no-capture repro script is inlined in #339. Written with AI assistance.
