### PR TITLE
feat(launcher/hifi): passthrough, output suffix, format auto-detect, Betamax/Betacam placeholders

### DIFF
--- a/vhsdecode/decode_launcher.py
+++ b/vhsdecode/decode_launcher.py
@@ -145,6 +145,60 @@ TAPE_FORMATS_BY_TOOL = {
 # Supported tape speeds
 TAPE_SPEEDS = ["SP", "LP", "EP", "SLP", "VP"]
 
+# Filename keyword -> tape format CLI value. Order matters: more specific /
+# rarer formats are checked first so "vhs" doesn't shadow "svhs" etc.
+# Each entry is (list_of_keywords, tape_format_cli_value, tool_subcommand).
+# tool_subcommand is None when the format is valid for the currently selected
+# decoder and should not force a tool switch.
+FILENAME_TAPE_FORMAT_HINTS: list[tuple[tuple[str, ...], str, Optional[str]]] = [
+    (("svhs_et", "svhs-et", "s-vhs_et", "s-vhs-et"), "SVHS_ET", None),
+    (("svhs", "s-vhs", "supervhs", "super-vhs"), "SVHS", None),
+    (("vhshq", "vhs-hq", "vhs_hq"), "VHSHQ", None),
+    (("vhs",), "VHS", None),
+    (("umatic_hi", "umatic-hi", "umatic hi"), "UMATIC_HI", None),
+    (("umatic", "u-matic"), "UMATIC", None),
+    (("betamax_hifi", "betamax-hifi", "betamax hifi", "βetamax hifi"), "BETAMAX_HIFI", "hifi"),
+    (("superbeta", "super-beta"), "SUPERBETA", None),
+    (("betamax", "beta-max", "βetamax"), "BETAMAX", None),
+    (("video8", "video-8"), "VIDEO8", None),
+    (("hi8", "hi-8"), "HI8", None),
+    (("eiaj",), "EIAJ", None),
+    (("quaduplex", "quadruplex", "quad",), "QUADRUPLEX", None),
+    (("vcr_lp", "vcr-lp", "vcr lp", "philips vcr_lp"), "VCR_LP", None),
+    (("vcr", "philips vcr"), "VCR", None),
+    (("smpte-c", "smpte c", "typec", "type-c"), "TYPEC", None),
+    (("smpte-b", "smpte b", "typeb", "type-b"), "TYPEB", None),
+    (("video2000", "video-2000"), "VIDEO2000", None),
+    (("betacam", "beta-cam"), None, "hifi"),  # placeholder - hifi GUI handles it
+]
+
+# Filename keyword -> TV system combo label.
+FILENAME_SYSTEM_HINTS: list[tuple[tuple[str, ...], str]] = [
+    (("ntscj", "ntsc-j", "ntsc_j"), "NTSCJ"),
+    (("ntsc",), "NTSC"),
+    (("pal_m", "pal-m", "palm"), "PAL_M"),
+    (("mesecam",), "MESECAM"),
+    (("pal",), "PAL"),
+]
+
+# Filename keyword -> tape speed combo label.
+FILENAME_TAPE_SPEED_HINTS: list[tuple[tuple[str, ...], str]] = [
+    (("slp",), "SLP"),
+    (("ep",), "EP"),
+    (("lp",), "LP"),
+    (("vp",), "VP"),
+    (("sp",), "SP"),
+]
+
+# Filename keyword -> hifi GUI format combo label (used when launching hifi).
+# Mirrors vhsdecode.hifi.HifiUi auto-detect so launcher and hifi GUI agree.
+FILENAME_HIFI_FORMAT_HINTS: list[tuple[tuple[str, ...], str]] = [
+    (("betamax",), "Betamax"),
+    (("betacam",), "Betacam"),
+    (("video8", "hi8", "hi-8"), "Video8/Hi8"),
+    (("svhs", "s-vhs", "supervhs", "super-vhs", "vhs"), "VHS"),
+]
+
 TOOL_ENTRYPOINTS = {
     "hifi": "hifi-decode",
     "filter-tune": "filter-tune",
@@ -152,6 +206,12 @@ TOOL_ENTRYPOINTS = {
     "cvbs": "cvbs-decode",
     "ld": "ld-decode",
 }
+
+# Mirrors vhsdecode.hifi.HifiUi.FileIODialogUI.OUTPUT_FILE_SUFFIX so the
+# launcher can derive the same default output name the hifi GUI does without
+# importing the Qt-based UI module here.
+HIFI_OUTPUT_SUFFIX = "_HiFi_Decoded.flac"
+HIFI_AUDIO_OUTPUT_EXTENSIONS = {".flac", ".wav"}
 
 
 def _load_app_icon() -> QIcon:
@@ -363,7 +423,29 @@ def _build_basic_decoder_args(
     threads: int,
 ) -> list[str]:
     if tool.subcommand == "hifi":
-        return ["-t", str(threads)]
+        args: list[str] = []
+        input_path = input_path.strip()
+        output_path = output_path.strip()
+        if input_path:
+            args.append(input_path)
+            if output_path:
+                # The launcher's Output base field is an extension-less base
+                # name for the terminal decoders. The hifi GUI expects a full
+                # output filename; derive the same suffixed name it would when
+                # the user loads the input directly, unless the user already
+                # typed an audio extension (.flac/.wav).
+                out_ext = Path(output_path).suffix.lower()
+                if out_ext not in HIFI_AUDIO_OUTPUT_EXTENSIONS:
+                    output_path = f"{output_path}{HIFI_OUTPUT_SUFFIX}"
+                args.append(output_path)
+        if frequency.strip():
+            args += ["-f", frequency.strip()]
+        args += ["-t", str(threads)]
+        if system == "PAL":
+            args += ["--pal"]
+        elif system == "NTSC":
+            args += ["--ntsc"]
+        return args
     if tool.subcommand not in DECODER_SUBCOMMANDS:
         return []
 
@@ -734,9 +816,10 @@ class DecodeLauncherWindow(QWidget):
             window.move(0, 0)
         self._track_hosted_launch(window, window)
 
-    def _launch_hifi_in_process(self, extra: str, threads: int) -> None:
-        extra_args = _split_user_args(extra) if extra else []
-        extra_args = ["-t", str(threads)] + extra_args
+    def _launch_hifi_in_process(self, basic_args: list[str], extra: str) -> None:
+        extra_args = list(basic_args)
+        if extra:
+            extra_args += _split_user_args(extra)
 
         from vhsdecode.hifi.main import launch_hosted_ui
 
@@ -748,13 +831,13 @@ class DecodeLauncherWindow(QWidget):
         self._track_hosted_launch(controller, controller.window)
 
     def _launch_native_gui_in_process(
-        self, tool: ToolSpec, extra: str, threads: int
+        self, tool: ToolSpec, basic_args: list[str], extra: str
     ) -> bool:
         if tool.subcommand == "filter-tune":
             self._launch_filter_tune_in_process(extra)
             return True
         if tool.subcommand == "hifi":
-            self._launch_hifi_in_process(extra, threads)
+            self._launch_hifi_in_process(basic_args, extra)
             return True
         return False
 
@@ -790,6 +873,7 @@ class DecodeLauncherWindow(QWidget):
         self.note_label.setText(tool.notes)
         decoder_selected = tool.subcommand in DECODER_SUBCOMMANDS
         hifi_selected = tool.subcommand == "hifi"
+        file_inputs_enabled = decoder_selected or hifi_selected
         for widget in (
             self.input_edit,
             self.input_browse_button,
@@ -798,7 +882,7 @@ class DecodeLauncherWindow(QWidget):
             self.frequency_edit,
             self.system_combo,
         ):
-            widget.setEnabled(decoder_selected)
+            widget.setEnabled(file_inputs_enabled)
         self.tape_format_combo.setEnabled(tool.subcommand == "vhs")
         self.tape_speed_combo.setEnabled(tool.subcommand == "vhs")
         self.threads_spin.setEnabled(decoder_selected or hifi_selected)
@@ -850,7 +934,62 @@ class DecodeLauncherWindow(QWidget):
     def _on_input_changed(self, value: str) -> None:
         if not self._output_manually_set:
             self.output_edit.setText(self._infer_default_output_base(value))
+        self._auto_detect_config_from_filename(value)
         self._refresh_tool_state()
+
+    def _auto_detect_config_from_filename(self, input_path: str) -> None:
+        """Auto-set tool / tape format / tape speed / TV system from keywords
+        found in the input filename. Only updates a control when a matching
+        keyword is present; absent keywords leave the current selection alone.
+        """
+        if not input_path:
+            return
+        name_lower = os.path.basename(input_path).lower()
+        if not name_lower:
+            return
+
+        # Tool / tape format: pick the first matching hint (order already
+        # favors more-specific formats over generic ones).
+        target_tool: Optional[str] = None
+        target_format_value: Optional[str] = None
+        for keywords, fmt_value, tool_sub in FILENAME_TAPE_FORMAT_HINTS:
+            if any(kw in name_lower for kw in keywords):
+                target_format_value = fmt_value
+                target_tool = tool_sub
+                break
+
+        # If a hint wants the hifi tool (e.g. betamax/betacam), switch to it
+        # only when the user hasn't already selected a terminal decoder that
+        # also accepts the format. We never downgrade from hifi back to vhs.
+        if target_tool == "hifi" and self._selected_tool().subcommand != "hifi":
+            for i, tool in enumerate(self._tools):
+                if tool.subcommand == "hifi":
+                    self.tool_combo.setCurrentIndex(i)
+                    break
+
+        # Tape format combo: only set when the current tool exposes the value.
+        if target_format_value is not None:
+            self._set_tape_format_by_value(target_format_value)
+
+        # TV system.
+        for keywords, system_label in FILENAME_SYSTEM_HINTS:
+            if any(kw in name_lower for kw in keywords):
+                if self.system_combo.findText(system_label) >= 0:
+                    self.system_combo.setCurrentText(system_label)
+                break
+
+        # Tape speed.
+        for keywords, speed_label in FILENAME_TAPE_SPEED_HINTS:
+            if any(kw in name_lower for kw in keywords):
+                if self.tape_speed_combo.findText(speed_label) >= 0:
+                    self.tape_speed_combo.setCurrentText(speed_label)
+                break
+
+    def _set_tape_format_by_value(self, value: str) -> None:
+        for i, (_label, fmt_value) in enumerate(self._active_tape_format_options):
+            if fmt_value == value:
+                self.tape_format_combo.setCurrentIndex(i)
+                return
 
     def _on_output_edited(self, value: str) -> None:
         self._output_manually_set = bool(value.strip())
@@ -894,6 +1033,8 @@ class DecodeLauncherWindow(QWidget):
         handled = False
         if input_path:
             self.input_edit.setText(input_path)
+            # _on_input_changed fires via the textChanged signal and runs the
+            # filename auto-detect; no need to call it again here.
             handled = True
         if params_json_path:
             self.params_json_check.setChecked(True)
@@ -1184,7 +1325,7 @@ class DecodeLauncherWindow(QWidget):
             if tool.prefer_native_gui and not self.force_terminal_check.isChecked():
                 try:
                     if self._launch_native_gui_in_process(
-                        tool, extra, self.threads_spin.value()
+                        tool, basic_args, extra
                     ):
                         return
                 except Exception as hosted_exc:

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -259,7 +259,7 @@ def ui_parameters_to_decode_options(values: MainUIParameters):
     decode_options = {
         "input_rate": float(values.input_sample_rate) * 1e6,
         "standard": "p" if values.standard == "PAL" else "n",
-        "format": "vhs" if values.format == "VHS" else "8mm",
+        "format": "vhs" if values.format in ("VHS", "Betamax", "Betacam") else "8mm",
         "demod_type": values.demod_type.lower(),
         "auto_fine_tune": values.automatic_fine_tuning,
         "bias_guess": values.bias_guess,
@@ -633,7 +633,16 @@ class HifiUi(QMainWindow):
         format_layout = QHBoxLayout()
         format_label = QLabel("Format")
         self.format_combo = QComboBox(self)
-        self.format_combo.addItems(["VHS", "Video8/Hi8"])
+        self.format_combo.addItems(["VHS", "Video8/Hi8", "Betamax", "Betacam"])
+        self.format_combo.setToolTip(
+            "Tape format.\n"
+            "VHS / SVHS: VHS HiFi AFM stereo profile.\n"
+            "Video8/Hi8: 8mm AFM audio profile.\n"
+            "Betamax: placeholder - uses the VHS decode profile until a "
+            "dedicated Betamax profile is available.\n"
+            "Betacam: placeholder - uses the VHS decode profile until a "
+            "dedicated Betacam profile is available."
+        )
         format_layout.addWidget(format_label)
         format_layout.addWidget(self.format_combo)
         self.format_combo.currentIndexChanged.connect(self.on_format_change)
@@ -1189,7 +1198,7 @@ class HifiUi(QMainWindow):
         afe_right_carrier=0,
     ):
         standard, _ = get_standard(
-            "vhs" if format == "VHS" else "8mm",
+            "vhs" if format in ("VHS", "Betamax", "Betacam") else "8mm",
             "p" if standard == "PAL" else "n",
             afe_vco_deviation,
             afe_left_carrier,
@@ -1200,7 +1209,7 @@ class HifiUi(QMainWindow):
         self.afe_right_carrier_spinbox.setValue(int(standard.RCarrierRef))
 
     def update_deemphasis_expander_values(self, format):
-        if format == "VHS":
+        if format in ("VHS", "Betamax", "Betacam"):
             self.deemphasis_low_tau_dial_control.setValue(DEFAULT_VHS_DEEMPHASIS_TAU_1)
             self.deemphasis_high_tau_dial_control.setValue(DEFAULT_VHS_DEEMPHASIS_TAU_2)
             self.nr_deemphasis_low_tau_dial_control.setValue(DEFAULT_VHS_NR_DEEMPHASIS_TAU_1)
@@ -1238,11 +1247,31 @@ class HifiUi(QMainWindow):
         )
 
     def on_format_change(self):
+        current_format = self.format_combo.currentText()
         self.update_afe_values(
-            format=self.format_combo.currentText(),
+            format=current_format,
             standard=self.standard_combo.currentText(),
         )
-        self.update_deemphasis_expander_values(self.format_combo.currentText())
+        self.update_deemphasis_expander_values(current_format)
+        self._warn_if_placeholder_format(current_format)
+
+    PLACEHOLDER_FORMATS = ("Betamax", "Betacam")
+
+    def _warn_if_placeholder_format(self, current_format: str) -> None:
+        if current_format in self.PLACEHOLDER_FORMATS:
+            print(
+                f"{current_format}: using the VHS decode profile as a placeholder "
+                "until a dedicated profile is available."
+            )
+            QMessageBox.warning(
+                self,
+                "Placeholder format",
+                f"{current_format}: Place Holder - Format yet to be implemented.\n\n"
+                "Decoding will use the VHS profile as a stand-in.",
+            )
+
+    def _is_placeholder_format_selected(self) -> bool:
+        return self.format_combo.currentText() in self.PLACEHOLDER_FORMATS
 
     def change_button_color(self, button, color):
         button.setStyleSheet(
@@ -1301,6 +1330,8 @@ class HifiUi(QMainWindow):
 
     def on_play_clicked(self):
         print("[PLAY] Play command issued.")
+        if self._is_placeholder_format_selected():
+            self._warn_if_placeholder_format(self.format_combo.currentText())
         if self.confirm_overwrite():
             return
 
@@ -1313,6 +1344,8 @@ class HifiUi(QMainWindow):
 
     def on_preview_clicked(self):
         print("[PREVIEW] Preview command issued.")
+        if self._is_placeholder_format_selected():
+            self._warn_if_placeholder_format(self.format_combo.currentText())
         if self.confirm_overwrite():
             return
 
@@ -1716,11 +1749,44 @@ class FileIODialogUI(HifiUi):
         self.set_input_sample_rate_mhz(mhz)
         print(f"Input sample rate auto set to {mhz:g} MHz from the FLAC header")
 
+    def auto_detect_format_system_from_filename(self, input_path: str):
+        """Auto-set Format and Standard from keywords in the input filename.
+
+        Recognizes VHS/SVHS, Video8/Hi8, Betamax, Betacam, NTSC and PAL. Only
+        updates a control when a matching keyword is found; the existing
+        selection is left untouched otherwise.
+        """
+        if not input_path:
+            return
+        name_lower = os.path.basename(input_path).lower()
+
+        # Check rarer/more-specific formats first so SVHS/VHS don't shadow them.
+        if "betamax" in name_lower:
+            self.format_combo.setCurrentText("Betamax")
+        elif "betacam" in name_lower:
+            self.format_combo.setCurrentText("Betacam")
+        elif "video8" in name_lower or "hi8" in name_lower or "hi-8" in name_lower:
+            self.format_combo.setCurrentText("Video8/Hi8")
+        elif (
+            "svhs" in name_lower
+            or "s-vhs" in name_lower
+            or "supervhs" in name_lower
+            or "super-vhs" in name_lower
+            or "vhs" in name_lower
+        ):
+            self.format_combo.setCurrentText("VHS")
+
+        if "ntsc" in name_lower:
+            self.standard_combo.setCurrentText("NTSC")
+        elif "pal" in name_lower:
+            self.standard_combo.setCurrentText("PAL")
+
     def set_input_file(self, file_name: str):
         self.file_input_textbox.setText(file_name)
         self._last_input_path = file_name
         self.auto_populate_output_file(file_name)
         self.auto_set_input_frequency(file_name)
+        self.auto_detect_format_system_from_filename(file_name)
 
     def on_input_editing_finished(self):
         # auto fill the output when the user typed/pasted a new input path
@@ -1729,6 +1795,7 @@ class FileIODialogUI(HifiUi):
             self._last_input_path = text
             self.auto_populate_output_file(text)
             self.auto_set_input_frequency(text)
+            self.auto_detect_format_system_from_filename(text)
 
     def dragEnterEvent(self, event):
         mime_data = event.mimeData()
@@ -1790,6 +1857,10 @@ class FileIODialogUI(HifiUi):
         # an input was provided without an output: derive the output name
         if values.input_file and not values.output_file:
             self.auto_populate_output_file(values.input_file)
+        # auto-detect format/standard from the filename when pre-populated
+        # (e.g. when launched from the decode-launcher with an input file).
+        if values.input_file:
+            self.auto_detect_format_system_from_filename(values.input_file)
 
     def on_decode_finished(self, decoded_filename: str = "input stream"):
         decoded_filename = os.path.basename(self.file_input_textbox.text())


### PR DESCRIPTION
## Summary

Fixes and additions for the decode-launcher and hifi-decode GUI.

### decode-launcher -> hifi-decode GUI passthrough

- Forward input/output/frequency/system from the launcher into `launch_hosted_ui` so the hifi GUI opens pre-populated instead of blank (previously only `-t <threads>` + extra args were forwarded).
- Enable the launcher's input/output/frequency/system fields for the hifi tool (they were disabled for hifi, so loaded files were not visible/editable).
- Derive the `_HiFi_Decoded.flac` output suffix for hifi when the launcher output base has no audio extension (`.flac`/`.wav` respected), matching the GUI's own `derive_output_file` behavior.

### Filename auto-detect (decode-launcher)

- Auto-set tool, tape format, tape speed and TV system from keywords in the input filename on browse/drag-drop/typing/launcher pre-pop.
- Coverage: VHS/VHSHQ/SVHS/SVHS_ET, Umatic/Umatic_Hi, Betamax/Betamax_Hifi/SuperBeta, Video8/Hi8, EIAJ, Quadruplex, VCR/VCR_LP, TypeC/TypeB, Video2000; systems NTSC/NTSCJ/PAL/PAL_M/MESECAM; speeds SP/LP/EP/SLP/VP. Betamax/Betacam switch to the hifi tool.

### hifi GUI (`HifiUi`)

- Add Betamax and Betacam format options as placeholders that map to the VHS decode profile internally (`format=vhs`); show a `QMessageBox` warning on selection and on Play/Preview ("Place Holder - Format yet to be implemented").
- Filename auto-detect for Format/Standard (VHS/SVHS, Video8/Hi8, Betamax, Betacam, NTSC, PAL) on browse/drop/type/launcher pre-pop.

## Cross-platform

Changes are pure Python with no Windows-specific branching in the new logic; applies to source runs and the Linux AppImage / macOS `.app` CI builds unchanged (both workflows pull these modules from the same source tree).

## Verification

- `ast.parse` on both files.
- Headless checks: hifi arg building (input/output/`-f`/`-t`/`--pal`/`--ntsc`); `_HiFi_Decoded.flac` suffix derivation (no-ext gets suffix, `.flac`/`.wav` respected, empty stays empty); `ui_parameters_to_decode_options` mapping (VHS->vhs, Video8/Hi8->8mm, Betamax->vhs, Betacam->vhs); launcher filename auto-detect across 10 representative filenames.
- User-confirmed real-world: rebuilt `dist\decode.exe`, launcher loads files into hifi GUI pre-populated, drag-drop works (after clearing an elevated-privilege UIPI block unrelated to this code), decoding runs.

## Files changed

- `vhsdecode/decode_launcher.py`
- `vhsdecode/hifi/HifiUi.py`