### PR TITLE
Ringing Correction with Luma Transient Improvement

### DIFF
--- a/filter_tune/filter_tune.py
+++ b/filter_tune/filter_tune.py
@@ -493,7 +493,6 @@ class DeemphasisFilters:
         bandpass = None
         if filter_params["nonlinear_bandpass_upper"]["value"] != 0:
             bandpass = filter_params["nonlinear_bandpass_upper"]["value"]
-        
         self.filters["NLHighPassF"] = compute_video_filters.gen_nonlinear_bandpass(
             bandpass,
             filter_params["nonlinear_highpass_freq"].get("value", 1000),
@@ -501,7 +500,6 @@ class DeemphasisFilters:
             fs / 2.0,
             block_len,
         )
-        
         self.filters["NLAmplitudeLPF"] = (
             compute_video_filters.gen_nonlinear_amplitude_lpf(
                 filter_params["nonlinear_amplitude_lpf"]["value"], fs / 2.0

--- a/filter_tune/filter_tune.py
+++ b/filter_tune/filter_tune.py
@@ -493,6 +493,7 @@ class DeemphasisFilters:
         bandpass = None
         if filter_params["nonlinear_bandpass_upper"]["value"] != 0:
             bandpass = filter_params["nonlinear_bandpass_upper"]["value"]
+        
         self.filters["NLHighPassF"] = compute_video_filters.gen_nonlinear_bandpass(
             bandpass,
             filter_params["nonlinear_highpass_freq"].get("value", 1000),
@@ -500,6 +501,7 @@ class DeemphasisFilters:
             fs / 2.0,
             block_len,
         )
+        
         self.filters["NLAmplitudeLPF"] = (
             compute_video_filters.gen_nonlinear_amplitude_lpf(
                 filter_params["nonlinear_amplitude_lpf"]["value"], fs / 2.0

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -1,3 +1,4 @@
+import math
 import numpy as np
 import numba as nb
 import scipy.fft
@@ -11,8 +12,9 @@ import matplotlib.ticker as mticker
 # 1. NUMBA KERNEL: CAUSAL PHASE EQUALIZATION FIR
 # -----------------------------------------------------------------------------
 
-FSC=3.579545 # TODO: parameterize (used only in debug)
-FSC_RATIO = 4 # sets ratio of FFT length to fsc
+FSC = 3.579545 # TODO: parameterize (used only in debug)
+FPS = 525
+FSC_RATIO = 4
 
 FIR_LEN = 127
 FFT_LEN = 512
@@ -22,6 +24,7 @@ DELAY_OFFSET = FIR_LEN // 2  # Anchors the causal peak
 def _make_interpolated_inverse_eq(fir_len, delay_offset):
     @nb.njit(
         "float32[:](float32[::1], float32[::1], int64, float32[::1], float32[::1])",
+        parallel=True,
         cache=True,
         nogil=True,
         fastmath=True
@@ -31,24 +34,21 @@ def _make_interpolated_inverse_eq(fir_len, delay_offset):
         first = picture_clean[0]
         last = picture_clean[n_samples - 1]
 
-        # Pre-allocate tap buffer for the per-pixel interpolated kernel
-        h_interp = np.empty(fir_len, dtype=np.float32)
-
-        for k in range(n_samples):
+        # Process each sample independently in parallel without allocating inner arrays
+        for k in nb.prange(n_samples):
             alpha = np.float32(k) / np.float32(n_samples - 1) if n_samples > 1 else np.float32(0.0)
             one_minus_alpha = np.float32(1.0) - alpha
 
-            # 2. Interpolate FIR taps directly for current pixel k
-            for j in range(fir_len):
-                h_interp[j] = one_minus_alpha * kernel_a[j] + alpha * kernel_b[j]
-
-            # 3. Apply the causal filter sweep for pixel k
             read_head = k + delay_offset
             acc = 0.0
 
+            # Interpolate FIR tap for current pixel on the fly
             for j in range(fir_len):
+                h_val = one_minus_alpha * kernel_a[j] + alpha * kernel_b[j]
+                
                 idx = read_head - j
                 
+                # Boundary clamping
                 if idx < 0:
                     val = first
                 elif idx >= n_samples:
@@ -56,11 +56,10 @@ def _make_interpolated_inverse_eq(fir_len, delay_offset):
                 else:
                     val = picture_clean[idx]
 
-                acc += val * h_interp[j]
+                acc += val * h_val
 
-            # 4. Delta Injection
-            delta = acc - picture_clean[k]
-            out[k] = picture_raw[k] + delta
+            # Delta Injection
+            out[k] = picture_raw[k] + (acc - picture_clean[k])
 
         return out
     return _apply_interpolated_inverse_eq
@@ -68,7 +67,7 @@ def _make_interpolated_inverse_eq(fir_len, delay_offset):
 _apply_interpolated_inverse_eq = _make_interpolated_inverse_eq(FIR_LEN, DELAY_OFFSET)
 
 
-@nb.njit("float32[:](float32[::1], float32[::1])", cache=True, nogil=True, fastmath=True)
+@nb.njit("float32[:](float32[::1], float32[::1])", parallel=True, cache=True, nogil=True, fastmath=True)
 def _apply_zero_phase_fir(picture, fir_kernel):
     n_samples = len(picture)
     fir_len = len(fir_kernel)
@@ -78,6 +77,7 @@ def _apply_zero_phase_fir(picture, fir_kernel):
     first = picture[0]
     last = picture[n_samples - 1]
 
+    # Apply standard zero-phase FIR filtering across pixels
     for i in nb.prange(n_samples):
         acc = 0.0
         for j in range(fir_len):
@@ -121,6 +121,7 @@ def _build_ideal_step(
     for i in range(win_size):
         t_rise = float(i) - measured_center_rise
 
+        # Build smooth cosine transition between sync and blanking limits
         if t_rise < -target_transition / 2.0:
             ideal[i] = local_sync
         elif t_rise <= target_transition / 2.0:
@@ -146,6 +147,7 @@ def _build_ideal_hsync_pulse(
     center_fall = float(front_porch_len) + phase_delay
     center_rise = float(front_porch_len + sync_len) + phase_delay
     
+    # Generate complete target pulse for reference plot
     for i in range(win_size):
         t_fall = float(i) - center_fall
         t_rise = float(i) - center_rise
@@ -188,46 +190,44 @@ def _get_levels(data):
     return sync_tip_average, blanking_average
 
 
+@nb.njit(cache=True, nogil=True, fastmath=True)
 def _suppress_color_carrier_fft(samples):
     out = samples.copy()
-    i = 0.0
-    q = 0.0
-    for n, x in enumerate(samples):
-        phase = (n & 3)
-        if phase == 0:
-            i += x
-        elif phase == 2:
-            i -= x
-        elif phase == 1:
-            q -= x
-        else:
-            q += x
-            
-    scale = 2.0 / len(samples)
-    i *= scale
-    q *= scale
+    i_acc, q_acc = 0.0, 0.0
+    n = len(samples)
     
-    for n in range(len(out)):
-        phase = n & 3
-        if phase == 0:
-            out[n] -= i
-        elif phase == 1:
-            out[n] -= -q
-        elif phase == 2:
-            out[n] -= -i
-        else:
-            out[n] -= q
+    # Accumulate quadrature phases
+    for j in range(n):
+        phase = j & 3
+        if phase == 0: i_acc += samples[j]
+        elif phase == 2: i_acc -= samples[j]
+        elif phase == 1: q_acc -= samples[j]
+        else: q_acc += samples[j]
+            
+    scale = 2.0 / n
+    i_acc *= scale
+    q_acc *= scale
+    
+    # Subtract average carrier
+    for j in range(n):
+        phase = j & 3
+        if phase == 0: out[j] -= i_acc
+        elif phase == 1: out[j] -= -q_acc
+        elif phase == 2: out[j] -= -i_acc
+        else: out[j] -= q_acc
+        
     return out
 
 
 def _build_causal_fir_from_spectrum(H_inv, fft_len, fir_len, delay_offset):
-    freqs_norm = np.abs(np.fft.fftfreq(fft_len))
+    freqs_norm = np.abs(scipy.fft.fftfreq(fft_len))
     
     taper = np.clip((0.45 - freqs_norm) / 0.10, 0.0, 1.0)
     taper_smooth = 0.5 * (1.0 - np.cos(np.pi * taper)) 
     H_inv_tapered = H_inv * taper_smooth
 
-    omega = 2.0 * np.pi * np.fft.fftfreq(fft_len)
+    # Apply linear phase shift to maintain causal peak location
+    omega = 2.0 * np.pi * scipy.fft.fftfreq(fft_len)
     causal_phase_shift = np.exp(-1j * omega * delay_offset)
     H_inv_tapered *= causal_phase_shift
 
@@ -263,7 +263,6 @@ def apply_inverse_equalization(
     back_porch_len,
     target_transition,
     group_delay_state,
-    noise_threshold=1,
     interpolate_amplitude=True,
     interpolate_phase=True,
     interpolate_time=True, # TODO: allow interpolation to be disabled for speed
@@ -282,6 +281,7 @@ def apply_inverse_equalization(
     win_noise = scipy.signal.windows.hann(sync_tip_flat_len)
     start_idx_noise = (FFT_LEN - sync_tip_flat_len) // 2
 
+    # Accumulate noise profile from flat sync tip regions
     for line in range(line_start, line_end + 1):
         loc = line * line_length
         tip_start = loc + front_porch_len + int(sync_len * 0.3)
@@ -301,7 +301,7 @@ def apply_inverse_equalization(
         noise_mag_profile = np.zeros(FFT_LEN, dtype=np.float64)
 
     # =========================================================================
-    # PARTS 1 & 2: Pass 1 - Line Measurement & 1000-Pulse Ring Buffer Validation
+    # PARTS 1 & 2: Pass 1 - Line Measurement & Pulse Ring Buffer Validation
     # =========================================================================
     MAX_HISTORY_PULSES = 1000
 
@@ -348,6 +348,7 @@ def apply_inverse_equalization(
         if start_loc >= 0 and start_loc + win_size < n_samples:
             pulse = video_buf[start_loc : start_loc + win_size]
 
+            # Measure dynamic levels for ideal pulse target
             measured_sync_tip_level, measured_blanking_level = _get_levels(pulse)
             mid_val = measured_sync_tip_level + (measured_blanking_level - measured_sync_tip_level) / 2.0
 
@@ -411,7 +412,7 @@ def apply_inverse_equalization(
                 avg_power_magnitude = np.mean(historical_mean_s_yy) + 1e-12
                 relative_deviation = spectral_distance / avg_power_magnitude
                 
-                if relative_deviation > (0.4 * noise_threshold + 0.20):
+                if relative_deviation > (0.4 * 0.20):
                     is_outlier = True
 
             if not is_outlier:
@@ -436,11 +437,12 @@ def apply_inverse_equalization(
         hf_power = accum_s_yy[hf_mask]
         hf_median = np.median(hf_power) if len(hf_power) > 0 else 0.0
         hf_mad = np.median(np.abs(hf_power - hf_median)) if len(hf_power) > 0 else 0.0
-        noise_penalty = (hf_median + 3.0 * hf_mad) * noise_threshold
+        noise_penalty = (hf_median + 3.0 * hf_mad)
 
         num_passes = 5  
         H_total = np.ones(FFT_LEN, dtype=np.complex128)
 
+        # Iteratively solve for the optimal equalizer response
         for pass_idx in range(num_passes):
             current_S_xy = accum_s_xy * np.conj(H_total)
             current_S_yy = accum_s_yy * (np.abs(H_total) ** 2)
@@ -475,6 +477,7 @@ def apply_inverse_equalization(
     line_kernels = []
     line_H_invs = []
 
+    # Compile the final FIR arrays for delta injection
     for i in range(len(raw_line_spectra)):
         mag = np.abs(raw_line_spectra[i]) if interpolate_amplitude else avg_amplitude
         phase = np.angle(raw_line_spectra[i]) if interpolate_phase else avg_phase
@@ -491,6 +494,7 @@ def apply_inverse_equalization(
     video_clean = _suppress_color_carrier_fft(video_buf)
     video_buf_filtered = video_buf.copy()
     
+    # Process delta corrections across each line
     for i, line in enumerate(range(line_start, line_end + 1)):
         loc = line * line_length
         if loc >= len(video_buf):
@@ -512,9 +516,9 @@ def apply_inverse_equalization(
         
         video_buf_filtered[loc : loc + line_length] = filtered_line
 
-    # ==============================================
+    # =========================================================================
     # PART 5: Exact Inverse Noise Floor Compensation
-    # ==============================================
+    # =========================================================================
     avg_H_inv = np.mean(line_H_invs, axis=0) if len(line_H_invs) > 0 else np.ones(FFT_LEN, dtype=np.complex128)
 
     gd_mag = np.abs(avg_H_inv)
@@ -524,6 +528,7 @@ def apply_inverse_equalization(
     mean_noise = np.mean(noise_mag_profile)
     noise_weight = np.clip((noise_mag_profile / (mean_noise + 1e-12)) * 2.0, 0.0, 1.0)
 
+    # Invert the static noise response characteristics
     H_corrective = 1.0 - (noise_weight * (1.0 - inverse_multiplier))
     H_corrective[0] = 1.0
 
@@ -549,7 +554,7 @@ def apply_inverse_equalization(
     )
 
     mid_kernel = line_kernels[len(line_kernels) // 2] if len(line_kernels) > 0 else np.zeros(FIR_LEN)
-    lti_params = derive_lti_parameters(mid_kernel, noise_threshold=noise_threshold)
+    lti_params = derive_lti_parameters(mid_kernel)
 
     if debug:
         full_win_size = max(front_porch_len + sync_len + back_porch_len, FIR_LEN)
@@ -783,7 +788,7 @@ def _show_group_delay_debug(
 # -----------------------------------------------------------------------------
 # LTI PARAMETER DERIVATION FUNCTION
 # -----------------------------------------------------------------------------
-def derive_lti_parameters(fir_kernel, noise_threshold):
+def derive_lti_parameters(fir_kernel):
     total_energy = np.sum(fir_kernel**2)
     if total_energy <= 1e-12:
         return {'gain': 0.0, 'threshold': 0.1, 'blur_radius': 0.0}
@@ -794,10 +799,10 @@ def derive_lti_parameters(fir_kernel, noise_threshold):
     indices = np.arange(len(fir_kernel))
     weighted_spread = np.sum(indices * np.abs(fir_kernel)) / np.sum(np.abs(fir_kernel))
     
-    noise_suppression_factor = max(0.2, 1.0 - 2.0 * noise_threshold)
+    noise_suppression_factor = max(0.2, 1.0 - 2.0)
     lti_gain = np.clip(energy_dispersion * 1.5 * noise_suppression_factor, 0.0, 1.0)
     
-    lti_threshold = np.clip(noise_threshold * 0.75, 0.02, 0.15)
+    lti_threshold = np.clip(0.75, 0.02, 0.15)
 
     return {
         'gain': float(lti_gain),

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -320,8 +320,9 @@ def apply_inverse_equalization(
     start_idx = (FFT_LEN - win_size) // 2
     count = 0
 
-    pulses_padded = []
-    pulses_ideal = []
+    S_xy = np.zeros(FFT_LEN, dtype=np.complex128)
+    S_xx = np.zeros(FFT_LEN, dtype=np.complex128)
+    S_yy = np.zeros(FFT_LEN, dtype=np.float64)
 
     for line in range(line_start, line_end + 1):
         loc = line * line_length
@@ -371,24 +372,18 @@ def apply_inverse_equalization(
             pad_ideal[start_idx : start_idx + win_size] = d_ideal
             pad_pulse[start_idx : start_idx + win_size] = d_pulse
 
-            pulses_padded.append(pad_pulse)
-            pulses_ideal.append(pad_pulse)
+            # measure pulse's actual frequency response
+            Y = scipy.fft.fft(pad_pulse)
+            # measure the pulse's expected frequency response, given the sync pulse parameters
+            X = scipy.fft.fft(pad_ideal)
+            
+            S_xy += X * np.conj(Y)
+            S_xx += np.abs(X)**2
 
     if count > 0:
-        F_batch = scipy.fft.fft(
-            np.asarray(pulses_padded + pulses_ideal),
-            axis=1,
-        )
-
-        # measure pulse's actual frequency response
-        Y = F_batch[:len(pulses_padded)]
-        # measure expected frequency response
-        X = F_batch[len(pulses_padded):]
-
         current_measurement = {
-            's_xy': np.sum(X * np.conj(Y), axis=0),
-            's_xx': np.sum(np.abs(X)**2, axis=0),
-            's_yy': np.sum(np.abs(Y)**2, axis=0),
+            's_xy': S_xy,
+            's_xx': S_xx,
         }
         group_delay_state.append(current_measurement)
     else:
@@ -397,12 +392,10 @@ def apply_inverse_equalization(
 
     rolling_S_xy = np.zeros(FFT_LEN, dtype=np.complex128)
     rolling_S_xx = np.zeros(FFT_LEN, dtype=np.complex128)
-    rolling_S_yy = np.zeros(FFT_LEN, dtype=np.float64)
 
     for measurement in group_delay_state:
         rolling_S_xy += measurement['s_xy']
         rolling_S_xx += measurement['s_xx']
-        rolling_S_yy += measurement['s_yy']
 
     # =========================================================================
     # PART 2: Analyze Pulse Structure
@@ -597,8 +590,6 @@ def apply_inverse_equalization(
                 corrected_ffts.append(corrected_fft)
                 delta_ffts.append(delta_fft)
 
-                pulse_ffts
-
         all_corr_arr = np.array(corrected_pulses)
         sync_tip_average, blanking_average = _get_levels(all_corr_arr.flatten())
 
@@ -762,7 +753,7 @@ def _show_group_delay_debug(
     # =========================================================================
     # SUBTRACTION SPECTROGRAM
     # =========================================================================
-    image = ax5.imshow(
+    ax5.imshow(
         delta_spec_data,
         aspect='auto',
         origin='lower',
@@ -777,7 +768,7 @@ def _show_group_delay_debug(
     # =========================================================================
     # CORRECTED SPECTROGRAM
     # =========================================================================
-    image = ax6.imshow(
+    ax6.imshow(
         corrected_spec_data,
         aspect='auto',
         origin='lower',
@@ -881,30 +872,24 @@ def derive_lti_parameters(fir_kernel, noise_threshold):
 # -----------------------------------------------------------------------------
 @nb.njit(cache=True, nogil=True, fastmath=True)
 def apply_adaptive_luma_transient_improvement(video_buf, gain, threshold):
-    """
-    Applies non-linear LTI using parameters derived from the group delay kernel.
-    Modifies video_buf in place.
-    """
     n = len(video_buf)
-
-    # Preserve original samples needed for the stencil
     prev = video_buf[0]
 
     for i in range(1, n - 1):
         curr = video_buf[i]
         nxt = video_buf[i + 1]
 
-        diff = nxt - prev
-        abs_diff = abs(diff)
+        # 1st derivative (span of 2 pixels) to check threshold
+        abs_diff = abs(nxt - prev)
 
-        # Only boost active step transitions exceeding noise threshold
         if abs_diff > threshold:
-            # Local slope estimate
-            grad = curr - prev
+            # 2nd derivative (Laplacian) isolates the high-frequency edge energy symmetrically
+            laplacian = prev - 2.0 * curr + nxt
 
-            # Non-linear gain scaling (tapers off near plateaus to prevent ringing)
+            # Non-linear gain taper
             edge_weight = min(1.0, abs_diff / (2.0 * threshold))
-            video_buf[i] = curr + (gain * edge_weight) * grad
+            
+            # Subtracting the Laplacian acts as a symmetric unsharp mask / peaking filter
+            video_buf[i] = curr - (gain * edge_weight * laplacian)
 
-        # Advance cached original sample
         prev = curr

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -1,15 +1,21 @@
 import numpy as np
 import numba as nb
 import scipy.fft
+import scipy
+from scipy.interpolate import UnivariateSpline
 
 from matplotlib.colors import LinearSegmentedColormap
+import matplotlib.ticker as mticker
 
 # -----------------------------------------------------------------------------
 # 1. NUMBA KERNEL: CAUSAL PHASE EQUALIZATION FIR
 # -----------------------------------------------------------------------------
 
+FSC=3.579545 # TODO: parameterize (used only in debug)
+FSC_RATIO = 4 # sets ratio of FFT length to fsc
+
 FIR_LEN = 63
-FFT_LEN = 2**9
+FFT_LEN = 512
 
 @nb.njit(cache=True, nogil=True, fastmath=True)
 def _apply_inverse_eq(picture, n_samples, causal_kernel):
@@ -32,237 +38,59 @@ def _apply_inverse_eq(picture, n_samples, causal_kernel):
 
     return out
 
-def _calc_phase_advance(S_xy):
+
+def _fit_smooth_phase(S_xy, smooth=1):
+    phase = -np.unwrap(np.angle(S_xy))
+    mag = np.abs(S_xy)
+
+    # frequency bins to mask for horizontal smearing
+    w = 2 * np.pi * np.fft.fftfreq(len(S_xy))
+    mask = (w > 0.01 * np.pi) & (w < 0.2 * np.pi)
+
+    w_fit = w[mask]
+    phase_fit = phase[mask]
+
+    weight = mag[mask]
+    weight /= np.max(weight)
+
+    slope, intercept = np.polyfit(
+        w_fit, phase_fit, 1, w=weight,
+    )
+
+    excess = phase_fit - (slope * w_fit + intercept)
+    spline = UnivariateSpline(
+        w_fit, excess, w=weight, s=smooth*len(w_fit)
+    )
+
+    phase_corr = np.zeros_like(phase)
+    phase_corr[mask] = slope * w_fit + intercept + spline(w_fit)
+
+    half = len(phase) // 2
+    phase_corr[half + 1:] = -phase_corr[1:half][::-1]
+    phase_corr[0] = 0.0
+    phase_corr[half] = 0.0
+
+    return phase_corr, -slope
+
+def _build_fsc_mask(n, width_bins=3):
     """
-    Calculates the exact group delay advance (in fractional samples).
-    
-    Optimized for maximum ringing cancellation:
-    Strictly bandpasses the spectrum to remove the massive low-frequency 
-    sync edge energy. It locates the high-frequency ringing resonance peak 
-    and fits the phase slope locally around that specific frequency.
+    Creates a soft mask around the color subcarrier.
+    Returns values 0..1.
     """
-    phase = np.unwrap(np.angle(S_xy))
-    freqs = scipy.fft.fftfreq(FFT_LEN)
-    
-    # 1. Blind the algorithm to the massive sync edge energy
-    # by strictly hard-cutting the lower 5% of the spectrum.
-    start_bin = max(5, int(FFT_LEN * 0.05))
-    end_bin = int(FFT_LEN * 0.40)
-    
-    if start_bin >= end_bin:
-        return 0.0
-        
-    w_high = 2.0 * np.pi * freqs[start_bin:end_bin]
-    p_high = phase[start_bin:end_bin]
-    mag_high = np.abs(S_xy[start_bin:end_bin])
-    
-    # 2. Locate the ringing resonance peak
-    # Multiplying by w_high helps flatten out any residual 1/f sync leakage
-    resonance_profile = mag_high * w_high
-    peak_idx = np.argmax(resonance_profile)
-    
-    # 3. Create a narrow local window exclusively around the ringing peak
-    window_radius = max(3, int(FFT_LEN * 0.015))
-    local_start = max(0, peak_idx - window_radius)
-    local_end = min(len(w_high), peak_idx + window_radius + 1)
-    
-    w_local = w_high[local_start:local_end]
-    p_local = p_high[local_start:local_end]
-    weights_local = resonance_profile[local_start:local_end]
-    
-    # Normalize local weights for numerical stability in polyfit
-    w_max = np.max(weights_local)
-    if w_max > 0.0:
-        weights_local /= w_max
-        
-    # 4. Fit the phase slope strictly and locally at the ringing frequency
-    # Because group delay = -d(phase)/d(w), the slope of this local tangent 
-    # gives us the exact delay of the ringing artifact itself.
-    if len(w_local) > 1:
-        slope, _ = np.polyfit(w_local, p_local, 1, w=weights_local)
-    else:
-        slope = 0.0
-        
-    return -slope
 
+    freq = np.abs(np.fft.fftfreq(n))
+    fsc = 1.0 / FSC_RATIO
 
-def _show_group_delay_debug(
-    raw_pulses,
-    corrected_pulses,
-    ideal,
-    fir_kernel,
-    calc_advance,
-    line_indices,
-    pulse_ffts,
-    delta_ffts,
-    corrected_ffts,
-    FFT_LEN,
-):
-    try:
-        import matplotlib.pyplot as plt
-        from matplotlib.widgets import Slider
-    except ImportError:
-        print("Matplotlib is required to render the debug plot.")
-        return
+    mask = np.zeros(n)
+    dist = np.abs(freq - fsc)
 
-    n_lines = len(raw_pulses)
-    if n_lines == 0:
-        return
-
-    # Expand figure layout to fit 6 subplots
-    fig = plt.figure(figsize=(16, 20))
-    
-    ax1 = plt.subplot2grid((6, 2), (0, 0), colspan=2) # Line Inspection
-    ax2 = plt.subplot2grid((6, 2), (1, 0), colspan=1) # All Lines Overlay
-    ax3 = plt.subplot2grid((6, 2), (1, 1), colspan=1) # Causal Kernel Taps
-    ax4 = plt.subplot2grid((6, 2), (2, 0), colspan=2) # Raw Pulse
-    ax5 = plt.subplot2grid((6, 2), (3, 0), colspan=2) # Delta
-    ax6 = plt.subplot2grid((6, 2), (4, 0), colspan=2) # Corrected Pulse
-    ax_slider = plt.subplot2grid((6, 2), (5, 0), colspan=2) # Slider
-
-    initial_idx = 0
-    line_num = line_indices[initial_idx]
-    
-    raw_line, = ax1.plot(raw_pulses[initial_idx], label=f'Raw Line {line_num}', color='#d62728', linewidth=1.8, alpha=0.85)
-    corr_line, = ax1.plot(corrected_pulses[initial_idx], label=f'Equalized Line {line_num}', color='#1f77b4', linewidth=2.2)
-    ax1.plot(ideal, label='Target Reference', color='#7f7f7f', linestyle=':', linewidth=2)
-    
-    ax1.set_title(f"Line Inspection [Line 1] | Group Delay Advance: {calc_advance:.3f} samples", fontweight='bold')
-    ax1.legend(loc='upper right')
-    ax1.grid(True, alpha=0.35)
-    ax1.set_ylabel("Amplitude")
-
-    for p in raw_pulses:
-        ax2.plot(p, color='#d62728', alpha=min(0.25, max(0.02, 5.0 / n_lines)), linewidth=0.8)
-    for p in corrected_pulses:
-        ax2.plot(p, color='#1f77b4', alpha=min(0.25, max(0.02, 5.0 / n_lines)), linewidth=0.8)
-
-    ax2.set_title(f"All Lines Overlay ({n_lines} Lines)", fontweight='bold')
-    ax2.grid(True, alpha=0.35)
-    ax2.set_ylabel("Amplitude")
-
-    x_axis = np.arange(len(fir_kernel))
-    ax3.plot(x_axis, fir_kernel, label='Causal Taps (t >= 0)', color='purple', marker='.', linewidth=1.2)
-    ax3.set_title("Causal Equalization Kernel", fontweight='bold')
-    ax3.axhline(0, color='black', alpha=0.3)
-    ax3.set_xlim(0, len(fir_kernel) - 1)
-    ax3.legend(loc='upper right')
-    ax3.grid(True, alpha=0.35)
-
-    # =========================================================================
-    # Build FFTs
-    # =========================================================================
-    freqs = scipy.fft.fftfreq(FFT_LEN)
-    half_len = FFT_LEN // 2
-    pos_freqs = freqs[:half_len]
-
-    num_ffts = len(pulse_ffts)
-    min_line = line_indices[0] if line_indices else 0
-    max_line = line_indices[-1] if line_indices else num_ffts - 1
-    
-    pulse_spec_data = np.zeros((len(pulse_ffts), half_len + 1), dtype=np.float64)
-    delta_spec_data = np.zeros((len(delta_ffts), half_len + 1), dtype=np.float64)
-    corrected_spec_data = np.zeros((len(corrected_ffts), half_len + 1), dtype=np.float64)
-    for i in range(num_ffts):
-        if i < pulse_spec_data.shape[0]:
-            pulse_fft = pulse_ffts[i]
-            pulse_spec_data[i, :] = 20 * np.log10(np.maximum(np.abs(pulse_fft[:half_len + 1]), 1e-12))
-    
-        if i < delta_spec_data.shape[0]:
-            delta_fft = delta_ffts[i]
-            delta_spec_data[i, :] = 20 * np.log10(np.maximum(np.abs(delta_fft[:half_len + 1]), 1e-12))
-
-        if i < corrected_spec_data.shape[0]:
-            corrected_fft = corrected_ffts[i]
-            corrected_spec_data[i, :] = 20 * np.log10(np.maximum(np.abs(corrected_fft[:half_len + 1]), 1e-12))
-
-    # Custom Audacity-style multi-stop gradient: Black -> Deep Green -> Neon Green -> White
-    green = LinearSegmentedColormap.from_list(
-        "green", 
-        ["#00ff00", "#000000"]
+    width = width_bins / n
+    inside = dist < width
+    mask[inside] = 0.5 * (
+        1.0 + np.cos(np.pi * dist[inside] / width)
     )
 
-    # =========================================================================
-    # PULSE SPECTROGRAM
-    # =========================================================================
-    image = ax4.imshow(
-        pulse_spec_data,
-        aspect='auto',
-        origin='lower',
-        extent=[pos_freqs[0], pos_freqs[-1], min_line, max_line],
-        cmap=green
-    )
-    cbar = fig.colorbar(image, ax=ax4, pad=0)
-    cbar.set_label('Pulse (Raw)')
-
-    ax4.set_title("$Y_{raw}$", fontweight='bold')
-    ax4.set_xlabel("Normalized Frequency")
-    ax4.set_ylabel("Line Index")
-
-    # =========================================================================
-    # SUBTRACTION SPECTROGRAM
-    # =========================================================================
-    image = ax5.imshow(
-        delta_spec_data,
-        aspect='auto',
-        origin='lower',
-        extent=[pos_freqs[0], pos_freqs[-1], min_line, max_line],
-        cmap=green
-    )
-    cbar = fig.colorbar(image, ax=ax5, pad=0)
-    cbar.set_label('Delta')
-
-    ax5.set_title("$Y_{delta}$", fontweight='bold')
-    ax5.set_xlabel("Normalized Frequency")
-    ax5.set_ylabel("Line Index")
-
-    # =========================================================================
-    # CORRECTED SPECTROGRAM
-    # =========================================================================
-    image = ax6.imshow(
-        corrected_spec_data,
-        aspect='auto',
-        origin='lower',
-        extent=[pos_freqs[0], pos_freqs[-1], min_line, max_line],
-        cmap=green
-    )
-    cbar = fig.colorbar(image, ax=ax6, pad=0)
-    cbar.set_label('Pulse Corrected')
-
-    ax6.set_title("$Y_{delta} - Y_{raw}$", fontweight='bold')
-    ax6.set_xlabel("Normalized Frequency")
-    ax6.set_ylabel("Line Index")
-
-
-    # =========================================================================
-    # Slider
-    # =========================================================================
-    slider = Slider(
-        ax=ax_slider,
-        label='Line Index ',
-        valmin=0,
-        valmax=max(0, n_lines - 1),
-        valinit=0,
-        valstep=1,
-        color='#1f77b4'
-    )
-
-    def update(val):
-        idx = int(slider.val)
-        l_num = line_indices[idx]
-        raw_line.set_ydata(raw_pulses[idx])
-        raw_line.set_label(f'Raw Line {l_num}')
-        corr_line.set_ydata(corrected_pulses[idx])
-        corr_line.set_label(f'Equalized Line {l_num}')
-        ax1.set_title(f"Line Inspection [Line {l_num}] | Group Delay Advance: {calc_advance:.3f} samples", fontweight='bold')
-        ax1.legend(loc='upper right')
-        fig.canvas.draw_idle()
-
-    slider.on_changed(update)
-
-    plt.tight_layout()
-    plt.show()
-
+    return mask
 
 def _build_ideal_step(
     measured_center_rise,
@@ -326,12 +154,16 @@ def _normalize_inplace(video_buf, sync_tip_level, blanking_level):
     for i in range(video_buf.size):
         video_buf[i] = (video_buf[i] - sync_tip_level) * scale - 1.0
 
+    return video_buf
+
 
 @nb.njit(cache=True, nogil=True, fastmath=True)
 def _denormalize_inplace(video_buf, sync_tip_level, blanking_level):
     scale = 0.5 * (blanking_level - sync_tip_level)
     for i in range(video_buf.size):
         video_buf[i] = (video_buf[i] + 1.0) * scale + sync_tip_level
+
+    return video_buf
 
 
 @nb.njit(cache=True, nogil=True, fastmath=True)
@@ -343,6 +175,97 @@ def _get_levels(data):
     blanking_average = np.median(part[-k:])
     return sync_tip_average, blanking_average
 
+def _suppress_color_carrier(x, harmonics=0):
+    """
+    Remove a coherent carrier and its harmonics using quadrature projection.
+
+    Parameters
+    ----------
+    x : ndarray
+        Real signal.
+    harmonics : int
+        Number of harmonics to suppress, including the fundamental.
+    """
+
+    n = np.arange(len(x))
+    y = x.copy()
+
+    for h in range(1, harmonics + 1):
+        phase = 2.0 * np.pi * h * n / FSC
+
+        c = np.cos(phase)
+        s = np.sin(phase)
+
+        cc = np.dot(c, c)
+        ss = np.dot(s, s)
+
+        if cc > 1e-12:
+            ac = np.dot(y, c) / cc
+            y -= ac * c
+
+        if ss > 1e-12:
+            bs = np.dot(y, s) / ss
+            y -= bs * s
+
+    return y
+
+def _suppress_color_carrier_fft(samples):
+    """
+    Remove a pure Fs/4 carrier using quadrature estimation.
+    """
+
+    out = samples.copy()
+
+    # Accumulate I/Q over the whole pulse
+    i = 0.0
+    q = 0.0
+
+    for n, x in enumerate(samples):
+        phase = (n & 3)
+
+        if phase == 0:
+            i += x
+        elif phase == 2:
+            i -= x
+        elif phase == 1:
+            q -= x
+        else:
+            q += x
+
+    # Remove estimated carrier
+    scale = 2.0 / len(samples)
+    i *= scale
+    q *= scale
+
+    for n in range(len(out)):
+        phase = n & 3
+
+        if phase == 0:
+            out[n] -= i
+        elif phase == 1:
+            out[n] -= -q
+        elif phase == 2:
+            out[n] -= -i
+        else:
+            out[n] -= q
+
+    return out
+
+def _taper_delta_fft(fft):
+    freqs = np.abs(np.fft.fftfreq(len(fft)))
+
+    mask = np.ones_like(freqs)
+
+    start = 0.20   # 1 fsc
+    end = 0.25     # Nyquist (2 fsc)
+
+    idx = (freqs >= start) & (freqs <= end)
+
+    t = (freqs[idx] - start) / (end - start)
+    mask[idx] = 0.5 * (1.0 + np.cos(np.pi * t))
+    mask[freqs > end] = 0.0
+
+    return fft * mask
 
 # -----------------------------------------------------------------------------
 # Group Delay Correction
@@ -359,21 +282,27 @@ def apply_inverse_equalization(
     back_porch_len,
     target_transition,
     group_delay_state,
-    noise_threshold=0.2, # TODO, determine automatically; set frequency scaling based on noise floor, or MAD between frequencies
+    noise_threshold=1, # TODO, determine automatically; set frequency scaling based on noise floor, or MAD between frequencies
     debug=False
 ):
     _normalize_inplace(video_buf, sync_tip_level, blanking_level)
-    
+
     n_samples = len(video_buf)
-    
+
     pre_rise_samples = int(np.round(0.25 * sync_len))
     win_size = pre_rise_samples + back_porch_len
+    win_size -= win_size % 4 
     offset_rise = pre_rise_samples
-    
+
     S_xy = np.zeros(FFT_LEN, dtype=np.complex128)
+    S_xx = np.zeros(FFT_LEN, dtype=np.complex128)
     S_yy = np.zeros(FFT_LEN, dtype=np.float64)
-    
-    win = np.hanning(win_size)
+
+    pulse_ffts = []
+    delta_ffts = []
+    corrected_ffts = []
+
+    win = scipy.signal.windows.tukey(win_size, alpha=0.05)
     start_idx = (FFT_LEN - win_size) // 2
     count = 0
 
@@ -384,8 +313,9 @@ def apply_inverse_equalization(
         loc = line * line_length
         start_loc = loc + sync_len - pre_rise_samples
         if start_loc >= 0 and start_loc + win_size < n_samples:
-            
             pulse = video_buf[start_loc : start_loc + win_size]
+            # pulse = _suppress_color_carrier(pulse)
+
             measured_sync_tip_level, measured_blanking_level = _get_levels(pulse)
             mid_val = measured_sync_tip_level + (measured_blanking_level - measured_sync_tip_level) / 2.0
 
@@ -426,16 +356,20 @@ def apply_inverse_equalization(
             pad_pulse = np.zeros(FFT_LEN, dtype=np.float64)
             pad_ideal[start_idx : start_idx + win_size] = d_ideal
             pad_pulse[start_idx : start_idx + win_size] = d_pulse
-            
-            X = scipy.fft.fft(pad_ideal)
+
+            # measure pulse's actual frequency response
             Y = scipy.fft.fft(pad_pulse)
+            # measure the pulse's expected frequency response, given the sync pulse parameters
+            X = scipy.fft.fft(pad_ideal)
             
             S_xy += X * np.conj(Y)
+            S_xx += np.abs(X)**2
             S_yy += np.abs(Y)**2
 
     if count > 0:
         current_measurement = {
             's_xy': S_xy,
+            's_xx': S_xx,
             's_yy': S_yy,
         }
         group_delay_state.append(current_measurement)
@@ -444,76 +378,205 @@ def apply_inverse_equalization(
         return video_buf
 
     rolling_S_xy = np.zeros(FFT_LEN, dtype=np.complex128)
+    rolling_S_xx = np.zeros(FFT_LEN, dtype=np.complex128)
     rolling_S_yy = np.zeros(FFT_LEN, dtype=np.float64)
 
     for measurement in group_delay_state:
         rolling_S_xy += measurement['s_xy']
+        rolling_S_xx += measurement['s_xx']
         rolling_S_yy += measurement['s_yy']
 
     # =========================================================================
-    # PART 2: Analytical Advance & Deconvolution
+    # PART 2: Analyze Pulse Structure
+    #     2A: Group Delay (Horizontal Smear)
+    #     2B: Ringing
+    #     2C: Chroma carrier leakage
     # =========================================================================
-    # Dynamically extract the optimal floating-point advance from phase slope
-    advance_float = _calc_phase_advance(rolling_S_xy)
-    
-    # Split into integer video shift and fractional kernel phase-shift
-    int_adv = int(np.round(advance_float))
-    frac_adv = advance_float - int_adv
-    
-    reg = np.max(rolling_S_yy) * noise_threshold 
-    denom = rolling_S_yy + reg
-    denom[denom == 0] = 1e-12
-    H_inv = rolling_S_xy / denom
 
-    # Apply ONLY the fractional sub-sample advance to the kernel in frequency domain.
-    # This securely modifies the filter shape without needing to FFT the whole video buffer.
-    w_full = 2.0 * np.pi * scipy.fft.fftfreq(FFT_LEN)
-    H_inv = H_inv * np.exp(-1j * w_full * frac_adv)
+    # rolling_S_xy = _suppress_color_carrier_fft(rolling_S_xy)
+    # rolling_S_xy = _taper_delta_fft(rolling_S_xy)
+
+    phase_error, advance_float = _fit_smooth_phase(
+        rolling_S_xy
+    )
+
+    H_measured = (rolling_S_xy / np.maximum(rolling_S_xx, 1e-12))
+    # Normalize DC
+    H_measured /= max(np.abs(H_measured[0]), 1e-12)
+
+    # ------------------------------------------------------------
+    # 2A Remove horizontal smear (phase only)
+    # ------------------------------------------------------------
+    smear_strength = 1
+    smear_gd_sigma = FFT_LEN / FIR_LEN # group delay measurement smoothing
+    smear_weight_sigma = FFT_LEN / (2 * FIR_LEN) # correction transition smoothing
+
+    # Estimate group delay stability
+    phase = -np.unwrap(np.angle(H_measured))
+    w = 2.0 * np.pi * np.fft.fftfreq(len(H_measured))
+    group_delay = -np.gradient(phase, w)
+
+    # Smooth group delay to find broad delay behavior
+    gd_smooth = scipy.ndimage.gaussian_filter1d(
+        group_delay, smear_gd_sigma
+    )
+
+    # Difference from smooth delay = non-smear behavior
+    gd_error = np.abs(group_delay - gd_smooth)
+    gd_scale = np.percentile(gd_error, 95)
+
+    smear_weight = np.clip(
+        1.0 - gd_error / max(gd_scale, 1e-12), 0.0, 1.0
+    )
+    smear_weight = scipy.ndimage.gaussian_filter1d(
+        smear_weight, smear_weight_sigma
+    )
+
+    phase_error_weighted = phase_error * smear_weight
+
+    # Apply phase-only correction
+    H_smear = np.exp(
+        -1j *
+        smear_strength *
+        phase_error_weighted
+    )
+
+    # ------------------------------------------------------------
+    # 2B Remove ringing
+    # ------------------------------------------------------------
+    ring_strength = 1
+    ring_sigma = 1 # FFT_LEN / FIR_LEN
+
+    # remove color carrier leakage from this measurement
+    fsc_mask = _build_fsc_mask(FFT_LEN, width_bins=4)
+    H_after_smear = H_measured * H_smear * (1.0 - fsc_mask) + fsc_mask
+
+    H_target = np.abs(H_after_smear) * np.exp(
+        1j * scipy.ndimage.gaussian_filter1d(
+            np.unwrap(np.angle(H_after_smear)), ring_sigma
+        )
+    )
+
+    H_residual = H_after_smear - H_target
+
+    # Keep causal ringing tail only
+    h_residual=scipy.fft.ifft(H_residual).real
+
+    peak=np.argmax(np.abs(h_residual))
+    h_residual[:peak + 1] = 0
+
+    ring_window=scipy.signal.windows.tukey(
+        FIR_LEN, alpha=0.25
+    )
+
+    h_residual[peak + 1:peak + 1 + FIR_LEN] *= ring_window[:min(
+        FIR_LEN, len(h_residual) - peak - 1
+    )]
+
+    h_residual[peak+1+FIR_LEN:] = 0
+
+    H_ring_error = scipy.fft.fft(h_residual)
+
+    ring_gain = np.sqrt(
+        np.sum(np.abs(H_residual) ** 2) /
+        max(np.sum(np.abs(H_ring_error) ** 2), 1e-12)
+    )
+
+    H_ring = 1.0 - ring_strength * H_ring_error * ring_gain
+
+    # ------------------------------------------------------------
+    # 2C Remove chroma leakage following smear slope
+    # ------------------------------------------------------------
+    chroma_strength = 1
+
+    # Use same phase slope as smear correction
+    H_chroma_slope = np.exp(-1j * phase_error)
+    # Limit correction to carrier region
+    H_chroma_slope = H_chroma_slope * fsc_mask + (1.0 - fsc_mask)
+
+    # Measure remaining carrier error
+    H_after_chroma_slope = H_after_smear * H_chroma_slope
+    H_chroma_residual = (H_after_chroma_slope - 1.0) * fsc_mask
+
+    # Convert residual to causal correction
+    h_chroma = scipy.fft.ifft(H_chroma_residual).real
+    h_chroma[0] = 0
+    h_chroma[FIR_LEN:] = 0
+    h_chroma[1:FIR_LEN] *= scipy.signal.windows.tukey(
+        FIR_LEN-1, alpha=0.25
+    )
+    H_chroma_error = scipy.fft.fft(h_chroma)
+
+    H_chroma = 1.0 - chroma_strength * H_chroma_error
+
+    ### assemble the filters
+    H_inv = (
+        H_smear
+      * H_ring
+      * H_chroma
+    )
+
+    ######################################################
+    # TODO: Might be able to detect head switching pulses.
+    #       The ringing pattern clearly differs when the head switch occurs.
+    #       This could be used to detect the switching position, measure it, and correct it's slope
+    ######################################################
+
+    # =========================================================================
+    # PART 3: Build Causal Inverse Equalization FIR Filter
+    # =========================================================================
 
     # IFFT back to time domain
     h_full = scipy.fft.fftshift(scipy.fft.ifft(H_inv).real)
     
-    # The Wiener deconvolution naturally places the main impulse offset by int_adv.
-    # By shifting our extraction center to match this offset, we extract the causal tail 
-    # perfectly aligned.
-    true_center = FFT_LEN // 2 - int_adv
-    
-    # Isolate causal tail taps for t >= 1
-    fir_tail = h_full[true_center + 1:].copy()
+    # Make FIR causal
+    true_center = FFT_LEN // 2
 
     # Assemble half-size causal kernel
     fir_kernel = np.zeros(FIR_LEN, dtype=np.float32)
-    
-    # Safely insert the tail up to the maximum available filter length
-    insert_len = min(len(fir_tail), FIR_LEN - 1)
-    fir_kernel[1:1 + insert_len] = fir_tail[:insert_len]
- 
-    # Fade out the tail using a half-cosine window
-    fade_len = round(FIR_LEN * 0.15) # fade out last 15%
-    fade_axis = np.arange(fade_len, dtype=np.float64)
-    fir_kernel[FIR_LEN - fade_len:] *= 0.5 * (1.0 + np.cos(np.pi * fade_axis / fade_len))
+    fir_kernel[0] = h_full[true_center]
+    fir_kernel[1:] = h_full[
+        true_center + 1:
+        true_center + FIR_LEN
+    ]
+    fir_kernel /= np.sum(fir_kernel)
 
-    # Base DC Normalization: Enforce DC Unity strictly on the center tap (t=0)
-    fir_kernel[0] = 1.0 - np.sum(fir_kernel[1:])
+    # =========================================================================
+    # PART 4: Apply Inverse Equalization FIR Filter
+    # =========================================================================
+    video_buf_filtered = _apply_inverse_eq(video_buf, n_samples, fir_kernel)
+
+    lti_params = derive_lti_parameters(
+        fir_kernel, 
+        noise_threshold=noise_threshold
+    )
 
     if debug:
         full_win_size = max(front_porch_len + sync_len + back_porch_len, FIR_LEN)
         raw_pulses = []
         corrected_pulses = []
         line_indices = []
-        pulse_ffts = []
-        delta_ffts = []
-        corrected_ffts = []
 
         for line in range(line_start, line_end + 1):
             start_loc = line * line_length - front_porch_len
             if start_loc >= 0 and start_loc + full_win_size < n_samples:
                 raw_p = video_buf[start_loc : start_loc + full_win_size].copy()
                 corr_p = _apply_inverse_eq(raw_p, full_win_size, fir_kernel)
+                # raw_p = _suppress_color_carrier(raw_p)
 
                 raw_pulses.append(raw_p)
                 corrected_pulses.append(corr_p)
                 line_indices.append(line)
+
+                pulse_fft = scipy.fft.fft(raw_p, n=FFT_LEN)
+                corrected_fft = scipy.fft.fft(corr_p, n=FFT_LEN)
+                delta_fft = corrected_fft - pulse_fft
+
+                pulse_ffts.append(pulse_fft)
+                corrected_ffts.append(corrected_fft)
+                delta_ffts.append(delta_fft)
+
+                pulse_ffts
 
         all_corr_arr = np.array(corrected_pulses)
         sync_tip_average, blanking_average = _get_levels(all_corr_arr.flatten())
@@ -526,36 +589,15 @@ def apply_inverse_equalization(
             sync_tip_average,
             blanking_average,
             full_win_size,
-            phase_delay=-(advance_float+int_adv),
+            phase_delay=0,
         )
-        ideal_fft = _build_ideal_hsync_pulse(
-            front_porch_len,
-            sync_len,
-            target_transition,
-            sync_tip_average,
-            blanking_average,
-            FFT_LEN,
-            phase_delay=-(advance_float+int_adv),
-        )
-        y_ideal = scipy.fft.fft(ideal_fft, n=FFT_LEN)
-
-        # get ffts of all the pulses before, after, amount of change all subtracted from the ideal pulse
-        for i in range(len(raw_pulses)):
-            # Capture FFT of raw and corrected pulses
-            y_raw = scipy.fft.fft(raw_pulses[i], n=FFT_LEN)
-            y_corr = scipy.fft.fft(corrected_pulses[i], n=FFT_LEN)
-            y_delta = (y_corr - y_raw)
-    
-            pulse_ffts.append(y_raw - y_ideal)
-            delta_ffts.append(y_ideal - y_delta)
-            corrected_ffts.append(y_corr - y_ideal)
                     
         _show_group_delay_debug(
             raw_pulses,
             corrected_pulses,
             ideal_debug,
             fir_kernel,
-            advance_float,
+            0,
             line_indices,
             pulse_ffts,
             delta_ffts,
@@ -563,19 +605,217 @@ def apply_inverse_equalization(
             FFT_LEN,
         )
 
-    # =========================================================================
-    # PART 3: Apply Strictly Causal Equalization
-    # =========================================================================
-    video_buf = _apply_inverse_eq(video_buf, n_samples, fir_kernel)
 
-    _denormalize_inplace(video_buf, sync_tip_level, blanking_level)
+    return _denormalize_inplace(video_buf_filtered, sync_tip_level, blanking_level), lti_params
 
-    lti_params = derive_lti_parameters(
-        fir_kernel, 
-        noise_threshold=noise_threshold
+
+# Set `--debug_plot inverse_eq` to show this plot
+def _show_group_delay_debug(
+    raw_pulses,
+    corrected_pulses,
+    ideal,
+    fir_kernel,
+    calc_advance,
+    line_indices,
+    pulse_ffts,
+    delta_ffts,
+    corrected_ffts,
+    FFT_LEN,
+):
+    try:
+        import matplotlib.pyplot as plt
+        from matplotlib.widgets import Slider
+    except ImportError:
+        print("Matplotlib is required to render the debug plot.")
+        return
+
+    n_lines = len(raw_pulses)
+    if n_lines == 0:
+        return
+
+    # Expand figure layout to fit 6 subplots
+    plt.style.use("dark_background")
+    plt.rcParams.update({
+        "figure.facecolor": "#121212",
+        "axes.facecolor": "#181818",
+        "axes.edgecolor": "#aaaaaa",
+        "axes.labelcolor": "#dddddd",
+        "axes.titlecolor": "#ffffff",
+        "xtick.color": "#cccccc",
+        "ytick.color": "#cccccc",
+        "text.color": "#dddddd",
+        "grid.color": "#555555",
+        "grid.alpha": 0.35,
+    })
+    fig = plt.figure(figsize=(16, 20))
+    
+    ax1 = plt.subplot2grid((6, 2), (0, 0), colspan=2) # Line Inspection
+    ax2 = plt.subplot2grid((6, 2), (1, 0), colspan=1) # All Lines Overlay
+    ax3 = plt.subplot2grid((6, 2), (1, 1), colspan=1) # Causal Kernel Taps
+    ax_slider = plt.subplot2grid((6, 1), (2, 0), colspan=2) # Slider
+
+    # FFT section
+    ax4 = plt.subplot2grid((6, 2), (3, 0), colspan=2) # Raw Pulse
+    ax5 = plt.subplot2grid((6, 2), (4, 0), colspan=2, sharex=ax4, sharey=ax4) # Delta
+    ax6 = plt.subplot2grid((6, 2), (5, 0), colspan=2, sharex=ax4, sharey=ax4) # Corrected Pulse
+
+    initial_idx = 0
+    line_num = line_indices[initial_idx]
+    
+    raw_line, = ax1.plot(raw_pulses[initial_idx], label=f'Raw Line {line_num}', color='#d62728', linewidth=1.8, alpha=0.85)
+    corr_line, = ax1.plot(corrected_pulses[initial_idx], label=f'Equalized Line {line_num}', color='#1f77b4', linewidth=2.2)
+    ax1.plot(ideal, label='Target Reference', color='#7f7f7f', linestyle=':', linewidth=2)
+    
+    ax1.set_title(f"Line Inspection [Line 1] | Group Delay Advance: {calc_advance:.3f} samples", fontweight='bold')
+    ax1.legend(loc='lower right')
+    ax1.grid(True, alpha=0.35)
+    ax1.set_ylabel("Amplitude")
+
+    for p in raw_pulses:
+        ax2.plot(p, color='#d62728', alpha=min(0.25, max(0.02, 5.0 / n_lines)), linewidth=0.8)
+    for p in corrected_pulses:
+        ax2.plot(p, color='#1f77b4', alpha=min(0.25, max(0.02, 5.0 / n_lines)), linewidth=0.8)
+
+    ax2.set_title(f"All Lines Overlay ({n_lines} Lines)", fontweight='bold')
+    ax2.grid(True, alpha=0.35)
+    ax2.set_ylabel("Amplitude")
+
+    x_axis = np.arange(len(fir_kernel))
+    ax3.plot(x_axis, fir_kernel, label='Causal Taps (t >= 0)', color='purple', marker='.', linewidth=1.2)
+    ax3.set_title("Causal Equalization Kernel", fontweight='bold')
+    ax3.axhline(0, color='black', alpha=0.3)
+    ax3.set_xlim(0, len(fir_kernel) - 1)
+    ax3.legend(loc='upper right')
+    ax3.grid(True, alpha=0.35)
+
+    # =========================================================================
+    # Build FFTs
+    # =========================================================================
+    freqs = scipy.fft.fftfreq(FFT_LEN)
+    half_len = FFT_LEN // 2
+    pos_freqs = freqs[:half_len] * FSC_RATIO * FSC
+
+    num_ffts = len(pulse_ffts)
+    min_line = line_indices[0] if line_indices else 0
+    max_line = line_indices[-1] if line_indices else num_ffts - 1
+    
+    pulse_spec_data = np.zeros((len(pulse_ffts), half_len + 1), dtype=np.float64)
+    delta_spec_data = np.zeros((len(delta_ffts), half_len + 1), dtype=np.float64)
+    corrected_spec_data = np.zeros((len(corrected_ffts), half_len + 1), dtype=np.float64)
+    for i in range(num_ffts):
+        if i < pulse_spec_data.shape[0]:
+            pulse_fft = pulse_ffts[i]
+            pulse_spec_data[i, :] = 20 * np.log10(np.maximum(np.abs(pulse_fft[:half_len + 1]), 1e-12))
+    
+        if i < delta_spec_data.shape[0]:
+            delta_fft = delta_ffts[i]
+            delta_spec_data[i, :] = 20 * np.log10(np.maximum(np.abs(delta_fft[:half_len + 1]), 1e-12))
+
+        if i < corrected_spec_data.shape[0]:
+            corrected_fft = corrected_ffts[i]
+            corrected_spec_data[i, :] = 20 * np.log10(np.maximum(np.abs(corrected_fft[:half_len + 1]), 1e-12))
+
+    # Custom Audacity-style multi-stop gradient: Black -> Deep Green -> Neon Green -> White
+    green_pos = LinearSegmentedColormap.from_list(
+        "green", 
+        ["#000000", "#00ff00"]
+    )   
+    green_neg = LinearSegmentedColormap.from_list(
+        "green", 
+        ["#00ff00", "#000000"]
     )
 
-    return video_buf, lti_params
+    # =========================================================================
+    # PULSE SPECTROGRAM
+    # =========================================================================
+    ax4.imshow(
+        pulse_spec_data,
+        aspect='auto',
+        origin='lower',
+        extent=[pos_freqs[0], pos_freqs[-1], min_line, max_line],
+        cmap=green_pos
+    )
+    ax4.set_title("Raw $Y_{raw}$", fontweight='bold')
+    ax4.set_adjustable('box')
+
+    # =========================================================================
+    # SUBTRACTION SPECTROGRAM
+    # =========================================================================
+    image = ax5.imshow(
+        delta_spec_data,
+        aspect='auto',
+        origin='lower',
+        extent=[pos_freqs[0], pos_freqs[-1], min_line, max_line],
+        cmap=green_neg
+    )
+    ax5.set_title("Delta $Y_{delta}$", fontweight='bold')
+    ax5.set_xlabel("Frequency (MHz)")
+    ax5.set_ylabel("Line Index")
+    ax5.set_adjustable('box')
+
+    # =========================================================================
+    # CORRECTED SPECTROGRAM
+    # =========================================================================
+    image = ax6.imshow(
+        corrected_spec_data,
+        aspect='auto',
+        origin='lower',
+        extent=[pos_freqs[0], pos_freqs[-1], min_line, max_line],
+        cmap=green_pos
+    )
+    ax6.set_title("Corrected $Y_{delta} - Y_{raw}$", fontweight='bold')
+    ax6.set_adjustable('box')
+    ax6.set_xlabel("Normalized Frequency")
+
+    ax6.xaxis.set_major_locator(mticker.MultipleLocator(0.5))
+    ax6.xaxis.set_major_formatter(mticker.FormatStrFormatter('%.1f'))
+
+    for ax in (ax4, ax5, ax6):
+        ax.set_xlim(pos_freqs[0], pos_freqs[-1])
+        ax.set_ylim(min_line, max_line)
+
+
+    # =========================================================================
+    # Slider
+    # =========================================================================
+    slider = Slider(
+        ax=ax_slider,
+        label='Line Index ',
+        valmin=0,
+        valmax=max(0, n_lines - 1),
+        valinit=0,
+        valstep=1,
+        color='#1f77b4'
+    )
+
+    ax_slider.set_facecolor("#181818")
+    slider.label.set_color("#dddddd")
+    slider.valtext.set_color("#dddddd")
+
+    def update(val):
+        idx = int(slider.val)
+        l_num = line_indices[idx]
+        raw_line.set_ydata(raw_pulses[idx])
+        raw_line.set_label(f'Raw Line {l_num}')
+        corr_line.set_ydata(corrected_pulses[idx])
+        corr_line.set_label(f'Equalized Line {l_num}')
+        ax1.set_title(f"Line Inspection [Line {l_num}] | Group Delay Advance: {calc_advance:.3f} samples", fontweight='bold')
+        ax1.legend(loc='lower right')
+        fig.canvas.draw_idle()
+
+    slider.on_changed(update)
+
+    plt.subplots_adjust(
+        left=0.05,
+        right=0.98,
+        top=0.98,
+        bottom=0.05,
+        hspace=0.25
+    )
+    
+    plt.show()
+
+
 
 
 # -----------------------------------------------------------------------------

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -1,0 +1,417 @@
+import numpy as np
+import numba as nb
+
+"""
+The transient response needs to model the two transitions
+Other noise should be ignored, I only need to model the transient's slope and then fit a response curve to it
+The ringing happens only in the forward direction and it appears to be following an exponential decay, vs. a following a raised cosine slope
+As the pulse progresses through time, it appears to shift very slightly up just before the transition upward,
+then progresses upwards, then overshoots a bit before setting back down exponentially
+
+Maybe treat this like an attack / release, where the attack is the beginning slow increase, and the release is the decay at the top
+
+run a few passes to extrapolate the multistage deemphasis passes
+There is a non-linear deemphasis, and a sub deemphasis stage, I need to extrapolate the amount of correction to apply to each stage
+
+Get the different models for emphasis, fit the hsync pulses to those models, apply deemphasis through luma signal
+
+Non-linear filters
+
+Perform least squares optimization on the filters for the averaged sync pulse
+Fit the filter parameters to the best parameters that correct the pulse
+
+"""
+
+@nb.njit(cache=True, nogil=True, fastmath=True)
+def apply_tbc_ringing_correction(
+    tbc_video, 
+    line_start, 
+    line_end, 
+    line_length, 
+    blanking_level, 
+    sync_tip_level, 
+    front_porch_len=15, 
+    sync_len=67,         
+    back_porch_len=67,   
+    gain_scale=1.0,
+    target_transition=3.3 
+):
+    n_samples = len(tbc_video)
+    win_size = front_porch_len + sync_len + back_porch_len
+    offset_fall = front_porch_len
+    offset_rise = front_porch_len + sync_len
+
+    # 1. Extract Full Average Pulse Shape
+    avg_pulse_shape = np.zeros(win_size, dtype=np.float64)
+    count = 0
+    
+    for line in range(line_start, line_end + 1):
+        loc = line * line_length
+        if loc - offset_fall >= 0 and loc + sync_len + back_porch_len < n_samples:
+            for k in range(win_size):
+                avg_pulse_shape[k] += tbc_video[loc - offset_fall + k]
+            count += 1
+
+    if count > 0:
+        avg_pulse_shape /= float(count)
+    else:
+        return tbc_video.copy()
+
+    # 2. Dynamic Subpixel Phase Alignment
+    mid_val = (blanking_level + sync_tip_level) / 2.0
+    
+    measured_center_fall = float(offset_fall)
+    for i in range(win_size - 1):
+        if avg_pulse_shape[i] >= mid_val >= avg_pulse_shape[i+1]:
+            y0 = avg_pulse_shape[i] - mid_val
+            y1 = avg_pulse_shape[i+1] - mid_val
+            if (y0 - y1) != 0.0:
+                measured_center_fall = float(i) + abs(y0) / abs(y0 - y1)
+            break
+
+    measured_center_rise = float(offset_rise)
+    search_start = int(measured_center_fall + (sync_len // 2))
+    for i in range(search_start, win_size - 1):
+        if avg_pulse_shape[i] <= mid_val <= avg_pulse_shape[i+1]:
+            y0 = avg_pulse_shape[i] - mid_val
+            y1 = avg_pulse_shape[i+1] - mid_val
+            if (y1 - y0) != 0.0:
+                measured_center_rise = float(i) + abs(y0) / abs(y1 - y0)
+            break
+
+    sum_fp, count_fp = 0.0, 0
+    for i in range(0, max(1, int(measured_center_fall - 4))):
+        sum_fp += avg_pulse_shape[i]
+        count_fp += 1
+    local_blank_f = sum_fp / count_fp if count_fp > 0 else blanking_level
+    
+    sum_sync, count_sync = 0.0, 0
+    for i in range(int(measured_center_fall + 12), int(measured_center_rise - 12)):
+        sum_sync += avg_pulse_shape[i]
+        count_sync += 1
+    local_sync = sum_sync / count_sync if count_sync > 0 else sync_tip_level
+    
+    sum_bp, count_bp = 0.0, 0
+    for i in range(int(measured_center_rise + 4), win_size):
+        sum_bp += avg_pulse_shape[i]
+        count_bp += 1
+    local_blank_r = sum_bp / count_bp if count_bp > 0 else blanking_level
+
+    shared_blank = (local_blank_f + local_blank_r) / 2.0
+    local_blank_f = shared_blank
+    local_blank_r = shared_blank
+
+    # 3. Build Phase & DC-Aligned Target
+    ideal = np.zeros(win_size, dtype=np.float64)
+    mid_sync = int(measured_center_fall + (measured_center_rise - measured_center_fall) / 2.0)
+    
+    for i in range(win_size):
+        t_fall = float(i) - measured_center_fall
+        t_rise = float(i) - measured_center_rise
+
+        if i <= mid_sync: # Falling half
+            if t_fall < -target_transition / 2.0:
+                ideal[i] = local_blank_f
+            elif t_fall <= target_transition / 2.0:
+                phase = (t_fall + target_transition / 2.0) / target_transition * np.pi
+                ideal[i] = local_blank_f + (local_sync - local_blank_f) * (1.0 - np.cos(phase)) / 2.0
+            else:
+                ideal[i] = local_sync
+        else:             # Rising half
+            if t_rise < -target_transition / 2.0:
+                ideal[i] = local_sync
+            elif t_rise <= target_transition / 2.0:
+                phase = (t_rise + target_transition / 2.0) / target_transition * np.pi
+                ideal[i] = local_sync + (local_blank_r - local_sync) * (1.0 - np.cos(phase)) / 2.0
+            else:
+                ideal[i] = local_blank_r
+
+    # 4. Split and Isolate Asymmetric Deficit Profiles
+    error = avg_pulse_shape - ideal
+    
+    error_fall = np.zeros(win_size, dtype=np.float64)
+    error_rise = np.zeros(win_size, dtype=np.float64)
+    
+    tail_len = 18.0
+    fade_len = 6.0
+    
+    for i in range(win_size):
+        dist_f = float(i) - measured_center_fall
+        if dist_f < -tail_len - fade_len: w_f = 0.0
+        elif dist_f < -tail_len: w_f = (dist_f + tail_len + fade_len) / fade_len
+        elif dist_f < tail_len: w_f = 1.0
+        elif dist_f < tail_len + fade_len: w_f = 1.0 - (dist_f - tail_len) / fade_len
+        else: w_f = 0.0
+        
+        error_fall[i] = error[i] * w_f
+        
+        dist_r = float(i) - measured_center_rise
+        if dist_r < -tail_len - fade_len: w_r = 0.0
+        elif dist_r < -tail_len: w_r = (dist_r + tail_len + fade_len) / fade_len
+        elif dist_r < tail_len: w_r = 1.0
+        elif dist_r < tail_len + fade_len: w_r = 1.0 - (dist_r - tail_len) / fade_len
+        else: w_r = 0.0
+        
+        error_rise[i] = error[i] * w_r
+
+    amp_fall = local_sync - local_blank_f
+    amp_rise = local_blank_r - local_sync
+    E_frac_fall = error_fall / (amp_fall if amp_fall != 0 else 1.0)
+    E_frac_rise = error_rise / (amp_rise if amp_rise != 0 else 1.0)
+
+    # Remove DC bias from the error fraction so correction doesn't shift baseline
+    E_frac_fall -= np.mean(E_frac_fall)
+    E_frac_rise -= np.mean(E_frac_rise)
+
+    # 5. Macro-State Tracker
+    smooth_len = int(max(4.0, target_transition * 2.5))
+    half_w = smooth_len // 2
+    sig_sm = np.empty(n_samples, dtype=np.float64)
+    
+    run_sum = 0.0
+    for i in range(smooth_len):
+        idx = max(0, min(n_samples - 1, i - half_w))
+        run_sum += tbc_video[idx]
+        
+    for i in range(n_samples):
+        sig_sm[i] = run_sum / smooth_len
+        sub_idx = max(0, i - half_w)
+        add_idx = min(n_samples - 1, i + half_w + 1)
+        run_sum += tbc_video[add_idx] - tbc_video[sub_idx]
+
+    state = np.zeros(n_samples, dtype=np.float64)
+    curr = 0.5
+    thresh = abs(amp_fall) * 0.03
+    for i in range(1, n_samples):
+        dx = sig_sm[i] - sig_sm[i-1]
+        if dx > thresh: curr = 1.0
+        elif dx < -thresh: curr = 0.0
+        state[i] = curr
+
+    state_sm = np.empty(n_samples, dtype=np.float64)
+    run_sum = 0.0
+    for i in range(smooth_len):
+        idx = max(0, min(n_samples - 1, i - half_w))
+        run_sum += state[idx]
+        
+    for i in range(n_samples):
+        state_sm[i] = run_sum / smooth_len
+        sub_idx = max(0, i - half_w)
+        add_idx = min(n_samples - 1, i + half_w + 1)
+        run_sum += state_sm[add_idx] - state_sm[sub_idx] if add_idx < n_samples else 0.0
+
+    # 6. Dual-Profile Linear Convolution
+    out = np.empty_like(tbc_video)
+    
+    for i in range(n_samples):
+        corr_fall = 0.0
+        corr_rise = 0.0
+        
+        for k in range(1, win_size):
+            tap_f = i + offset_fall - k
+            if 1 <= tap_f < n_samples:
+                dx = tbc_video[tap_f] - tbc_video[tap_f - 1]
+                corr_fall += dx * E_frac_fall[k]
+                
+        for k in range(1, win_size):
+            tap_r = i + offset_rise - k
+            if 1 <= tap_r < n_samples:
+                dx = tbc_video[tap_r] - tbc_video[tap_r - 1]
+                corr_rise += dx * E_frac_rise[k]
+                
+        w = state_sm[i]
+        correction = corr_rise * w + corr_fall * (1.0 - w)
+        out[i] = tbc_video[i] - (correction * gain_scale)
+        
+    return out
+
+
+
+def plot_tbc_correction_debug(
+    tbc_video,
+    line_start,
+    line_end,
+    line_length,
+    blanking_level,
+    sync_tip_level,
+    front_porch_len=15, 
+    sync_len=67,
+    back_porch_len=67,
+    gain_scale=1.0,
+    target_transition=3.3
+):
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("Matplotlib is required to render the debug plot.")
+        return
+
+    n_samples = len(tbc_video)
+    win_size = front_porch_len + sync_len + back_porch_len
+    offset_fall = front_porch_len
+    offset_rise = front_porch_len + sync_len
+
+    # 1. Extract Average Pulse Shape Internally
+    avg_pulse_shape = np.zeros(win_size, dtype=np.float64)
+    count = 0
+    for line in range(line_start, line_end + 1):
+        loc = line * line_length
+        if loc - offset_fall >= 0 and loc + sync_len + back_porch_len < n_samples:
+            avg_pulse_shape += tbc_video[loc - offset_fall : loc + sync_len + back_porch_len]
+            count += 1
+
+    if count > 0: avg_pulse_shape /= float(count)
+    else: return
+
+    # 2. Dynamic Subpixel Phase Alignment
+    mid_val = (blanking_level + sync_tip_level) / 2.0
+    
+    measured_center_fall = float(offset_fall)
+    for i in range(win_size - 1):
+        if avg_pulse_shape[i] >= mid_val >= avg_pulse_shape[i+1]:
+            y0 = avg_pulse_shape[i] - mid_val
+            y1 = avg_pulse_shape[i+1] - mid_val
+            if (y0 - y1) != 0.0:
+                measured_center_fall = float(i) + abs(y0) / abs(y0 - y1)
+            break
+
+    measured_center_rise = float(offset_rise)
+    search_start = int(measured_center_fall + (sync_len // 2))
+    for i in range(search_start, win_size - 1):
+        if avg_pulse_shape[i] <= mid_val <= avg_pulse_shape[i+1]:
+            y0 = avg_pulse_shape[i] - mid_val
+            y1 = avg_pulse_shape[i+1] - mid_val
+            if (y1 - y0) != 0.0:
+                measured_center_rise = float(i) + abs(y0) / abs(y1 - y0)
+            break
+
+    # 3. Measure Local Baseline Levels
+    sum_fp, count_fp = 0.0, 0
+    for i in range(0, max(1, int(measured_center_fall - 4))):
+        sum_fp += avg_pulse_shape[i]
+        count_fp += 1
+    local_blank_f = sum_fp / count_fp if count_fp > 0 else blanking_level
+    
+    sum_sync, count_sync = 0.0, 0
+    for i in range(int(measured_center_fall + 12), int(measured_center_rise - 12)):
+        sum_sync += avg_pulse_shape[i]
+        count_sync += 1
+    local_sync = sum_sync / count_sync if count_sync > 0 else sync_tip_level
+    
+    sum_bp, count_bp = 0.0, 0
+    for i in range(int(measured_center_rise + 4), win_size):
+        sum_bp += avg_pulse_shape[i]
+        count_bp += 1
+    local_blank_r = sum_bp / count_bp if count_bp > 0 else blanking_level
+
+    shared_blank = (local_blank_f + local_blank_r) / 2.0
+    local_blank_f = shared_blank
+    local_blank_r = shared_blank
+
+    # 4. Synthesize Phase & DC-Aligned Target
+    ideal = np.zeros(win_size, dtype=np.float64)
+    mid_sync = int(measured_center_fall + (measured_center_rise - measured_center_fall) / 2.0)
+
+    for i in range(win_size):
+        t_fall = float(i) - measured_center_fall
+        t_rise = float(i) - measured_center_rise
+        
+        if i <= mid_sync:
+            if t_fall < -target_transition / 2.0: 
+                ideal[i] = local_blank_f
+            elif t_fall <= target_transition / 2.0:
+                ideal[i] = local_blank_f + (local_sync - local_blank_f) * (1.0 - np.cos((t_fall + target_transition / 2.0) / target_transition * np.pi)) / 2.0
+            else: 
+                ideal[i] = local_sync
+        else:
+            if t_rise < -target_transition / 2.0: 
+                ideal[i] = local_sync
+            elif t_rise <= target_transition / 2.0:
+                ideal[i] = local_sync + (local_blank_r - local_sync) * (1.0 - np.cos((t_rise + target_transition / 2.0) / target_transition * np.pi)) / 2.0
+            else: 
+                ideal[i] = local_blank_r
+
+    # 5. Split Asymmetric Profiles
+    error = avg_pulse_shape - ideal
+    error_fall = np.zeros(win_size, dtype=np.float64)
+    error_rise = np.zeros(win_size, dtype=np.float64)
+    
+    tail_len = 18.0
+    fade_len = 6.0
+    
+    for i in range(win_size):
+        dist_f = float(i) - measured_center_fall
+        if dist_f < -tail_len - fade_len: w_f = 0.0
+        elif dist_f < -tail_len: w_f = (dist_f + tail_len + fade_len) / fade_len
+        elif dist_f < tail_len: w_f = 1.0
+        elif dist_f < tail_len + fade_len: w_f = 1.0 - (dist_f - tail_len) / fade_len
+        else: w_f = 0.0
+        error_fall[i] = error[i] * w_f
+        
+        dist_r = float(i) - measured_center_rise
+        if dist_r < -tail_len - fade_len: w_r = 0.0
+        elif dist_r < -tail_len: w_r = (dist_r + tail_len + fade_len) / fade_len
+        elif dist_r < tail_len: w_r = 1.0
+        elif dist_r < tail_len + fade_len: w_r = 1.0 - (dist_r - tail_len) / fade_len
+        else: w_r = 0.0
+        error_rise[i] = error[i] * w_r
+
+    amp_fall = local_sync - local_blank_f
+    amp_rise = local_blank_r - local_sync
+    E_frac_fall = error_fall / (amp_fall if amp_fall != 0 else 1.0)
+    E_frac_rise = error_rise / (amp_rise if amp_rise != 0 else 1.0)
+
+    # Remove DC bias from the error fraction so correction doesn't shift baseline
+    E_frac_fall -= np.mean(E_frac_fall)
+    E_frac_rise -= np.mean(E_frac_rise)
+
+    # 6. Simulate State-Blended Correction
+    corrected = np.empty_like(avg_pulse_shape)
+    pad_shape = np.pad(avg_pulse_shape, (win_size, win_size), mode='edge')
+
+    for i in range(win_size):
+        corr_fall = 0.0
+        corr_rise = 0.0
+        padded_i = i + win_size
+        
+        for k in range(1, win_size):
+            tap_f = padded_i + offset_fall - k
+            corr_fall += (pad_shape[tap_f] - pad_shape[tap_f - 1]) * E_frac_fall[k]
+            
+            tap_r = padded_i + offset_rise - k
+            corr_rise += (pad_shape[tap_r] - pad_shape[tap_r - 1]) * E_frac_rise[k]
+
+        w = 1.0 if i > mid_sync else 0.0
+        correction = corr_rise * w + corr_fall * (1.0 - w)
+        corrected[i] = pad_shape[padded_i] - (correction * gain_scale)
+
+    correction_applied = avg_pulse_shape - corrected
+
+    # 7. Render 3-Pane Plot
+    fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(14, 12), sharex=True)
+
+    ax1.plot(avg_pulse_shape, label='Before (Raw Avg Pulse)', color='#d62728', linewidth=1.8)
+    ax1.plot(corrected, label='After (Dual-FIR Corrected)', color='#1f77b4', linewidth=2.2)
+    ax1.plot(ideal, label=f'Local DC & Phase-Aligned Target Spec', color='#7f7f7f', linestyle=':', linewidth=2)
+    ax1.axhline(blanking_level, color='black', alpha=0.3, label='Global Blanking Ref')
+    ax1.axhline(sync_tip_level, color='black', alpha=0.3, label='Global Sync Ref')
+    ax1.set_title("4Fsc Localized Pulse Structure Comparison")
+    ax1.legend()
+    ax1.grid(True, alpha=0.4)
+
+    ax2.plot(E_frac_fall, label='Falling Deficit ($E_{fall}$)', color='purple', linewidth=1.5)
+    ax2.plot(E_frac_rise, label='Rising Deficit ($E_{rise}$)', color='orange', linewidth=1.5)
+    ax2.set_title("Split Filtering Models (DC Bias Eliminated)")
+    ax2.axhline(0, color='black', alpha=0.3)
+    ax2.legend()
+    ax2.grid(True, alpha=0.4)
+
+    ax3.plot(correction_applied, label='Correction Delta', color='green', linewidth=1.5)
+    ax3.fill_between(range(win_size), 0, correction_applied, color='green', alpha=0.2)
+    ax3.axhline(0, color='black', alpha=0.3)
+    ax3.set_title("Absolute Correction Amount (Transients Only)")
+    ax3.legend()
+    ax3.grid(True, alpha=0.4)
+
+    plt.tight_layout()
+    plt.show()

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -2,12 +2,14 @@ import numpy as np
 import numba as nb
 import scipy.fft
 
+from matplotlib.colors import LinearSegmentedColormap
+
 # -----------------------------------------------------------------------------
 # 1. NUMBA KERNEL: CAUSAL PHASE EQUALIZATION FIR
 # -----------------------------------------------------------------------------
 
 FIR_LEN = 63
-MIN_FFT_LEN = 2**9
+FFT_LEN = 2**9
 
 @nb.njit(cache=True, nogil=True, fastmath=True)
 def _apply_inverse_eq(picture, n_samples, causal_kernel):
@@ -30,62 +32,57 @@ def _apply_inverse_eq(picture, n_samples, causal_kernel):
 
     return out
 
-
-def _calc_phase_advance(S_xy, pad_len):
+def _calc_phase_advance(S_xy):
     """
-    Calculates the required group-delay advance (in fractional samples).
+    Calculates the exact group delay advance (in fractional samples).
     
-    scans the Weighted R^2 to safely find the maximum coherent bandwidth 
-    and establish phase-aligned ringing cancellation.
+    Optimized for maximum ringing cancellation:
+    Strictly bandpasses the spectrum to remove the massive low-frequency 
+    sync edge energy. It locates the high-frequency ringing resonance peak 
+    and fits the phase slope locally around that specific frequency.
     """
     phase = np.unwrap(np.angle(S_xy))
-    freqs = scipy.fft.fftfreq(pad_len)
-
-    # Skip the DC ledge to prevent early low-frequency lock
-    start_bin = max(2, int(pad_len * 0.02))
-    max_bins = max(start_bin + 5, int(pad_len * 0.35))
-
-    w_full = 2.0 * np.pi * freqs[start_bin:max_bins]
-    p_full = phase[start_bin:max_bins]
-    mag_full = np.abs(S_xy[start_bin:max_bins])
-
-    # High-Frequency Weighting: mag * w^2 targets the ringing resonance
-    weights_full = mag_full * (w_full ** 2)
-
-    best_end = len(w_full)
-    best_r2 = -np.inf
-    min_window = max(4, int(0.05 * len(w_full)))
+    freqs = scipy.fft.fftfreq(FFT_LEN)
     
-    # =========================================================================
-    # R^2 Boundary Detection & Bulk Slope
-    # =========================================================================
-    for end in range(min_window, len(w_full)):
-        w = w_full[:end]
-        p = p_full[:end]
-        wt = weights_full[:end]
-
-        wt_norm = wt / np.max(wt) if np.max(wt) > 0 else wt
-
-        slope, intercept = np.polyfit(w, p, 1, w=wt_norm)
-        fit = slope * w + intercept
-
-        p_mean = np.average(p, weights=wt_norm)
-        ss_res = np.sum(wt_norm * (p - fit) ** 2)
-        ss_tot = np.sum(wt_norm * (p - p_mean) ** 2)
+    # 1. Blind the algorithm to the massive sync edge energy
+    # by strictly hard-cutting the lower 5% of the spectrum.
+    start_bin = max(5, int(FFT_LEN * 0.05))
+    end_bin = int(FFT_LEN * 0.40)
+    
+    if start_bin >= end_bin:
+        return 0.0
         
-        r2 = 1.0 - (ss_res / ss_tot) if ss_tot > 1e-12 else 0.0
-
-        if r2 > best_r2:
-            best_r2 = r2
-            best_end = end
-
-    # Isolate the optimal coherent bandwidth
-    w_opt = w_full[:best_end]
-    p_opt = p_full[:best_end]
-    wt_opt = weights_full[:best_end]
+    w_high = 2.0 * np.pi * freqs[start_bin:end_bin]
+    p_high = phase[start_bin:end_bin]
+    mag_high = np.abs(S_xy[start_bin:end_bin])
     
-    # Calculate the rough bulk slope as our baseline
-    slope, _ = np.polyfit(w_opt, p_opt, 1, w=wt_opt)
+    # 2. Locate the ringing resonance peak
+    # Multiplying by w_high helps flatten out any residual 1/f sync leakage
+    resonance_profile = mag_high * w_high
+    peak_idx = np.argmax(resonance_profile)
+    
+    # 3. Create a narrow local window exclusively around the ringing peak
+    window_radius = max(3, int(FFT_LEN * 0.015))
+    local_start = max(0, peak_idx - window_radius)
+    local_end = min(len(w_high), peak_idx + window_radius + 1)
+    
+    w_local = w_high[local_start:local_end]
+    p_local = p_high[local_start:local_end]
+    weights_local = resonance_profile[local_start:local_end]
+    
+    # Normalize local weights for numerical stability in polyfit
+    w_max = np.max(weights_local)
+    if w_max > 0.0:
+        weights_local /= w_max
+        
+    # 4. Fit the phase slope strictly and locally at the ringing frequency
+    # Because group delay = -d(phase)/d(w), the slope of this local tangent 
+    # gives us the exact delay of the ringing artifact itself.
+    if len(w_local) > 1:
+        slope, _ = np.polyfit(w_local, p_local, 1, w=weights_local)
+    else:
+        slope = 0.0
+        
     return -slope
 
 
@@ -96,6 +93,10 @@ def _show_group_delay_debug(
     fir_kernel,
     calc_advance,
     line_indices,
+    pulse_ffts,
+    delta_ffts,
+    corrected_ffts,
+    FFT_LEN,
 ):
     try:
         import matplotlib.pyplot as plt
@@ -108,57 +109,139 @@ def _show_group_delay_debug(
     if n_lines == 0:
         return
 
-    fig = plt.figure(figsize=(15, 11))
+    # Expand figure layout to fit 6 subplots
+    fig = plt.figure(figsize=(16, 20))
     
-    ax1 = plt.subplot2grid((3, 2), (0, 0), colspan=2) 
-    ax2 = plt.subplot2grid((3, 2), (1, 0), colspan=1) 
-    ax3 = plt.subplot2grid((3, 2), (1, 1), colspan=1) 
-    ax_slider = plt.subplot2grid((3, 2), (2, 0), colspan=2) 
+    ax1 = plt.subplot2grid((6, 2), (0, 0), colspan=2) # Line Inspection
+    ax2 = plt.subplot2grid((6, 2), (1, 0), colspan=1) # All Lines Overlay
+    ax3 = plt.subplot2grid((6, 2), (1, 1), colspan=1) # Causal Kernel Taps
+    ax4 = plt.subplot2grid((6, 2), (2, 0), colspan=2) # Raw Pulse
+    ax5 = plt.subplot2grid((6, 2), (3, 0), colspan=2) # Delta
+    ax6 = plt.subplot2grid((6, 2), (4, 0), colspan=2) # Corrected Pulse
+    ax_slider = plt.subplot2grid((6, 2), (5, 0), colspan=2) # Slider
 
     initial_idx = 0
     line_num = line_indices[initial_idx]
     
     raw_line, = ax1.plot(raw_pulses[initial_idx], label=f'Raw Line {line_num}', color='#d62728', linewidth=1.8, alpha=0.85)
     corr_line, = ax1.plot(corrected_pulses[initial_idx], label=f'Equalized Line {line_num}', color='#1f77b4', linewidth=2.2)
-    ax1.plot(ideal, label='Target Reference (Phase-Aligned)', color='#7f7f7f', linestyle=':', linewidth=2)
+    ax1.plot(ideal, label='Target Reference', color='#7f7f7f', linestyle=':', linewidth=2)
     
-    ax1.set_title(f"Line Inspection [Line {line_num}] | Group Delay Advance: {calc_advance:.3f} samples", fontweight='bold')
+    ax1.set_title(f"Line Inspection [Line 1] | Group Delay Advance: {calc_advance:.3f} samples", fontweight='bold')
     ax1.legend(loc='upper right')
     ax1.grid(True, alpha=0.35)
-    ax1.set_ylabel("Normalized Amplitude")
+    ax1.set_ylabel("Amplitude")
 
     for p in raw_pulses:
         ax2.plot(p, color='#d62728', alpha=min(0.25, max(0.02, 5.0 / n_lines)), linewidth=0.8)
-    
     for p in corrected_pulses:
         ax2.plot(p, color='#1f77b4', alpha=min(0.25, max(0.02, 5.0 / n_lines)), linewidth=0.8)
 
-    ax2.plot(ideal, color='black', linestyle='--', linewidth=1.5, label='Target (Phase-Aligned)')
     ax2.set_title(f"All Lines Overlay ({n_lines} Lines)", fontweight='bold')
     ax2.grid(True, alpha=0.35)
-    ax2.set_ylabel("Normalized Amplitude")
-
-    from matplotlib.lines import Line2D
-    custom_lines = [
-        Line2D([0], [0], color='#d62728', lw=1.5, label='Raw Set'),
-        Line2D([0], [0], color='#1f77b4', lw=1.5, label='Corrected Set'),
-        Line2D([0], [0], color='black', lw=1.5, linestyle='--', label='Target')
-    ]
-    ax2.legend(handles=custom_lines, loc='upper right')
+    ax2.set_ylabel("Amplitude")
 
     x_axis = np.arange(len(fir_kernel))
     ax3.plot(x_axis, fir_kernel, label='Causal Taps (t >= 0)', color='purple', marker='.', linewidth=1.2)
-    ax3.set_title("Derived Causal Equalization Kernel", fontweight='bold')
+    ax3.set_title("Causal Equalization Kernel", fontweight='bold')
     ax3.axhline(0, color='black', alpha=0.3)
     ax3.set_xlim(0, len(fir_kernel) - 1)
     ax3.legend(loc='upper right')
     ax3.grid(True, alpha=0.35)
 
+    # =========================================================================
+    # Build FFTs
+    # =========================================================================
+    freqs = scipy.fft.fftfreq(FFT_LEN)
+    half_len = FFT_LEN // 2
+    pos_freqs = freqs[:half_len]
+
+    num_ffts = len(pulse_ffts)
+    min_line = line_indices[0] if line_indices else 0
+    max_line = line_indices[-1] if line_indices else num_ffts - 1
+    
+    pulse_spec_data = np.zeros((len(pulse_ffts), half_len + 1), dtype=np.float64)
+    delta_spec_data = np.zeros((len(delta_ffts), half_len + 1), dtype=np.float64)
+    corrected_spec_data = np.zeros((len(corrected_ffts), half_len + 1), dtype=np.float64)
+    for i in range(num_ffts):
+        if i < pulse_spec_data.shape[0]:
+            pulse_fft = pulse_ffts[i]
+            pulse_spec_data[i, :] = 20 * np.log10(np.maximum(np.abs(pulse_fft[:half_len + 1]), 1e-12))
+    
+        if i < delta_spec_data.shape[0]:
+            delta_fft = delta_ffts[i]
+            delta_spec_data[i, :] = 20 * np.log10(np.maximum(np.abs(delta_fft[:half_len + 1]), 1e-12))
+
+        if i < corrected_spec_data.shape[0]:
+            corrected_fft = corrected_ffts[i]
+            corrected_spec_data[i, :] = 20 * np.log10(np.maximum(np.abs(corrected_fft[:half_len + 1]), 1e-12))
+
+    # Custom Audacity-style multi-stop gradient: Black -> Deep Green -> Neon Green -> White
+    green = LinearSegmentedColormap.from_list(
+        "green", 
+        ["#00ff00", "#000000"]
+    )
+
+    # =========================================================================
+    # PULSE SPECTROGRAM
+    # =========================================================================
+    image = ax4.imshow(
+        pulse_spec_data,
+        aspect='auto',
+        origin='lower',
+        extent=[pos_freqs[0], pos_freqs[-1], min_line, max_line],
+        cmap=green
+    )
+    cbar = fig.colorbar(image, ax=ax4, pad=0)
+    cbar.set_label('Pulse (Raw)')
+
+    ax4.set_title("$Y_{raw}$", fontweight='bold')
+    ax4.set_xlabel("Normalized Frequency")
+    ax4.set_ylabel("Line Index")
+
+    # =========================================================================
+    # SUBTRACTION SPECTROGRAM
+    # =========================================================================
+    image = ax5.imshow(
+        delta_spec_data,
+        aspect='auto',
+        origin='lower',
+        extent=[pos_freqs[0], pos_freqs[-1], min_line, max_line],
+        cmap=green
+    )
+    cbar = fig.colorbar(image, ax=ax5, pad=0)
+    cbar.set_label('Delta')
+
+    ax5.set_title("$Y_{delta}$", fontweight='bold')
+    ax5.set_xlabel("Normalized Frequency")
+    ax5.set_ylabel("Line Index")
+
+    # =========================================================================
+    # CORRECTED SPECTROGRAM
+    # =========================================================================
+    image = ax6.imshow(
+        corrected_spec_data,
+        aspect='auto',
+        origin='lower',
+        extent=[pos_freqs[0], pos_freqs[-1], min_line, max_line],
+        cmap=green
+    )
+    cbar = fig.colorbar(image, ax=ax6, pad=0)
+    cbar.set_label('Pulse Corrected')
+
+    ax6.set_title("$Y_{delta} - Y_{raw}$", fontweight='bold')
+    ax6.set_xlabel("Normalized Frequency")
+    ax6.set_ylabel("Line Index")
+
+
+    # =========================================================================
+    # Slider
+    # =========================================================================
     slider = Slider(
         ax=ax_slider,
         label='Line Index ',
         valmin=0,
-        valmax=n_lines - 1,
+        valmax=max(0, n_lines - 1),
         valinit=0,
         valstep=1,
         color='#1f77b4'
@@ -276,7 +359,7 @@ def apply_inverse_equalization(
     back_porch_len,
     target_transition,
     group_delay_state,
-    noise_threshold=0.2,
+    noise_threshold=0.2, # TODO, determine automatically; set frequency scaling based on noise floor, or MAD between frequencies
     debug=False
 ):
     _normalize_inplace(video_buf, sync_tip_level, blanking_level)
@@ -287,14 +370,11 @@ def apply_inverse_equalization(
     win_size = pre_rise_samples + back_porch_len
     offset_rise = pre_rise_samples
     
-    min_required_len = max(2 * win_size - 1, MIN_FFT_LEN)
-    pad_len = scipy.fft.next_fast_len(min_required_len, real=False)
-    
-    S_xy = np.zeros(pad_len, dtype=np.complex128)
-    S_yy = np.zeros(pad_len, dtype=np.float64)
+    S_xy = np.zeros(FFT_LEN, dtype=np.complex128)
+    S_yy = np.zeros(FFT_LEN, dtype=np.float64)
     
     win = np.hanning(win_size)
-    start_idx = (pad_len - win_size) // 2
+    start_idx = (FFT_LEN - win_size) // 2
     count = 0
 
     # =========================================================================
@@ -342,8 +422,8 @@ def apply_inverse_equalization(
             d_ideal = np.gradient(ideal_for_fir) * win
             d_pulse = np.gradient(pulse) * win
             
-            pad_ideal = np.zeros(pad_len, dtype=np.float64)
-            pad_pulse = np.zeros(pad_len, dtype=np.float64)
+            pad_ideal = np.zeros(FFT_LEN, dtype=np.float64)
+            pad_pulse = np.zeros(FFT_LEN, dtype=np.float64)
             pad_ideal[start_idx : start_idx + win_size] = d_ideal
             pad_pulse[start_idx : start_idx + win_size] = d_pulse
             
@@ -363,8 +443,8 @@ def apply_inverse_equalization(
         _denormalize_inplace(video_buf, sync_tip_level, blanking_level)
         return video_buf
 
-    rolling_S_xy = np.zeros(pad_len, dtype=np.complex128)
-    rolling_S_yy = np.zeros(pad_len, dtype=np.float64)
+    rolling_S_xy = np.zeros(FFT_LEN, dtype=np.complex128)
+    rolling_S_yy = np.zeros(FFT_LEN, dtype=np.float64)
 
     for measurement in group_delay_state:
         rolling_S_xy += measurement['s_xy']
@@ -374,7 +454,7 @@ def apply_inverse_equalization(
     # PART 2: Analytical Advance & Deconvolution
     # =========================================================================
     # Dynamically extract the optimal floating-point advance from phase slope
-    advance_float = _calc_phase_advance(rolling_S_xy, pad_len)
+    advance_float = _calc_phase_advance(rolling_S_xy)
     
     # Split into integer video shift and fractional kernel phase-shift
     int_adv = int(np.round(advance_float))
@@ -387,17 +467,16 @@ def apply_inverse_equalization(
 
     # Apply ONLY the fractional sub-sample advance to the kernel in frequency domain.
     # This securely modifies the filter shape without needing to FFT the whole video buffer.
-    w_full = 2.0 * np.pi * scipy.fft.fftfreq(pad_len)
+    w_full = 2.0 * np.pi * scipy.fft.fftfreq(FFT_LEN)
     H_inv = H_inv * np.exp(-1j * w_full * frac_adv)
 
     # IFFT back to time domain
     h_full = scipy.fft.fftshift(scipy.fft.ifft(H_inv).real)
     
-    # NATIVE PHASE FIX:
     # The Wiener deconvolution naturally places the main impulse offset by int_adv.
     # By shifting our extraction center to match this offset, we extract the causal tail 
     # perfectly aligned.
-    true_center = pad_len // 2 - int_adv
+    true_center = FFT_LEN // 2 - int_adv
     
     # Isolate causal tail taps for t >= 1
     fir_tail = h_full[true_center + 1:].copy()
@@ -414,8 +493,7 @@ def apply_inverse_equalization(
     fade_axis = np.arange(fade_len, dtype=np.float64)
     fir_kernel[FIR_LEN - fade_len:] *= 0.5 * (1.0 + np.cos(np.pi * fade_axis / fade_len))
 
-    # 3. Base DC Normalization: Enforce DC Unity strictly on the center tap (t=0)
-    # MUST sum the faded kernel itself, not the raw infinite tail
+    # Base DC Normalization: Enforce DC Unity strictly on the center tap (t=0)
     fir_kernel[0] = 1.0 - np.sum(fir_kernel[1:])
 
     if debug:
@@ -423,6 +501,9 @@ def apply_inverse_equalization(
         raw_pulses = []
         corrected_pulses = []
         line_indices = []
+        pulse_ffts = []
+        delta_ffts = []
+        corrected_ffts = []
 
         for line in range(line_start, line_end + 1):
             start_loc = line * line_length - front_porch_len
@@ -434,15 +515,10 @@ def apply_inverse_equalization(
                 corrected_pulses.append(corr_p)
                 line_indices.append(line)
 
-    # =========================================================================
-    # PART 3: Apply Strictly Causal Equalization
-    # =========================================================================
-    video_buf = _apply_inverse_eq(video_buf, n_samples, fir_kernel)
-
-    if debug and len(raw_pulses) > 0:
         all_corr_arr = np.array(corrected_pulses)
         sync_tip_average, blanking_average = _get_levels(all_corr_arr.flatten())
 
+        # build ideal pulse
         ideal_debug = _build_ideal_hsync_pulse(
             front_porch_len,
             sync_len,
@@ -452,7 +528,28 @@ def apply_inverse_equalization(
             full_win_size,
             phase_delay=-(advance_float+int_adv),
         )
-        
+        ideal_fft = _build_ideal_hsync_pulse(
+            front_porch_len,
+            sync_len,
+            target_transition,
+            sync_tip_average,
+            blanking_average,
+            FFT_LEN,
+            phase_delay=-(advance_float+int_adv),
+        )
+        y_ideal = scipy.fft.fft(ideal_fft, n=FFT_LEN)
+
+        # get ffts of all the pulses before, after, amount of change all subtracted from the ideal pulse
+        for i in range(len(raw_pulses)):
+            # Capture FFT of raw and corrected pulses
+            y_raw = scipy.fft.fft(raw_pulses[i], n=FFT_LEN)
+            y_corr = scipy.fft.fft(corrected_pulses[i], n=FFT_LEN)
+            y_delta = (y_corr - y_raw)
+    
+            pulse_ffts.append(y_raw - y_ideal)
+            delta_ffts.append(y_ideal - y_delta)
+            corrected_ffts.append(y_corr - y_ideal)
+                    
         _show_group_delay_debug(
             raw_pulses,
             corrected_pulses,
@@ -460,7 +557,16 @@ def apply_inverse_equalization(
             fir_kernel,
             advance_float,
             line_indices,
+            pulse_ffts,
+            delta_ffts,
+            corrected_ffts,
+            FFT_LEN,
         )
+
+    # =========================================================================
+    # PART 3: Apply Strictly Causal Equalization
+    # =========================================================================
+    video_buf = _apply_inverse_eq(video_buf, n_samples, fir_kernel)
 
     _denormalize_inplace(video_buf, sync_tip_level, blanking_level)
 

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -1,169 +1,44 @@
 import numpy as np
 import numba as nb
-from scipy.optimize import curve_fit
+import scipy.signal
 
 # -----------------------------------------------------------------------------
-# 1. PHYSICAL DE-EMPHASIS TRANSIENT MODEL (LEAST SQUARES)
+# 1. NUMBA KERNEL: STRICTLY CAUSAL PHASE EQUALIZATION FIR
 # -----------------------------------------------------------------------------
-def vhs_deemphasis_transient_model(
-    t,
-    gain,
-    curvature,
-    A_rc,
-    alpha_rc,
-    A_dl,
-    alpha_dl,
-    time_offset,
-):
-    """
-    VHS de-emphasis ringing residual model.
-
-    The full physical model is:
-        nonlinear edge response
-      + RC settling
-      + delayed limiter ringing
-
-    For correction purposes we only return the residual error
-    relative to the monotonic edge response. This prevents the
-    correction from reshaping the actual transition.
-
-    Returns:
-        ringing residual only
-    """
-
-    tp = np.maximum(0.0, t + time_offset)
-
-    # JVC nonlinear edge response (desired signal component)
-    nonlinear = gain * np.tanh(curvature * tp)
-
-    # First-order RC settling (desired edge response component)
-    pre_emphasis = A_rc * np.exp(-alpha_rc * tp)
-
-    # Double limiter LPF phase/ringing component (undesired)
-    dl_lpf_effect = -A_dl * tp * np.exp(-alpha_dl * tp)
-
-    # Full modeled transient
-    full_transient = (
-        nonlinear
-        + pre_emphasis
-        + dl_lpf_effect
-    )
-
-    # Remove monotonic edge response.
-    # What remains is the ringing/distortion component only.
-    baseline = nonlinear + pre_emphasis
-
-    ringing_error = full_transient - baseline
-
-    # Force zero before transition
-    ringing_error[(t + time_offset) <= 0] = 0.0
-
-    return ringing_error
-
-
 @nb.njit(cache=True, nogil=True, fastmath=True)
-def _apply_vhs_deemphasis_model(
+def _apply_global_inverse_eq(
     tbc_video,
-    gain_scale,
-    gain,
-    curvature,
-    A_rc,
-    alpha_rc,
-    A_dl,
-    alpha_dl,
-    time_offset,
-    edge_delay,
+    n_samples,
+    fir_kernel
 ):
-    n_samples = len(tbc_video)
     out = np.empty_like(tbc_video)
-
-    last_edge = -100000.0
-    edge_type = 0
-
-    mid_level = -20.0
-
-    prev = tbc_video[0]
-    out[0] = prev
-
-
-    for i in range(1, n_samples):
-
-        v = tbc_video[i]
-
-        # ---------------------------------------------------------
-        # Same edge detector as debug pulse extraction
-        # ---------------------------------------------------------
-
-        if prev >= mid_level and v < mid_level:
-
-            frac = (prev - mid_level) / max(prev - v, 1e-12)
-
-            last_edge = (i - 1) + frac
-            edge_type = -1
-
-        elif prev <= mid_level and v > mid_level:
-
-            frac = (mid_level - prev) / max(v - prev, 1e-12)
-
-            last_edge = (i - 1) + frac
-            edge_type = 1
-
-        prev = v
-        correction = 0.0
-
-        if last_edge > -99999.0:
-
-            t = i - last_edge - edge_delay
-            tp = t + time_offset
-
-            if tp > 0.0:
-                nonlinear = (
-                    gain *
-                    np.tanh(curvature * tp)
-                )
-
-                rc = (
-                    A_rc *
-                    np.exp(-alpha_rc * tp)
-                )
-
-                dl = (
-                    -A_dl *
-                    tp *
-                    np.exp(-alpha_dl * tp)
-                )
-
-                ringing = nonlinear + rc + dl
-                baseline = nonlinear + rc
-                residual = ringing - baseline
-
-
-                if edge_type < 0:
-                    correction = residual
-
+    k_len = len(fir_kernel)
+    half_k = k_len // 2
+    
+    for i in range(n_samples):
+        val = 0.0
+        for j in range(k_len):
+            idx = i + half_k - j
+            if 0 <= idx < n_samples:
+                val += tbc_video[idx] * fir_kernel[j]
+            else:
+                if idx < 0:
+                    val += tbc_video[0] * fir_kernel[j]
                 else:
-                    correction = -residual
-
-
-
-        out[i] = v - gain_scale * correction
-
-
+                    val += tbc_video[n_samples - 1] * fir_kernel[j]
+        out[i] = val
+        
     return out
 
 
 # -----------------------------------------------------------------------------
-# 3. DEBUG PLOT RENDERER
+# 2. DEBUG PLOT RENDERER
 # -----------------------------------------------------------------------------
 def _render_debug_plot(
     avg_pulse_shape,
     corrected_pulse,
     ideal,
-    E_frac_fall,
-    E_frac_rise,
-    correction_applied,
-    blanking_level,
-    sync_tip_level,
+    fir_kernel,
     target_transition
 ):
     try:
@@ -172,34 +47,24 @@ def _render_debug_plot(
         print("Matplotlib is required to render the debug plot.")
         return
 
-    win_size = len(avg_pulse_shape)
-    fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(14, 12), sharex=True)
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(14, 10), sharex=False)
 
-    # Top Pane: Before vs. After vs. Fitted Target
     ax1.plot(avg_pulse_shape, label='Before (Raw Avg Pulse)', color='#d62728', linewidth=1.8)
-    ax1.plot(corrected_pulse, label='After (Fitted VHS De-emphasis Correction)', color='#1f77b4', linewidth=2.2)
+    ax1.plot(corrected_pulse, label='After (Causal Group Delay Equalization)', color='#1f77b4', linewidth=2.2)
     ax1.plot(ideal, label=f'Target Spec Step (Trans: {target_transition})', color='#7f7f7f', linestyle=':', linewidth=2)
-    ax1.axhline(blanking_level, color='black', alpha=0.3, label='Global Blanking Ref')
-    ax1.axhline(sync_tip_level, color='black', alpha=0.3, label='Global Sync Ref')
-    ax1.set_title("VHS Pulse Structure Comparison: Before vs. After")
+    ax1.set_title("System Identification: Strictly Causal Group Delay Equalization")
     ax1.legend()
     ax1.grid(True, alpha=0.4)
 
-    # Middle Pane: Fitted Error Fractional Profiles
-    ax2.plot(E_frac_fall, label='Averaged Fit Fall ($E_{avg}$)', color='purple', linewidth=1.5)
-    ax2.plot(E_frac_rise, label='Averaged Fit Rise ($E_{avg}$)', color='red', linewidth=1.5)
-    ax2.set_title("Least-Squares De-Emphasis Models (DC Offset Removed)")
+    center = len(fir_kernel) // 2
+    x_axis = np.arange(-center, center + 1)
+    
+    ax2.plot(x_axis, fir_kernel, label='Causal FIR Taps (t >= 0)', color='purple', marker='.', linewidth=1.5)
+    ax2.set_title("Derived Causal Group-Delay Kernel (Zero Pre-Shoot)")
     ax2.axhline(0, color='black', alpha=0.3)
+    ax2.set_xlim(-40, 40)
     ax2.legend()
     ax2.grid(True, alpha=0.4)
-
-    # Bottom Pane: Absolute Correction Amount
-    ax3.plot(correction_applied, label='Correction Delta', color='green', linewidth=1.5)
-    ax3.fill_between(range(win_size), 0, correction_applied, color='green', alpha=0.2)
-    ax3.axhline(0, color='black', alpha=0.3)
-    ax3.set_title("Absolute Correction Amount Applied Across Interval")
-    ax3.legend()
-    ax3.grid(True, alpha=0.4)
 
     plt.tight_layout()
     plt.show()
@@ -240,282 +105,177 @@ def build_ideal_step(
     return ideal
 
 
-
 # -----------------------------------------------------------------------------
-# 4. MAIN CORRECTION FUNCTION
+# 3. MAIN CORRECTION FUNCTION
 # -----------------------------------------------------------------------------
 def apply_tbc_vhs_deemphasis_correction(
     video_buf, 
     line_start, 
     line_end, 
     line_length, 
-    blanking_level, 
-    sync_tip_level, 
+    blanking_level_in, 
+    sync_tip_level_in, 
     front_porch_len=15, 
     sync_len=67,         
     back_porch_len=67,   
-    gain_scale=0.15,
     target_transition=3.3,
+    noise_threshold=0.01,
+    fir_length=129,
     debug=False
 ):
-    video_buf = ((video_buf - sync_tip_level) / (blanking_level - sync_tip_level)) * 40 - 40
+    blanking_level = 0.0
+    sync_tip_level = -40.0
     
     n_samples = len(video_buf)
     win_size = front_porch_len + sync_len + back_porch_len
     offset_fall = front_porch_len
     offset_rise = front_porch_len + sync_len
-
-    # --- Step 1: Extract Average Pulse Shape ---
-    avg_pulse_shape = np.zeros(win_size, dtype=np.float64)
-    count = 0
-    
-    for line in range(line_start, line_end + 1):
-        loc = line * line_length
-        # Safely extract window around sample 0 of the current line
-        if loc - offset_fall >= 0 and loc + sync_len + back_porch_len < n_samples:
-            avg_pulse_shape += video_buf[loc - offset_fall : loc + sync_len + back_porch_len]
-            count += 1
-
-    if count > 0:
-        avg_pulse_shape /= float(count)
-    else:
-        if debug:
-            print(f"DEBUG: 0 lines matched bounds! Check line_start ({line_start}), line_end ({line_end}), line_length ({line_length}), total samples ({n_samples}).")
-        return video_buf.copy()
-
-    # --- Step 2: Subpixel Phase Alignment ---
     mid_val = (blanking_level + sync_tip_level) / 2.0
     
-    measured_center_fall = float(offset_fall)
-    for i in range(win_size - 1):
-        if avg_pulse_shape[i] >= mid_val >= avg_pulse_shape[i+1]:
-            y0 = avg_pulse_shape[i] - mid_val
-            y1 = avg_pulse_shape[i+1] - mid_val
-            if (y0 - y1) != 0.0:
-                measured_center_fall = float(i) + abs(y0) / abs(y0 - y1)
-            break
-
-    measured_center_rise = float(offset_rise)
-    search_start = int(measured_center_fall + (sync_len // 2))
-    for i in range(search_start, win_size - 1):
-        if avg_pulse_shape[i] <= mid_val <= avg_pulse_shape[i+1]:
-            y0 = avg_pulse_shape[i] - mid_val
-            y1 = avg_pulse_shape[i+1] - mid_val
-            if (y1 - y0) != 0.0:
-                measured_center_rise = float(i) + abs(y0) / abs(y1 - y0)
-            break
-
-    # --- Step 3: Local Baseline Extraction (Shared Porch DC Offset) ---
-    sum_fp, count_fp = 0.0, 0
-    for i in range(0, max(1, int(measured_center_fall - 4))):
-        sum_fp += avg_pulse_shape[i]
-        count_fp += 1
-    local_blank_f = sum_fp / count_fp if count_fp > 0 else blanking_level
+    pad_len = 2048 
+    S_xy = np.zeros(pad_len, dtype=np.complex128)
+    S_yy = np.zeros(pad_len, dtype=np.float64)
     
-    sum_sync, count_sync = 0.0, 0
-    for i in range(int(measured_center_fall + 12), int(measured_center_rise - 12)):
-        sum_sync += avg_pulse_shape[i]
-        count_sync += 1
-    local_sync = sum_sync / count_sync if count_sync > 0 else sync_tip_level
+    win = np.hanning(win_size)
+    start_idx = (pad_len - win_size) // 2
+    count = 0
     
-    sum_bp, count_bp = 0.0, 0
-    for i in range(int(measured_center_rise + 4), win_size):
-        sum_bp += avg_pulse_shape[i]
-        count_bp += 1
-    local_blank_r = sum_bp / count_bp if count_bp > 0 else blanking_level
+    avg_pulse_shape = np.zeros(win_size, dtype=np.float64)
 
-    # Enforce identical DC level across front and back porches
-    shared_blank = (local_blank_f + local_blank_r) / 2.0
-    local_blank_f = shared_blank
-    local_blank_r = shared_blank
+    # --- Step 1: Accumulate Cross-Spectral Density ---
+    for line in range(line_start, line_end + 1):
+        loc = line * line_length
+        if loc - offset_fall >= 0 and loc + sync_len + back_porch_len < n_samples:
+            
+            pulse = video_buf[loc - offset_fall : loc + sync_len + back_porch_len]
+            avg_pulse_shape += pulse
+            count += 1
+            
+            measured_center_fall = float(offset_fall)
+            for i in range(win_size - 1):
+                if pulse[i] >= mid_val >= pulse[i+1]:
+                    y0 = pulse[i] - mid_val
+                    y1 = pulse[i+1] - mid_val
+                    if (y0 - y1) != 0.0:
+                        measured_center_fall = float(i) + abs(y0) / abs(y0 - y1)
+                    break
 
-    ideal = build_ideal_step(
-        measured_center_fall,
-        measured_center_rise,
-        target_transition,
-        local_blank_f,
-        local_sync,
-        local_blank_r,
-        win_size,
-    )
-    mid_sync = int(measured_center_fall + (measured_center_rise - measured_center_fall) / 2.0)
+            measured_center_rise = float(offset_rise)
+            search_start = int(measured_center_fall + (sync_len // 2))
+            for i in range(search_start, win_size - 1):
+                if pulse[i] <= mid_val <= pulse[i+1]:
+                    y0 = pulse[i] - mid_val
+                    y1 = pulse[i+1] - mid_val
+                    if (y1 - y0) != 0.0:
+                        measured_center_rise = float(i) + abs(y0) / abs(y1 - y0)
+                    break
+                    
+            sum_fp, count_fp = 0.0, 0
+            for i in range(0, max(1, int(measured_center_fall - 4))):
+                sum_fp += pulse[i]
+                count_fp += 1
+            local_blank_f = sum_fp / count_fp if count_fp > 0 else blanking_level
+            
+            sum_sync, count_sync = 0.0, 0
+            for i in range(int(measured_center_fall + 12), int(measured_center_rise - 12)):
+                sum_sync += pulse[i]
+                count_sync += 1
+            local_sync = sum_sync / count_sync if count_sync > 0 else sync_tip_level
+            
+            sum_bp, count_bp = 0.0, 0
+            for i in range(int(measured_center_rise + 4), win_size):
+                sum_bp += pulse[i]
+                count_bp += 1
+            local_blank_r = sum_bp / count_bp if count_bp > 0 else blanking_level
 
-    # --- Step 5: Least-Squares Model Fitting of De-Emphasis Response ---
-
-    x = np.arange(win_size, dtype=np.float64)
-
-    def residual_model_combined(
-        x,
-        gain,
-        curvature,
-        A_rc,
-        alpha_rc,
-        A_dl,
-        alpha_dl,
-        time_offset,
-        transition,
-    ):
-        out = np.zeros_like(x)
-
-        fall_mask = x < win_size
-        rise_mask = x >= win_size
-
-        if np.any(fall_mask):
-            xf = x[fall_mask]
-
-            out[fall_mask] = vhs_deemphasis_transient_model(
-                xf - measured_center_fall,
-                gain,
-                curvature,
-                A_rc,
-                alpha_rc,
-                A_dl,
-                alpha_dl,
-                time_offset,
+            shared_blank = (local_blank_f + local_blank_r) / 2.0
+            
+            ideal_for_fir = build_ideal_step(
+                measured_center_fall, measured_center_rise, target_transition,
+                shared_blank, local_sync, shared_blank, win_size
             )
 
-        if np.any(rise_mask):
-            xr = x[rise_mask] - win_size
+            d_ideal = np.gradient(ideal_for_fir) * win
+            d_pulse = np.gradient(pulse) * win
+            
+            pad_ideal = np.zeros(pad_len, dtype=np.float64)
+            pad_pulse = np.zeros(pad_len, dtype=np.float64)
+            pad_ideal[start_idx : start_idx + win_size] = d_ideal
+            pad_pulse[start_idx : start_idx + win_size] = d_pulse
+            
+            X = np.fft.fft(pad_ideal)
+            Y = np.fft.fft(pad_pulse)
+            
+            S_xy += X * np.conj(Y)
+            S_yy += np.abs(Y)**2
 
-            out[rise_mask] = vhs_deemphasis_transient_model(
-                xr - measured_center_rise,
-                gain,
-                curvature,
-                A_rc,
-                alpha_rc,
-                A_dl,
-                alpha_dl,
-                time_offset,
-            )
-
-        return out
-
-    # Regions to fit
-    t_vec_fall = x - measured_center_fall
-    mask_fall = (t_vec_fall >= -4.0) & (t_vec_fall <= 24.0)
-
-    t_vec_rise = x - measured_center_rise
-    mask_rise = (t_vec_rise >= -4.0) & (t_vec_rise <= 24.0)
+    if count == 0:
+        return video_buf
+        
+    avg_pulse_shape /= float(count)
     
-    amp_est = abs(local_sync - local_blank_f)
+    # --- Step 2: Inverse Deconvolution Model ---
+    reg = np.max(S_yy) * noise_threshold 
+    denom = S_yy + reg
+    denom[denom == 0] = 1e-12
+    
+    H_inv = S_xy / denom
 
-    # Initial guesses utilizing the Double Limiter LPF injection
-    p0 = [
-        0.0,               # gain
-        0.35,              # curvature
-        amp_est * 0.4,     # A_rc (RC decay amplitude)
-        0.8,               # alpha_rc (RC decay rate)
-        amp_est * 0.2,     # A_dl (Double Limiter LPF amplitude)
-        0.3,               # alpha_dl (Double Limiter LPF decay rate)
-        0.0,               # time_offset
-        target_transition,
-    ]
+    # --- Step 3: Extract Time-Domain Kernel and Enforce Strict Causality ---
+    h_full = np.fft.fftshift(np.fft.ifft(H_inv).real)
+    center_full = pad_len // 2
 
-    bounds = (
-        [
-            0.0,    # gain
-            0.01,   # curvature
-            0.0,    # A_rc
-            0.1,    # alpha_rc
-            0.0,    # A_dl
-            0.05,   # alpha_dl
-            -12.0,  # time_offset
-            1.0,    # transition
-        ],
-        [
-            50.0,   # gain
-            5.0,    # curvature
-            50.0,   # A_rc
-            5.0,    # alpha_rc
-            50.0,   # A_dl
-            0.5,    # alpha_dl
-            12.0,    # time_offset
-            25.0,   # transition
-        ],
+    if fir_length % 2 == 0:
+        fir_length += 1
+        
+    half_fir = fir_length // 2
+    
+    # Align $t=0$ precisely to index `half_fir`
+    peak_idx = np.argmax(np.abs(h_full))
+    h_full = np.roll(h_full, center_full - peak_idx)
+    
+    fir_kernel = h_full[center_full - half_fir : center_full + half_fir + 1].copy()
+
+    # 1. Zero out negative time (t < 0) to strictly enforce causality.
+    # This completely eliminates pre-shoot and future-looking phase errors.
+    fir_kernel[:half_fir] = 0.0
+
+    # 2. Smooth the causal forward-time tail (t >= 0) to prevent truncation ripples.
+    causal_len = len(fir_kernel) - half_fir
+    causal_window = np.hanning(2 * causal_len - 1)[causal_len - 1:]
+    fir_kernel[half_fir:] *= causal_window
+
+    # 3. Enforce strict DC unity gain (DC = 1.0)
+    fir_sum = np.sum(fir_kernel)
+    if fir_sum != 0.0:
+        fir_kernel /= fir_sum
+
+    # --- Step 4: Apply Strictly Causal Equalization ---
+    video_buf = _apply_global_inverse_eq(
+        video_buf,
+        n_samples,
+        fir_kernel
     )
-
-    fit_x = np.concatenate((x[mask_fall], x[mask_rise] + win_size))
-
-    residual = avg_pulse_shape - ideal
-    fit_y = np.concatenate((
-        residual[mask_fall],
-        -residual[mask_rise],
-    ))
-
-    try:
-        popt, _ = curve_fit(
-            residual_model_combined,
-            fit_x,
-            fit_y,
-            p0=p0,
-            bounds=bounds,
-            maxfev=10000,
-        )
-
-        gain, curvature, A_rc, alpha_rc, A_dl, alpha_dl, time_offset, transition = popt
-        edge_delay = -transition
-
-    except Exception as e:
-        print("combined fit failed:", e)
-
 
     if debug:
-        corrected_pulse = avg_pulse_shape.copy()
-
-        fall = vhs_deemphasis_transient_model(
-            t_vec_fall,
-            gain,
-            curvature,
-            A_rc,
-            alpha_rc,
-            A_dl,
-            alpha_dl,
-            time_offset,
+        corrected_pulse = _apply_global_inverse_eq(
+            avg_pulse_shape,
+            win_size,
+            fir_kernel
         )
-
-        rise = vhs_deemphasis_transient_model(
-            t_vec_rise,
-            gain,
-            curvature,
-            A_rc,
-            alpha_rc,
-            A_dl,
-            alpha_dl,
-            time_offset,
+        
+        shared_blank = (blanking_level + blanking_level) / 2.0
+        ideal_debug = build_ideal_step(
+            offset_fall, offset_rise, target_transition,
+            shared_blank, sync_tip_level, shared_blank, win_size
         )
-
-        for i in range(win_size):
-            if i <= mid_sync:
-                corrected_pulse[i] -= fall[i]
-            else:
-                corrected_pulse[i] += rise[i]
-
-        correction_applied = corrected_pulse - avg_pulse_shape
-
+        
         _render_debug_plot(
             avg_pulse_shape,
             corrected_pulse,
-            ideal,
-            fall,
-            rise,
-            correction_applied,
-            0,
-            -40,
+            ideal_debug,
+            fir_kernel,
             target_transition
         )
 
-    video_buf = _apply_vhs_deemphasis_model(
-        video_buf,
-        gain_scale,
-        gain,
-        curvature,
-        A_rc,
-        alpha_rc,
-        A_dl,
-        alpha_dl,
-        time_offset,
-        edge_delay
-    )
-
-    # denomalized data # TODO, run this after the data is already denomalized
-    return ((video_buf + 40) / 40) * (blanking_level - sync_tip_level) + sync_tip_level
+    return video_buf

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -35,7 +35,6 @@ def _make_interpolated_inverse_eq(fir_len, delay_offset):
         h_interp = np.empty(fir_len, dtype=np.float32)
 
         for k in range(n_samples):
-            # 1. Calculate linear interpolation factor alpha along the line (0.0 to 1.0)
             alpha = np.float32(k) / np.float32(n_samples - 1) if n_samples > 1 else np.float32(0.0)
             one_minus_alpha = np.float32(1.0) - alpha
 
@@ -50,7 +49,6 @@ def _make_interpolated_inverse_eq(fir_len, delay_offset):
             for j in range(fir_len):
                 idx = read_head - j
                 
-                # Boundary clamping
                 if idx < 0:
                     val = first
                 elif idx >= n_samples:
@@ -303,7 +301,7 @@ def apply_inverse_equalization(
         noise_mag_profile = np.zeros(FFT_LEN, dtype=np.float64)
 
     # =========================================================================
-    # PARTS 1, 2, 3: Per-Line Wiener Deconvolution with 1000-Pulse Ring Buffer
+    # PARTS 1 & 2: Pass 1 - Line Measurement & 1000-Pulse Ring Buffer Validation
     # =========================================================================
     MAX_HISTORY_PULSES = 1000
 
@@ -332,23 +330,20 @@ def apply_inverse_equalization(
     freqs = np.abs(np.fft.fftfreq(FFT_LEN))
     hf_mask = freqs > 0.35  
 
-    count = 0
     raw_line_spectra = []
     raw_line_rises = []
     
-    default_kernel = np.zeros(FIR_LEN, dtype=np.float32)
-    default_kernel[DELAY_OFFSET] = 1.0
-    last_valid_kernel = default_kernel
     last_valid_h_inv = np.ones(FFT_LEN, dtype=np.complex128)
+    last_valid_rise = float(offset_rise)
 
     for line in range(line_start, line_end + 1):
         loc = line * line_length
         start_loc = loc + sync_len - pre_rise_samples
         
-        S_xy = np.zeros(FFT_LEN, dtype=np.complex128)
-        S_yy = np.zeros(FFT_LEN, dtype=np.float64)
         measured_center_rise = float(offset_rise)
         is_outlier = False
+        current_s_xy = np.zeros(FFT_LEN, dtype=np.complex128)
+        current_s_yy = np.zeros(FFT_LEN, dtype=np.float64)
 
         if start_loc >= 0 and start_loc + win_size < n_samples:
             pulse = video_buf[start_loc : start_loc + win_size]
@@ -409,8 +404,8 @@ def apply_inverse_equalization(
             current_s_xy = X * np.conj(Y)
             current_s_yy = np.abs(Y)**2
 
-            # --- 1000-PULSE RING BUFFER OUTLIER REJECTION ---
-            if state_dict['count'] > (525 / 2): # roughly a field's work of lines in order to honor the rolling average
+            # Ring buffer outlier check against the 1000-pulse history
+            if state_dict['count'] > 10:
                 historical_mean_s_yy = np.mean(state_dict['s_yy_history'][:state_dict['count']], axis=0)
                 spectral_distance = np.mean(np.abs(current_s_yy - historical_mean_s_yy))
                 avg_power_magnitude = np.mean(historical_mean_s_yy) + 1e-12
@@ -425,16 +420,15 @@ def apply_inverse_equalization(
                 state_dict['s_yy_history'][ptr] = current_s_yy
                 state_dict['ptr'] = (ptr + 1) % MAX_HISTORY_PULSES
                 state_dict['count'] = min(MAX_HISTORY_PULSES, state_dict['count'] + 1)
-                count += 1
         else:
             is_outlier = True
 
         if is_outlier:
             raw_line_spectra.append(last_valid_h_inv)
-            raw_line_rises.append(measured_center_rise)
+            raw_line_rises.append(last_valid_rise)
             continue
 
-        # Compute averaged spectra over the entire 1000-pulse training set history
+        # Compute Wiener Deconvolution using historical sample average
         valid_count = state_dict['count']
         accum_s_xy = np.mean(state_dict['s_xy_history'][:valid_count], axis=0)
         accum_s_yy = np.mean(state_dict['s_yy_history'][:valid_count], axis=0)
@@ -460,20 +454,23 @@ def apply_inverse_equalization(
 
         raw_line_spectra.append(H_total)
         raw_line_rises.append(measured_center_rise)
+        
         last_valid_h_inv = H_total
+        last_valid_rise = measured_center_rise
 
-    if count == 0 and state_dict['count'] == 0:
+    if state_dict['count'] == 0:
         _denormalize_inplace(video_buf, sync_tip_level, blanking_level)
         return video_buf, {'gain': 0.0, 'threshold': 0.1, 'blur_radius': 0.0}
 
     # =========================================================================
-    # FIELD-WIDE STATISTICAL AVERAGING (For disabled interpolation toggles)
+    # PART 3: Field-Wide Statistical Averaging & Parameter Toggles
     # =========================================================================
     field_magnitudes = [np.abs(h) for h in raw_line_spectra]
     field_phases = [np.angle(h) for h in raw_line_spectra]
 
     avg_amplitude = np.mean(field_magnitudes, axis=0)
     avg_phase = np.angle(np.mean([np.exp(1j * p) for p in field_phases], axis=0))
+    avg_rise = np.mean(raw_line_rises)
 
     line_kernels = []
     line_H_invs = []
@@ -515,21 +512,17 @@ def apply_inverse_equalization(
         
         video_buf_filtered[loc : loc + line_length] = filtered_line
 
-    # =========================================================================
-    # PART 5: Exact Inverse Noise Floor Compensation (Frequency-Gated)
-    # =========================================================================
+    # ==============================================
+    # PART 5: Exact Inverse Noise Floor Compensation
+    # ==============================================
     avg_H_inv = np.mean(line_H_invs, axis=0) if len(line_H_invs) > 0 else np.ones(FFT_LEN, dtype=np.complex128)
 
     gd_mag = np.abs(avg_H_inv)
     gd_boost = np.maximum(1.0, gd_mag)
     inverse_multiplier = 1.0 / gd_boost
 
-    freqs_norm = np.abs(np.fft.fftfreq(FFT_LEN))
-    luma_protection = np.clip((freqs_norm - 0.10) / 0.10, 0.0, 1.0)
-
     mean_noise = np.mean(noise_mag_profile)
     noise_weight = np.clip((noise_mag_profile / (mean_noise + 1e-12)) * 2.0, 0.0, 1.0)
-    noise_weight *= luma_protection
 
     H_corrective = 1.0 - (noise_weight * (1.0 - inverse_multiplier))
     H_corrective[0] = 1.0

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -6,16 +6,18 @@ import scipy.fft
 # 1. NUMBA KERNEL: CAUSAL PHASE EQUALIZATION FIR
 # -----------------------------------------------------------------------------
 
+FIR_LEN = 63
+MIN_FFT_LEN = 2**9
+
 @nb.njit(cache=True, nogil=True, fastmath=True)
 def _apply_inverse_eq(picture, n_samples, causal_kernel):
     """
     Applies the causal FIR equalization filter to the video buffer.
     """
     out = np.zeros(n_samples, np.float32)
-    n_taps = len(causal_kernel)
 
     # Outer loop over causal filter taps ensures sequential, contiguous reads
-    for j in range(n_taps):
+    for j in range(FIR_LEN):
         coeff = causal_kernel[j]
             
         # Region 1: Left boundary clamping (i < j references indices < 0, clamped to picture[0])
@@ -31,24 +33,59 @@ def _apply_inverse_eq(picture, n_samples, causal_kernel):
 
 def _calc_phase_advance(S_xy, pad_len):
     """
-    Calculates the exact group delay advance (in fractional samples) 
-    from the cross-spectral density phase slope across the signal passband.
+    Calculates the required group-delay advance (in fractional samples).
+    
+    scans the Weighted R^2 to safely find the maximum coherent bandwidth 
+    and establish phase-aligned ringing cancellation.
     """
     phase = np.unwrap(np.angle(S_xy))
     freqs = scipy.fft.fftfreq(pad_len)
-    freq_percent = 0.05 # carefully tuned
+
+    # Skip the DC ledge to prevent early low-frequency lock
+    start_bin = max(2, int(pad_len * 0.02))
+    max_bins = max(start_bin + 5, int(pad_len * 0.35))
+
+    w_full = 2.0 * np.pi * freqs[start_bin:max_bins]
+    p_full = phase[start_bin:max_bins]
+    mag_full = np.abs(S_xy[start_bin:max_bins])
+
+    # High-Frequency Weighting: mag * w^2 targets the ringing resonance
+    weights_full = mag_full * (w_full ** 2)
+
+    best_end = len(w_full)
+    best_r2 = -np.inf
+    min_window = max(4, int(0.05 * len(w_full)))
     
-    # Active passband for a video sync pulse is concentrated in lower frequencies.
-    # Use the lower part of the spectrum to find the linear phase slope.
-    limit = max(2, int(pad_len * freq_percent))
+    # =========================================================================
+    # R^2 Boundary Detection & Bulk Slope
+    # =========================================================================
+    for end in range(min_window, len(w_full)):
+        w = w_full[:end]
+        p = p_full[:end]
+        wt = weights_full[:end]
+
+        wt_norm = wt / np.max(wt) if np.max(wt) > 0 else wt
+
+        slope, intercept = np.polyfit(w, p, 1, w=wt_norm)
+        fit = slope * w + intercept
+
+        p_mean = np.average(p, weights=wt_norm)
+        ss_res = np.sum(wt_norm * (p - fit) ** 2)
+        ss_tot = np.sum(wt_norm * (p - p_mean) ** 2)
+        
+        r2 = 1.0 - (ss_res / ss_tot) if ss_tot > 1e-12 else 0.0
+
+        if r2 > best_r2:
+            best_r2 = r2
+            best_end = end
+
+    # Isolate the optimal coherent bandwidth
+    w_opt = w_full[:best_end]
+    p_opt = p_full[:best_end]
+    wt_opt = weights_full[:best_end]
     
-    w = 2.0 * np.pi * freqs[1:limit]
-    p = phase[1:limit]
-    
-    # Fit line: p = slope * w + intercept
-    slope, _ = np.polyfit(w, p, 1)
-    
-    # Group delay is the negative derivative of phase with respect to angular frequency
+    # Calculate the rough bulk slope as our baseline
+    slope, _ = np.polyfit(w_opt, p_opt, 1, w=wt_opt)
     return -slope
 
 
@@ -239,7 +276,7 @@ def apply_inverse_equalization(
     back_porch_len,
     target_transition,
     group_delay_state,
-    noise_threshold=0.1,
+    noise_threshold=0.2,
     debug=False
 ):
     _normalize_inplace(video_buf, sync_tip_level, blanking_level)
@@ -250,7 +287,7 @@ def apply_inverse_equalization(
     win_size = pre_rise_samples + back_porch_len
     offset_rise = pre_rise_samples
     
-    min_required_len = 2 * win_size - 1
+    min_required_len = max(2 * win_size - 1, MIN_FFT_LEN)
     pad_len = scipy.fft.next_fast_len(min_required_len, real=False)
     
     S_xy = np.zeros(pad_len, dtype=np.complex128)
@@ -356,30 +393,33 @@ def apply_inverse_equalization(
     # IFFT back to time domain
     h_full = scipy.fft.fftshift(scipy.fft.ifft(H_inv).real)
     
-    # NATIVE PHASE FIX: 
+    # NATIVE PHASE FIX:
     # The Wiener deconvolution naturally places the main impulse offset by int_adv.
     # By shifting our extraction center to match this offset, we extract the causal tail 
-    # perfectly aligned
+    # perfectly aligned.
     true_center = pad_len // 2 - int_adv
     
     # Isolate causal tail taps for t >= 1
     fir_tail = h_full[true_center + 1:].copy()
-    causal_fir_len = len(fir_tail) + 1
 
-    # Assemble half-size causal kernel (65 taps)
-    fir_kernel = np.zeros(causal_fir_len, dtype=np.float32)
-    fir_kernel[1:] = fir_tail
+    # Assemble half-size causal kernel
+    fir_kernel = np.zeros(FIR_LEN, dtype=np.float32)
+    
+    # Safely insert the tail up to the maximum available filter length
+    insert_len = min(len(fir_tail), FIR_LEN - 1)
+    fir_kernel[1:1 + insert_len] = fir_tail[:insert_len]
  
     # Fade out the tail using a half-cosine window
-    fade_len = round(causal_fir_len * 0.15) # fade out last 15%
+    fade_len = round(FIR_LEN * 0.15) # fade out last 15%
     fade_axis = np.arange(fade_len, dtype=np.float64)
-    fir_kernel[causal_fir_len - fade_len:] *= 0.5 * (1.0 + np.cos(np.pi * fade_axis / fade_len))
+    fir_kernel[FIR_LEN - fade_len:] *= 0.5 * (1.0 + np.cos(np.pi * fade_axis / fade_len))
 
     # 3. Base DC Normalization: Enforce DC Unity strictly on the center tap (t=0)
-    fir_kernel[0] = 1.0 - np.sum(fir_tail)
+    # MUST sum the faded kernel itself, not the raw infinite tail
+    fir_kernel[0] = 1.0 - np.sum(fir_kernel[1:])
 
     if debug:
-        full_win_size = front_porch_len + sync_len + back_porch_len
+        full_win_size = max(front_porch_len + sync_len + back_porch_len, FIR_LEN)
         raw_pulses = []
         corrected_pulses = []
         line_indices = []

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -5,6 +5,7 @@ import scipy.fft
 import scipy
 from scipy.interpolate import UnivariateSpline
 import scipy.optimize
+from scipy.signal.windows import tukey
 
 from matplotlib.colors import LinearSegmentedColormap
 import matplotlib.ticker as mticker
@@ -19,7 +20,7 @@ FPS = 525
 FSC_RATIO = 4
 
 MAX_AVG_MEASUREMENTS = int(FPS)
-FIR_LEN = 31
+FIR_LEN = 21
 FFT_LEN = 512
 
 
@@ -45,6 +46,53 @@ def _apply_inverse_eq(picture, n_samples, causal_kernel):
     return out
 
 
+# Frequency energy estimate
+freq = scipy.fft.fftfreq(FFT_LEN)
+freq_abs = np.abs(freq)
+eps = 1e-12
+# Automatically centered derivative weighting
+def compute_fft_derivatives(
+    data,
+    win,
+    win_range,
+    derivative_count=5
+):
+    data_len = len(data)
+
+    pad_start = (FFT_LEN - data_len) // 2
+
+    def pad(sig):
+        out = np.zeros(FFT_LEN, dtype=np.float64)
+        out[pad_start:pad_start + data_len] = sig
+        return out
+
+    # Find strongest coherent frequency bands
+    def center_band(power, width=0.04):
+        idx = np.argmax(power[1:FFT_LEN//2]) + 1
+        center = freq_abs[idx]
+        return np.exp(-0.5 * ((freq_abs - center) / width)**2)
+
+    # Calculate centered derivatives
+    spl = UnivariateSpline(win_range, data, s=0, k=5)
+    d1 = spl.derivative(1)(win_range)
+
+    d_splines = [spl.derivative(i) for i in range(2, derivative_count)]
+    derivatives = [d1] + [ds(win_range) * win for ds in d_splines]
+
+    ffts = [scipy.fft.fft(pad(d)) for d in derivatives]
+    energies = [np.abs(f)**2 for f in ffts]
+    bands = [center_band(e) for e in energies]
+    derivatives_norm = [np.sum(b * energies[i]) + eps for i, b in enumerate(bands)]
+
+    w = [1.0 / np.sqrt(p) for p in derivatives_norm]
+    w /= np.mean(w)
+
+    X = sum(wi * Fi for wi, Fi in zip(w, ffts))
+    weights = sum(wi * Bi for wi, Bi in zip(w, bands))
+
+    return X, weights, d1
+
+
 # -----------------------------------------------------------------------------
 # Group Delay Correction
 # -----------------------------------------------------------------------------
@@ -60,7 +108,7 @@ def apply_inverse_equalization(
     back_porch_len,
     target_transition,
     state,
-    burst_phase_avg,
+    color_under_carrier_fsc_ratio,
     use_amplitude=True,
     use_phase=True,
     interpolate_time=True, 
@@ -69,6 +117,7 @@ def apply_inverse_equalization(
     _normalize_inplace(video_buf, sync_tip_level, blanking_level)
 
     if not state:
+        state['s_xy_delay_history'] = np.zeros((MAX_AVG_MEASUREMENTS, FFT_LEN), dtype=np.complex128)
         state['s_xy_history'] = np.zeros((MAX_AVG_MEASUREMENTS, FFT_LEN), dtype=np.complex128)
         state['s_yy_history'] = np.zeros((MAX_AVG_MEASUREMENTS, FFT_LEN), dtype=np.float64)
         state['ptr'] = 0
@@ -81,11 +130,13 @@ def apply_inverse_equalization(
     # =========================================================================
 
     pulse_data = []
-    pulse_pad_sum = np.zeros(FFT_LEN, dtype=np.float64)
 
     pre_rise_samples = int(np.round(0.25 * sync_len))
     win_size = pre_rise_samples + back_porch_len
-    win = np.hamming(win_size)
+    win = tukey(win_size, alpha=0.25)
+    win_range = np.arange(win_size)
+
+    pulse_pad_sum = np.zeros(win_size, dtype=np.float32)
     offset_rise = pre_rise_samples
 
     for line in range(line_start, line_end):
@@ -94,13 +145,13 @@ def apply_inverse_equalization(
         # Extract the full horizontal blanking interval
         pulse_start = max(0, loc + sync_len - pre_rise_samples)
         pulse_end = min(len(video_buf), pulse_start + win_size)
-        pulse_len = pulse_end - pulse_start
-
         pulse_measured = video_buf[pulse_start:pulse_end]
-        measured_sync_tip_level, measured_blanking_level = _get_levels(pulse_measured)
 
+        # measure pulse levels
+        measured_sync_tip_level, measured_blanking_level = _get_levels(pulse_measured)
         mid_val = measured_sync_tip_level + (measured_blanking_level - measured_sync_tip_level) / 2.0
 
+        # get the point of comparison, given this pulse will be a off spec (i.e. VHS)
         measured_center_rise = float(offset_rise)
         for i in range(win_size - 1):
             if pulse_measured[i] <= mid_val <= pulse_measured[i+1]:
@@ -109,48 +160,39 @@ def apply_inverse_equalization(
                 if (y1 - y0) != 0.0:
                     measured_center_rise = float(i) + abs(y0) / abs(y1 - y0)
                 break
-                
-        sum_sync, count_sync = 0.0, 0
-        end_sync_idx = max(1, int(measured_center_rise - 2))
-        for i in range(0, end_sync_idx):
-            sum_sync += pulse_measured[i]
-            count_sync += 1
-        local_sync = sum_sync / count_sync if count_sync > 0 else measured_sync_tip_level
-        
-        sum_bp, count_bp = 0.0, 0
-        start_bp_idx = min(win_size - 1, int(measured_center_rise + 2))
-        for i in range(start_bp_idx, win_size):
-            sum_bp += pulse_measured[i]
-            count_bp += 1
-        local_blank_r = sum_bp / count_bp if count_bp > 0 else measured_blanking_level
 
-        ideal_for_fir = _build_ideal_step(
+        pulse_reference = _build_ideal_step(
             measured_center_rise, target_transition,
-            local_sync, local_blank_r, win_size
+            measured_sync_tip_level, measured_blanking_level, win_size
         )
 
-        d_ideal = np.gradient(ideal_for_fir, edge_order=2) * win
-        d_pulse = np.gradient(pulse_measured, edge_order=2) * win
-        
-        pad_ideal = np.zeros(FFT_LEN, dtype=np.float64)
-        pad_pulse = np.zeros(FFT_LEN, dtype=np.float64)
-        pad_start = (FFT_LEN - pulse_len) // 2
+        # Combine spectra
+        X1, W_x, pulse_d1 = compute_fft_derivatives(pulse_measured, win, win_range)
+        Y1, W_y, ideal_d1 = compute_fft_derivatives(pulse_reference, win, win_range)
 
-        pad_ideal[pad_start : pad_start + pulse_len] = d_ideal
-        pad_pulse[pad_start : pad_start + pulse_len] = d_pulse
+        # Use the reference weighting (W_y) (or 0.5*(W_x+W_y) if you prefer)
+        W = 0.5 * (W_x + W_y)
+
+        s_xy = (X1 * np.conj(Y1)) * W
+        s_yy = (np.abs(Y1) ** 2) * W
+
+        s_xy_delay = X1 * np.conj(Y1)
+
+        # maintain local sums so
+        pulse_pad_sum += pulse_d1
 
         pulse_data.append({
             'pulse_raw': pulse_measured,
-            'pad_pulse': pad_pulse,
-            'pad_ideal': pad_ideal,
+            'pad_pulse': pulse_d1,
+            's_xy': s_xy,
+            's_yy': s_yy,
+            's_xy_delay': s_xy_delay,
             'measured_sync_tip_level': measured_sync_tip_level,
             'measured_blanking_level': measured_blanking_level,
         })
-        pulse_pad_sum += pad_pulse
 
     # Average of the padded raw pulses for outlier detection
     pulse_pad_avg = pulse_pad_sum / max(1, len(pulse_data))
-
     distances = []
     for d in pulse_data:
         d['distance'] = np.mean(np.abs(d['pad_pulse'] - pulse_pad_avg))
@@ -164,6 +206,7 @@ def apply_inverse_equalization(
     # PART 2: Filter Outliers, Wiener Deconvolution Setup (Frequency Domain)
     # =========================================================================
     # These are ring buffers storing the rolling averages
+    s_xy_delay_history = state['s_xy_delay_history']
     s_xy_history = state['s_xy_history']
     s_yy_history = state['s_yy_history']
 
@@ -171,6 +214,7 @@ def apply_inverse_equalization(
     first_half = min(state['count'], MAX_AVG_MEASUREMENTS - state['ptr'])
     second_half = state['count'] - first_half
 
+    s_xy_delay_sum = np.sum(s_xy_delay[state['ptr']:state['ptr'] + first_half], axis=0) + np.sum(s_xy_delay[:second_half], axis=0, dtype=np.complex64)
     s_xy_sum = np.sum(s_xy_history[state['ptr']:state['ptr'] + first_half], axis=0) + np.sum(s_xy_history[:second_half], axis=0)
     s_yy_sum = np.sum(s_yy_history[state['ptr']:state['ptr'] + first_half], axis=0) + np.sum(s_yy_history[:second_half], axis=0)
 
@@ -179,17 +223,16 @@ def apply_inverse_equalization(
         dist = np.mean(np.abs(data['pad_pulse'] - pulse_pad_avg))
 
         if dist <= dist_threshold:
-            # Take the raw FFTs of the actual and ideal step transitions
-            Y = scipy.fft.fft(data['pad_pulse'])
-            X = scipy.fft.fft(data['pad_ideal'])
+            # sum the delay for the weighting later
+            s_xy = data['s_xy']
+            s_yy = data['s_yy']
+            s_xy_delay = data['s_xy_delay']
 
-            # Compute the Frequency-Domain Delta (Cross-Spectrum)
-            s_xy = X * np.conj(Y)
-            s_yy = np.abs(Y)**2
-
+            s_xy_delay_sum += s_xy_delay
             s_xy_sum += s_xy
             s_yy_sum += s_yy
 
+            s_xy_delay_history[state['ptr']] = s_xy_delay
             s_xy_history[state['ptr']] = s_xy
             s_yy_history[state['ptr']] = s_yy
             state['ptr'] = (state['ptr'] + 1) % MAX_AVG_MEASUREMENTS
@@ -199,13 +242,15 @@ def apply_inverse_equalization(
             continue
 
     if state['count'] > 0:
+        s_xy_delay_mean = s_xy_delay_sum / state['count']
         s_xy_mean = s_xy_sum / state['count']
         s_yy_mean = s_yy_sum / state['count']
     else:
+        s_xy_delay_mean = s_xy_delay_sum
         s_xy_mean = s_xy_sum
         s_yy_mean = s_yy_sum
 
-    phase_advance = _calc_phase_advance(s_xy_mean)
+    phase_advance = _calc_phase_advance(s_xy_delay_mean)
     phase_advance_int = int(np.round(phase_advance))
     phase_advance_frac = phase_advance - phase_advance_int
 
@@ -214,36 +259,47 @@ def apply_inverse_equalization(
     # hf_median = np.median(hf_power) if len(hf_power) > 0 else 0.0
     # hf_mad = np.median(np.abs(hf_power - hf_median)) if len(hf_power) > 0 else 0.0
 
-    denom = s_yy_mean + np.max(s_yy_mean)
+    denom = s_yy_mean # + np.max(s_yy_mean) * 0.05 # TODO: tunable noise floor, perhaps determine from pulses
     denom[denom == 0] = 1e-12
 
     # The analytic Wiener transfer function (delta applied)
     H_inv = s_xy_mean / denom
     # Apply ONLY the fractional sub-sample advance to the kernel in frequency domain.
-    H_inv = H_inv * np.exp(-1j * 2.0 * np.pi * fft_freqs * phase_advance_frac)
+    H_inv = H_inv * np.exp(1j * 2.0 * np.pi * fft_freqs * phase_advance_frac)
 
-    # Create the FIR Kernel
+    # correction response
+    H_delta = 1 - H_inv
 
-    # Wiener deconvolution naturally places the main impulse offset by int_adv.
-    # By shifting our extraction center to match this offset
+    # frequency taper
+    freq_mag = np.abs(fft_freqs) / 0.5
+
+    roll_start = 0.70
+    roll_width = 0.30
+
+    freq_window = np.ones_like(freq_mag)
+
+    mask = freq_mag > roll_start
+    freq_window[mask] = 0.5 * (1.0 + np.cos(np.pi * (freq_mag[mask] - roll_start) / roll_width))
+    freq_window[freq_mag >= 1.0] = 0.0
+
+    H_delta *= freq_window
+
+    # time domain
+    h_full = scipy.fft.fftshift(
+        scipy.fft.ifft(H_delta).real
+    )
+
+    # causal extraction
     fir_center = FFT_LEN // 2 - phase_advance_int
-            
-    # Isolate causal tail taps for t >= 1
-    h_full = scipy.fft.fftshift(scipy.fft.ifft(H_inv).real)
-    fir_tail = h_full[fir_center + 1:]
-    
-    # Safely insert the tail up to the maximum available filter length
-    insert_len = min(len(fir_tail), FIR_LEN - 1)
+
+    fir_tail = h_full[fir_center+1:]
+
     fir_kernel = np.zeros(FIR_LEN, dtype=np.float32)
-    fir_kernel[1:1 + insert_len] = fir_tail[:insert_len]
 
-    # Fade out the tail using a half-cosine window
-    fade_len = round(FIR_LEN * 0.30) # fade out last 15%
-    fade_axis = np.arange(fade_len, dtype=np.float64)
-    fir_kernel[FIR_LEN - fade_len:] *= 0.5 * (1.0 + np.cos(np.pi * fade_axis / fade_len))
+    insert_len = min(len(fir_tail), FIR_LEN-1)
+    fir_kernel[1:1+insert_len] = fir_tail[:insert_len]
 
-    # 3. Base DC Normalization: Enforce DC Unity strictly on the center tap (t=0)
-    # MUST sum the faded kernel itself, not the raw infinite tail
+    # preserve unity DC
     fir_kernel[0] = 1.0 - np.sum(fir_kernel[1:])
 
     if state['count'] == 0:
@@ -636,7 +692,7 @@ def _show_group_delay_debug(
 LUMA_NOISE_FLOOR_DB = -45.0
 NOISE_REF_AMPLITUDE = 1.0
 
-LTI_GAIN_SCALE = 90.0
+LTI_GAIN_SCALE = 80.0
 LTI_GAIN_MAX = 8.0
 
 # How many noise-floors above the floor an edge needs to be before LTI treats

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -4,6 +4,7 @@ import numba as nb
 import scipy.fft
 import scipy
 from scipy.interpolate import UnivariateSpline
+import scipy.optimize
 
 from matplotlib.colors import LinearSegmentedColormap
 import matplotlib.ticker as mticker
@@ -17,102 +18,374 @@ FSC = 3.579545
 FPS = 525
 FSC_RATIO = 4
 
-MAX_HISTORY_PULSES = int(FPS / 2)
-FIR_LEN = 127
+MAX_AVG_MEASUREMENTS = int(FPS)
+FIR_LEN = 31
 FFT_LEN = 512
-DELAY_OFFSET = FIR_LEN // 2  # Anchors the causal peak
-
-
-def _make_interpolated_inverse_eq(fir_len, delay_offset):
-    @nb.njit(
-        "float32[:](float32[::1], float32[::1], int64, float32[::1], float32[::1])",
-        parallel=True,
-        cache=True,
-        nogil=True,
-        fastmath=True
-    )
-    def _apply_interpolated_inverse_eq(picture_raw, picture_clean, n_samples, kernel_a, kernel_b):
-        out = np.empty(n_samples, dtype=np.float32)
-        first = picture_clean[0]
-        last = picture_clean[n_samples - 1]
-
-        # Process each sample independently in parallel without allocating inner arrays
-        for k in nb.prange(n_samples):
-            alpha = np.float32(k) / np.float32(n_samples - 1) if n_samples > 1 else np.float32(0.0)
-            one_minus_alpha = np.float32(1.0) - alpha
-
-            read_head = k + delay_offset
-            acc = 0.0
-
-            # Interpolate FIR tap for current pixel on the fly
-            for j in range(fir_len):
-                h_val = one_minus_alpha * kernel_a[j] + alpha * kernel_b[j]
-                
-                idx = read_head - j
-                
-                # Boundary clamping
-                if idx < 0:
-                    val = first
-                elif idx >= n_samples:
-                    val = last
-                else:
-                    val = picture_clean[idx]
-
-                acc += val * h_val
-
-            # Delta Injection
-            out[k] = picture_raw[k] + (acc - picture_clean[k])
-
-        return out
-    return _apply_interpolated_inverse_eq
-
-_apply_interpolated_inverse_eq = _make_interpolated_inverse_eq(FIR_LEN, DELAY_OFFSET)
-
-
-@nb.njit("float32[:](float32[::1], float32[::1])", parallel=True, cache=True, nogil=True, fastmath=True)
-def _apply_zero_phase_fir(picture, fir_kernel):
-    n_samples = len(picture)
-    fir_len = len(fir_kernel)
-    half_fir = fir_len // 2
-    out = np.empty(n_samples, np.float32)
-    
-    first = picture[0]
-    last = picture[n_samples - 1]
-
-    # Apply standard zero-phase FIR filtering across pixels
-    for i in nb.prange(n_samples):
-        acc = 0.0
-        for j in range(fir_len):
-            idx = i + j - half_fir
-            if idx < 0:
-                val = first
-            elif idx >= n_samples:
-                val = last
-            else:
-                val = picture[idx]
-            acc += val * fir_kernel[j]
-        out[i] = acc
-        
-    return out
-
-
-def _build_fsc_mask(n, width_bins=3):
-    freq = np.abs(np.fft.fftfreq(n))
-    fsc = 1.0 / FSC_RATIO
-
-    mask = np.zeros(n)
-    dist = np.abs(freq - fsc)
-
-    width = width_bins / n
-    inside = dist < width
-    mask[inside] = 0.5 * (
-        1.0 + np.cos(np.pi * dist[inside] / width)
-    )
-    return mask
 
 
 @nb.njit(cache=True, nogil=True, fastmath=True)
-def _build_ideal_rising_pulse(
+def _apply_inverse_eq(picture, n_samples, causal_kernel):
+    """
+    Applies the causal FIR equalization filter to the video buffer.
+    """
+    out = np.zeros(n_samples, np.float32)
+
+    # Outer loop over causal filter taps ensures sequential, contiguous reads
+    for j in range(FIR_LEN):
+        coeff = causal_kernel[j]
+            
+        # Region 1: Left boundary clamping (i < j references indices < 0, clamped to picture[0])
+        for i in range(0, j):
+            out[i] += picture[0] * coeff
+            
+        # Region 2: Inner core (Pure sequential memory access: picture[i - j])
+        for i in range(j, n_samples):
+            out[i] += picture[i - j] * coeff
+
+    return out
+
+
+# -----------------------------------------------------------------------------
+# Group Delay Correction
+# -----------------------------------------------------------------------------
+def apply_inverse_equalization(
+    video_buf, 
+    line_start, 
+    line_end, 
+    line_length,
+    sync_tip_level,
+    blanking_level,
+    front_porch_len,
+    sync_len,         
+    back_porch_len,
+    target_transition,
+    state,
+    burst_phase_avg,
+    use_amplitude=True,
+    use_phase=True,
+    interpolate_time=True, 
+    debug=False
+):
+    _normalize_inplace(video_buf, sync_tip_level, blanking_level)
+
+    if not state:
+        state['s_xy_history'] = np.zeros((MAX_AVG_MEASUREMENTS, FFT_LEN), dtype=np.complex128)
+        state['s_yy_history'] = np.zeros((MAX_AVG_MEASUREMENTS, FFT_LEN), dtype=np.float64)
+        state['ptr'] = 0
+        state['count'] = 0
+
+    fft_freqs = np.fft.fftfreq(FFT_LEN)
+
+    # =========================================================================
+    # PART 1: Pulse Measurement (Frequency Domain Preparation)
+    # =========================================================================
+
+    pulse_data = []
+    pulse_pad_sum = np.zeros(FFT_LEN, dtype=np.float64)
+
+    pre_rise_samples = int(np.round(0.25 * sync_len))
+    win_size = pre_rise_samples + back_porch_len
+    win = np.hamming(win_size)
+    offset_rise = pre_rise_samples
+
+    for line in range(line_start, line_end):
+        loc = line * line_length
+
+        # Extract the full horizontal blanking interval
+        pulse_start = max(0, loc + sync_len - pre_rise_samples)
+        pulse_end = min(len(video_buf), pulse_start + win_size)
+        pulse_len = pulse_end - pulse_start
+
+        pulse_measured = video_buf[pulse_start:pulse_end]
+        measured_sync_tip_level, measured_blanking_level = _get_levels(pulse_measured)
+
+        mid_val = measured_sync_tip_level + (measured_blanking_level - measured_sync_tip_level) / 2.0
+
+        measured_center_rise = float(offset_rise)
+        for i in range(win_size - 1):
+            if pulse_measured[i] <= mid_val <= pulse_measured[i+1]:
+                y0 = pulse_measured[i] - mid_val
+                y1 = pulse_measured[i+1] - mid_val
+                if (y1 - y0) != 0.0:
+                    measured_center_rise = float(i) + abs(y0) / abs(y1 - y0)
+                break
+                
+        sum_sync, count_sync = 0.0, 0
+        end_sync_idx = max(1, int(measured_center_rise - 2))
+        for i in range(0, end_sync_idx):
+            sum_sync += pulse_measured[i]
+            count_sync += 1
+        local_sync = sum_sync / count_sync if count_sync > 0 else measured_sync_tip_level
+        
+        sum_bp, count_bp = 0.0, 0
+        start_bp_idx = min(win_size - 1, int(measured_center_rise + 2))
+        for i in range(start_bp_idx, win_size):
+            sum_bp += pulse_measured[i]
+            count_bp += 1
+        local_blank_r = sum_bp / count_bp if count_bp > 0 else measured_blanking_level
+
+        ideal_for_fir = _build_ideal_step(
+            measured_center_rise, target_transition,
+            local_sync, local_blank_r, win_size
+        )
+
+        d_ideal = np.gradient(ideal_for_fir, edge_order=2) * win
+        d_pulse = np.gradient(pulse_measured, edge_order=2) * win
+        
+        pad_ideal = np.zeros(FFT_LEN, dtype=np.float64)
+        pad_pulse = np.zeros(FFT_LEN, dtype=np.float64)
+        pad_start = (FFT_LEN - pulse_len) // 2
+
+        pad_ideal[pad_start : pad_start + pulse_len] = d_ideal
+        pad_pulse[pad_start : pad_start + pulse_len] = d_pulse
+
+        pulse_data.append({
+            'pulse_raw': pulse_measured,
+            'pad_pulse': pad_pulse,
+            'pad_ideal': pad_ideal,
+            'measured_sync_tip_level': measured_sync_tip_level,
+            'measured_blanking_level': measured_blanking_level,
+        })
+        pulse_pad_sum += pad_pulse
+
+    # Average of the padded raw pulses for outlier detection
+    pulse_pad_avg = pulse_pad_sum / max(1, len(pulse_data))
+
+    distances = []
+    for d in pulse_data:
+        d['distance'] = np.mean(np.abs(d['pad_pulse'] - pulse_pad_avg))
+        distances.append(d['distance'])
+
+    median_dist = np.median(distances) if distances else 0.0
+    mad_dist = np.median(np.abs(distances - median_dist)) if distances else 0.0
+    dist_threshold = median_dist + 3.0 * mad_dist + 1e-6
+
+    # =========================================================================
+    # PART 2: Filter Outliers, Wiener Deconvolution Setup (Frequency Domain)
+    # =========================================================================
+    # These are ring buffers storing the rolling averages
+    s_xy_history = state['s_xy_history']
+    s_yy_history = state['s_yy_history']
+
+    # ring buffer split indices
+    first_half = min(state['count'], MAX_AVG_MEASUREMENTS - state['ptr'])
+    second_half = state['count'] - first_half
+
+    s_xy_sum = np.sum(s_xy_history[state['ptr']:state['ptr'] + first_half], axis=0) + np.sum(s_xy_history[:second_half], axis=0)
+    s_yy_sum = np.sum(s_yy_history[state['ptr']:state['ptr'] + first_half], axis=0) + np.sum(s_yy_history[:second_half], axis=0)
+
+    for i, data in enumerate(pulse_data):
+        # Check individual pulse against the field average
+        dist = np.mean(np.abs(data['pad_pulse'] - pulse_pad_avg))
+
+        if dist <= dist_threshold:
+            # Take the raw FFTs of the actual and ideal step transitions
+            Y = scipy.fft.fft(data['pad_pulse'])
+            X = scipy.fft.fft(data['pad_ideal'])
+
+            # Compute the Frequency-Domain Delta (Cross-Spectrum)
+            s_xy = X * np.conj(Y)
+            s_yy = np.abs(Y)**2
+
+            s_xy_sum += s_xy
+            s_yy_sum += s_yy
+
+            s_xy_history[state['ptr']] = s_xy
+            s_yy_history[state['ptr']] = s_yy
+            state['ptr'] = (state['ptr'] + 1) % MAX_AVG_MEASUREMENTS
+            state['count'] = min(MAX_AVG_MEASUREMENTS, state['count'] + 1)
+        else:
+            # outlier
+            continue
+
+    if state['count'] > 0:
+        s_xy_mean = s_xy_sum / state['count']
+        s_yy_mean = s_yy_sum / state['count']
+    else:
+        s_xy_mean = s_xy_sum
+        s_yy_mean = s_yy_sum
+
+    phase_advance = _calc_phase_advance(s_xy_mean)
+    phase_advance_int = int(np.round(phase_advance))
+    phase_advance_frac = phase_advance - phase_advance_int
+
+    # hf_mask = fft_freqs > 0.35
+    # hf_power = s_yy_mean[hf_mask]
+    # hf_median = np.median(hf_power) if len(hf_power) > 0 else 0.0
+    # hf_mad = np.median(np.abs(hf_power - hf_median)) if len(hf_power) > 0 else 0.0
+
+    denom = s_yy_mean + np.max(s_yy_mean)
+    denom[denom == 0] = 1e-12
+
+    # The analytic Wiener transfer function (delta applied)
+    H_inv = s_xy_mean / denom
+    # Apply ONLY the fractional sub-sample advance to the kernel in frequency domain.
+    H_inv = H_inv * np.exp(-1j * 2.0 * np.pi * fft_freqs * phase_advance_frac)
+
+    # Create the FIR Kernel
+
+    # Wiener deconvolution naturally places the main impulse offset by int_adv.
+    # By shifting our extraction center to match this offset
+    fir_center = FFT_LEN // 2 - phase_advance_int
+            
+    # Isolate causal tail taps for t >= 1
+    h_full = scipy.fft.fftshift(scipy.fft.ifft(H_inv).real)
+    fir_tail = h_full[fir_center + 1:]
+    
+    # Safely insert the tail up to the maximum available filter length
+    insert_len = min(len(fir_tail), FIR_LEN - 1)
+    fir_kernel = np.zeros(FIR_LEN, dtype=np.float32)
+    fir_kernel[1:1 + insert_len] = fir_tail[:insert_len]
+
+    # Fade out the tail using a half-cosine window
+    fade_len = round(FIR_LEN * 0.30) # fade out last 15%
+    fade_axis = np.arange(fade_len, dtype=np.float64)
+    fir_kernel[FIR_LEN - fade_len:] *= 0.5 * (1.0 + np.cos(np.pi * fade_axis / fade_len))
+
+    # 3. Base DC Normalization: Enforce DC Unity strictly on the center tap (t=0)
+    # MUST sum the faded kernel itself, not the raw infinite tail
+    fir_kernel[0] = 1.0 - np.sum(fir_kernel[1:])
+
+    if state['count'] == 0:
+        _denormalize_inplace(video_buf, sync_tip_level, blanking_level)
+        return video_buf, {'gain': 0.0, 'threshold': 0.1, 'blur_radius': 0.0}
+
+
+    # =========================================================================
+    # PART 4: Execute Delta Injection via Sliding Interpolation
+    # =========================================================================
+
+    # Execute the entire field in a single parallelized pass
+    video_buf_filtered = _apply_inverse_eq(
+        video_buf,
+        len(video_buf),
+        fir_kernel
+    )
+
+    lti_params = derive_lti_parameters(fir_kernel) 
+
+    if debug:
+        full_win_size = max(front_porch_len + sync_len + back_porch_len, FIR_LEN)
+        pulse_ffts = []
+        delta_ffts = []
+        corrected_ffts = []
+        raw_pulses = []
+        corrected_pulses = []
+        line_indices = []
+        sync_tip_avg = 0
+        blanking_avg = 0
+
+
+        for idx, d in enumerate(pulse_data):
+            raw_p = d['pulse_raw']
+            corr_p = _apply_inverse_eq(
+                raw_p,
+                len(raw_p),
+                fir_kernel
+            )
+
+            sync_tip, blanking = _get_levels(corr_p)
+            sync_tip_avg += sync_tip
+            blanking_avg += blanking
+
+            raw_pulses.append(raw_p)
+
+            corrected_pulses.append(corr_p)
+            line_indices.append(idx)
+
+            pulse_fft = scipy.fft.fft(raw_p, n=FFT_LEN)
+            corrected_fft = scipy.fft.fft(corr_p, n=FFT_LEN)
+            delta_fft = corrected_fft - pulse_fft
+
+            pulse_ffts.append(pulse_fft)
+            corrected_ffts.append(corrected_fft)
+            delta_ffts.append(delta_fft)
+
+
+        ideal_debug = _build_reference_sync_pulse(
+            front_porch_len,
+            sync_len,
+            target_transition,
+            sync_tip_avg / len(pulse_data),
+            blanking_avg / len(pulse_data),
+            full_win_size,
+            phase_delay=0,
+        )
+                    
+        _show_group_delay_debug(
+            raw_pulses,
+            corrected_pulses,
+            ideal_debug,
+            fir_kernel,
+            line_indices,
+            pulse_ffts,
+            delta_ffts,
+            corrected_ffts,
+            FFT_LEN,
+        )
+
+    return _denormalize_inplace(video_buf_filtered, sync_tip_level, blanking_level), lti_params
+
+
+def _calc_phase_advance(S_xy):
+    """
+    Calculates the required group-delay advance (in fractional samples).
+    
+    scans the Weighted R^2 to safely find the maximum coherent bandwidth 
+    and establish phase-aligned ringing cancellation.
+    """
+    phase = np.unwrap(np.angle(S_xy))
+    freqs = scipy.fft.fftfreq(FFT_LEN)
+
+    # Skip the DC ledge to prevent early low-frequency lock
+    start_bin = max(2, int(FFT_LEN * 0.02))
+    max_bins = max(start_bin + 5, int(FFT_LEN * 0.35))
+
+    w_full = 2.0 * np.pi * freqs[start_bin:max_bins]
+    p_full = phase[start_bin:max_bins]
+    mag_full = np.abs(S_xy[start_bin:max_bins])
+
+    # High-Frequency Weighting: mag * w^2 targets the ringing resonance
+    weights_full = mag_full * (w_full ** 2)
+
+    best_end = len(w_full)
+    best_r2 = -np.inf
+    min_window = max(4, int(0.05 * len(w_full)))
+    
+    # =========================================================================
+    # R^2 Boundary Detection & Bulk Slope
+    # =========================================================================
+    for end in range(min_window, len(w_full)):
+        w = w_full[:end]
+        p = p_full[:end]
+        wt = weights_full[:end]
+
+        wt_norm = wt / np.max(wt) if np.max(wt) > 0 else wt
+
+        slope, intercept = np.polyfit(w, p, 1, w=wt_norm)
+        fit = slope * w + intercept
+
+        p_mean = np.average(p, weights=wt_norm)
+        ss_res = np.sum(wt_norm * (p - fit) ** 2)
+        ss_tot = np.sum(wt_norm * (p - p_mean) ** 2)
+        
+        r2 = 1.0 - (ss_res / ss_tot) if ss_tot > 1e-12 else 0.0
+
+        if r2 > best_r2:
+            best_r2 = r2
+            best_end = end
+
+    # Isolate the optimal coherent bandwidth
+    w_opt = w_full[:best_end]
+    p_opt = p_full[:best_end]
+    wt_opt = weights_full[:best_end]
+    
+    # Calculate the rough bulk slope as our baseline
+    slope, _ = np.polyfit(w_opt, p_opt, 1, w=wt_opt)
+    return -slope
+
+
+def _build_ideal_step(
     measured_center_rise,
     target_transition,
     local_sync,
@@ -123,7 +396,6 @@ def _build_ideal_rising_pulse(
     for i in range(win_size):
         t_rise = float(i) - measured_center_rise
 
-        # Build smooth cosine transition between sync and blanking limits
         if t_rise < -target_transition / 2.0:
             ideal[i] = local_sync
         elif t_rise <= target_transition / 2.0:
@@ -131,11 +403,12 @@ def _build_ideal_rising_pulse(
             ideal[i] = local_sync + (local_blank_r - local_sync) * (1.0 - np.cos(phase)) / 2.0
         else:
             ideal[i] = local_blank_r
+    
     return ideal
 
 
 @nb.njit(cache=True, nogil=True, fastmath=True)
-def _build_ideal_hsync_pulse(
+def _build_reference_sync_pulse(
     front_porch_len,
     sync_len,
     target_transition,
@@ -191,450 +464,12 @@ def _get_levels(data):
     blanking_average = np.median(part[-k:])
     return sync_tip_average, blanking_average
 
-
-@nb.njit(cache=True, nogil=True, fastmath=True)
-def _suppress_color_carrier_fft(samples):
-    out = samples.copy()
-    i_acc, q_acc = 0.0, 0.0
-    n = len(samples)
-    
-    # Accumulate quadrature phases
-    for j in range(n):
-        phase = j & 3
-        if phase == 0: i_acc += samples[j]
-        elif phase == 2: i_acc -= samples[j]
-        elif phase == 1: q_acc -= samples[j]
-        else: q_acc += samples[j]
-            
-    scale = 2.0 / n
-    i_acc *= scale
-    q_acc *= scale
-    
-    # Subtract average carrier
-    for j in range(n):
-        phase = j & 3
-        if phase == 0: out[j] -= i_acc
-        elif phase == 1: out[j] -= -q_acc
-        elif phase == 2: out[j] -= -i_acc
-        else: out[j] -= q_acc
-        
-    return out
-
-
-def _build_causal_fir_from_spectrum(H_inv, fft_len, fir_len, delay_offset):
-    freqs_norm = np.abs(scipy.fft.fftfreq(fft_len))
-    
-    taper = np.clip((0.45 - freqs_norm) / 0.10, 0.0, 1.0)
-    taper_smooth = 0.5 * (1.0 - np.cos(np.pi * taper)) 
-    H_inv_tapered = H_inv * taper_smooth
-
-    # Apply linear phase shift to maintain causal peak location
-    omega = 2.0 * np.pi * scipy.fft.fftfreq(fft_len)
-    causal_phase_shift = np.exp(-1j * omega * delay_offset)
-    H_inv_tapered *= causal_phase_shift
-
-    h_time = scipy.fft.ifft(H_inv_tapered).real
-    fir_kernel = np.zeros(fir_len, dtype=np.float32)
-    fir_kernel[:] = h_time[0 : fir_len]
-
-    fir_kernel[0 : delay_offset] = 0.0
-
-    tail_len = fir_len - delay_offset
-    tail_window = scipy.signal.windows.tukey(tail_len * 2, alpha=0.5)[tail_len:]
-    fir_kernel[delay_offset : fir_len] *= tail_window
-
-    kernel_sum = np.sum(fir_kernel)
-    if abs(kernel_sum) > 1e-12:
-        fir_kernel /= kernel_sum
-
-    return fir_kernel
-
-
-# -----------------------------------------------------------------------------
-# Group Delay Correction
-# -----------------------------------------------------------------------------
-def apply_inverse_equalization(
-    video_buf, 
-    line_start, 
-    line_end, 
-    line_length,
-    sync_tip_level,
-    blanking_level,
-    front_porch_len,
-    sync_len,         
-    back_porch_len,
-    target_transition,
-    group_delay_state,
-    burst_phase_avg,
-    interpolate_amplitude=True,
-    interpolate_phase=True,
-    interpolate_time=True, # TODO: allow interpolation to be disabled for speed
-    debug=False
-):
-    _normalize_inplace(video_buf, sync_tip_level, blanking_level)
-    n_samples = len(video_buf)
-
-    # =========================================================================
-    # PART 0: Measure the Constant Noise Floor
-    # =========================================================================
-    noise_power_sum = np.zeros(FFT_LEN, dtype=np.float64)
-    noise_count = 0
-    
-    sync_tip_flat_len = int(sync_len * 0.4)
-    win_noise = scipy.signal.windows.hann(sync_tip_flat_len)
-    start_idx_noise = (FFT_LEN - sync_tip_flat_len) // 2
-
-    # Accumulate noise profile from flat sync tip regions
-    for line in range(line_start, line_end + 1):
-        loc = line * line_length
-        tip_start = loc + front_porch_len + int(sync_len * 0.3)
-        if tip_start >= 0 and tip_start + sync_tip_flat_len < n_samples:
-            tip_chunk = video_buf[tip_start : tip_start + sync_tip_flat_len]
-            d_tip = np.gradient(tip_chunk) * win_noise
-            
-            pad_tip = np.zeros(FFT_LEN, dtype=np.float64)
-            pad_tip[start_idx_noise : start_idx_noise + sync_tip_flat_len] = d_tip
-            
-            noise_power_sum += np.abs(scipy.fft.fft(pad_tip))**2
-            noise_count += 1
-
-    if noise_count > 0:
-        noise_mag_profile = np.sqrt(noise_power_sum / noise_count) * 1.5
-    else:
-        noise_mag_profile = np.zeros(FFT_LEN, dtype=np.float64)
-
-    # =========================================================================
-    # PARTS 1 & 2: Pass 1 - Line Measurement & Pulse Ring Buffer Validation
-    # =========================================================================
-    if len(group_delay_state) == 0:
-        state_dict = {
-            's_xy_history': np.zeros((MAX_HISTORY_PULSES, FFT_LEN), dtype=np.complex128),
-            's_yy_history': np.zeros((MAX_HISTORY_PULSES, FFT_LEN), dtype=np.float64),
-            'ptr': 0,
-            'count': 0
-        }
-        group_delay_state.append(state_dict)
-    else:
-        state_dict = group_delay_state[0]
-        if 's_xy_history' not in state_dict:
-            state_dict['s_xy_history'] = np.zeros((MAX_HISTORY_PULSES, FFT_LEN), dtype=np.complex128)
-            state_dict['s_yy_history'] = np.zeros((MAX_HISTORY_PULSES, FFT_LEN), dtype=np.float64)
-            state_dict['ptr'] = 0
-            state_dict['count'] = 0
-
-    pre_rise_samples = int(np.round(0.25 * sync_len))
-    win_size = pre_rise_samples + back_porch_len
-    win_size -= win_size % 4 
-    offset_rise = pre_rise_samples
-    start_idx = (FFT_LEN - win_size) // 2
-
-    freqs = np.abs(np.fft.fftfreq(FFT_LEN))
-    hf_mask = freqs > 0.35  
-
-    # --- PASS 1: Extract and Accumulate All Gradients ---
-    extracted_data = []
-    accum_d_pulse = np.zeros(FFT_LEN, dtype=np.float64)
-    valid_extraction_count = 0
-
-    for line in range(line_start, line_end + 1):
-        loc = line * line_length
-        start_loc = loc + sync_len - pre_rise_samples
-        
-        measured_center_rise = float(offset_rise)
-        
-        if start_loc >= 0 and start_loc + win_size < n_samples:
-            pulse = video_buf[start_loc : start_loc + win_size]
-
-            # Measure dynamic levels for ideal pulse target
-            measured_sync_tip_level, measured_blanking_level = _get_levels(pulse)
-            mid_val = measured_sync_tip_level + (measured_blanking_level - measured_sync_tip_level) / 2.0
-
-            for i in range(win_size - 1):
-                if pulse[i] <= mid_val <= pulse[i+1]:
-                    y0 = pulse[i] - mid_val
-                    y1 = pulse[i+1] - mid_val
-                    if (y1 - y0) != 0.0:
-                        measured_center_rise = float(i) + abs(y0) / abs(y1 - y0)
-                    break
-                    
-            # 1. Generate the pure mathematical reference
-            ideal_rising_pulse = _build_ideal_rising_pulse(
-                measured_center_rise, target_transition,
-                measured_sync_tip_level, measured_blanking_level, win_size
-            )
-
-            # 2. DO NOT blend the raw pulse back into the ideal pulse.
-            # We want the ideal reference to remain perfectly flat on the back porch
-            # so the FFT captures the full length of the causal ringing tail as an error.
-            ideal_for_fir = ideal_rising_pulse.copy()
-
-            # 3. Use the Tukey window to handle boundary conditions smoothly.
-            transient_win = np.zeros(win_size, dtype=np.float64)
-            
-            # Slightly softer alpha (e.g., 0.10) ensures we don't accidentally clamp 
-            # the far end of the ringing tail before it naturally decays.
-            alpha = 0.10 
-            base_tukey = scipy.signal.windows.tukey(win_size, alpha=alpha)
-            
-            center_offset = win_size // 2
-            shift = int(measured_center_rise) - center_offset
-            transient_win = np.roll(base_tukey, shift)
-            
-            if shift > 0:
-                transient_win[:shift] = 0.0
-            elif shift < 0:
-                transient_win[shift:] = 0.0
-            
-            # Now, d_ideal will be perfectly zero on the back porch, 
-            # and d_pulse will contain the FULL ringing tail.
-            d_ideal = np.gradient(ideal_for_fir) * transient_win
-            d_pulse = np.gradient(pulse) * transient_win
-            
-            pad_ideal = np.zeros(FFT_LEN, dtype=np.float64)
-            
-            pad_ideal = np.zeros(FFT_LEN, dtype=np.float64)
-            pad_pulse = np.zeros(FFT_LEN, dtype=np.float64)
-            pad_ideal[start_idx : start_idx + win_size] = d_ideal
-            pad_pulse[start_idx : start_idx + win_size] = d_pulse
-
-            extracted_data.append({
-                'valid': True,
-                'pad_pulse': pad_pulse,
-                'pad_ideal': pad_ideal,
-                'rise': measured_center_rise,
-                'pulse_raw': pulse
-            })
-            accum_d_pulse += pad_pulse
-            valid_extraction_count += 1
-        else:
-            extracted_data.append({'valid': False})
-
-    # Calculate the exact average gradient across the entire field
-    if valid_extraction_count > 0:
-        avg_d_pulse = accum_d_pulse / valid_extraction_count
-    else:
-        avg_d_pulse = np.zeros(FFT_LEN, dtype=np.float64)
-
-    # Compute Median Absolute Deviation (MAD) of the distances from the average gradient 
-    # to establish a robust threshold for outlier rejection.
-    distances = []
-    for data in extracted_data:
-        if data['valid']:
-            distances.append(np.mean(np.abs(data['pad_pulse'] - avg_d_pulse)))
-            
-    if len(distances) > 0:
-        median_dist = np.median(distances)
-        mad_dist = np.median(np.abs(distances - median_dist))
-        # Equivalent to 3-sigma rejection
-        dist_threshold = median_dist + 3.0 * mad_dist + 1e-6 
-    else:
-        dist_threshold = 0.0
-
-    # --- PASS 2: Filter Outliers and Execute Wiener Deconvolution Setup ---
-    raw_line_spectra = []
-    raw_line_rises = []
-    
-    last_valid_h_inv = np.ones(FFT_LEN, dtype=np.complex128)
-    last_valid_rise = float(offset_rise)
-
-    accum_raw_pulse = np.zeros(win_size, dtype=np.float64)
-    field_pulse_count = 0
-
-    for data in extracted_data:
-        is_outlier = True
-        
-        if data['valid']:
-            # Check individual gradient against the field average
-            dist = np.mean(np.abs(data['pad_pulse'] - avg_d_pulse))
-            if dist <= dist_threshold:
-                is_outlier = False
-
-        if not is_outlier:
-            Y = scipy.fft.fft(data['pad_pulse'])
-            X = scipy.fft.fft(data['pad_ideal'])
-
-            current_s_xy = X * np.conj(Y)
-            current_s_yy = np.abs(Y)**2
-
-            ptr = state_dict['ptr']
-            state_dict['s_xy_history'][ptr] = current_s_xy
-            state_dict['s_yy_history'][ptr] = current_s_yy
-            state_dict['ptr'] = (ptr + 1) % MAX_HISTORY_PULSES
-            state_dict['count'] = min(MAX_HISTORY_PULSES, state_dict['count'] + 1)
-
-            accum_raw_pulse += data['pulse_raw']
-            field_pulse_count += 1
-        else:
-            raw_line_spectra.append(last_valid_h_inv)
-            raw_line_rises.append(last_valid_rise)
-            continue
-
-        # Compute Wiener Deconvolution using historical sample average
-        valid_count = state_dict['count']
-        accum_s_xy = np.mean(state_dict['s_xy_history'][:valid_count], axis=0)
-        accum_s_yy = np.mean(state_dict['s_yy_history'][:valid_count], axis=0)
-
-        hf_power = accum_s_yy[hf_mask]
-        hf_median = np.median(hf_power) if len(hf_power) > 0 else 0.0
-        hf_mad = np.median(np.abs(hf_power - hf_median)) if len(hf_power) > 0 else 0.0
-        noise_penalty = (hf_median + 3.0 * hf_mad)
-
-        # EXACT ANALYTIC WIENER SOLUTION (Unchokes Phase)
-        denom = accum_s_yy + noise_penalty
-        denom[denom == 0] = 1e-12
-        
-        # This one-step calculation perfectly preserves the exact phase angle
-        # while applying the noise penalty strictly to the magnitude.
-        H_total = accum_s_xy / denom
-
-        raw_line_spectra.append(H_total)
-        raw_line_rises.append(data['rise'])
-        
-        last_valid_h_inv = H_total
-        last_valid_rise = data['rise']
-
-    if state_dict['count'] == 0:
-        _denormalize_inplace(video_buf, sync_tip_level, blanking_level)
-        return video_buf, {'gain': 0.0, 'threshold': 0.1, 'blur_radius': 0.0}
-
-    # =========================================================================
-    # PART 3: Field-Wide Statistical Averaging & Phase Equalization Extraction
-    # =========================================================================
-    field_magnitudes = [np.abs(h) for h in raw_line_spectra]
-    avg_amplitude = np.mean(field_magnitudes, axis=0)
-
-    line_kernels = []
-    line_H_invs = []
-
-    for i in range(len(raw_line_spectra)):
-        # 1. Extract pure per-line phase directly
-        phase = np.angle(raw_line_spectra[i])
-        
-        # 2. Extract magnitude but enforce the Phase Authority Floor
-        raw_mag = np.abs(raw_line_spectra[i]) if interpolate_amplitude else avg_amplitude
-        
-        phase_authority_floor = 0.85
-        mag_clamped = np.clip(raw_mag, phase_authority_floor, 1.15)
-        
-        # 3. Recombine into a Phase-Dominant Equalizer
-        H_inv_modified = mag_clamped * np.exp(1j * phase)
-        
-        # 4. Taper the extreme high frequencies to pass-through
-        freqs_norm = np.abs(scipy.fft.fftfreq(FFT_LEN))
-        hf_taper = np.clip((0.48 - freqs_norm) / 0.08, 0.0, 1.0)
-        hf_taper_smooth = 0.5 * (1.0 - np.cos(np.pi * hf_taper))
-        
-        H_inv_modified = H_inv_modified * hf_taper_smooth + (1.0 + 0j) * (1.0 - hf_taper_smooth)
-
-        fir_kernel = _build_causal_fir_from_spectrum(H_inv_modified, FFT_LEN, FIR_LEN, DELAY_OFFSET)
-
-        line_kernels.append(fir_kernel)
-        line_H_invs.append(H_inv_modified)
-
-    # =========================================================================
-    # PART 4: Execute Delta Injection via Sliding Interpolation
-    # =========================================================================
-    video_clean = _suppress_color_carrier_fft(video_buf)
-    video_buf_filtered = video_buf.copy()
-    
-    # Process delta corrections across each line
-    for i, line in enumerate(range(line_start, line_end + 1)):
-        loc = line * line_length
-        if loc >= len(video_buf):
-            break
-            
-        raw_line = video_buf[loc : loc + line_length]
-        clean_line = video_clean[loc : loc + line_length]
-        
-        kernel_a = line_kernels[i]
-        kernel_b = line_kernels[i + 1] if i + 1 < len(line_kernels) else kernel_a
-        
-        filtered_line = _apply_interpolated_inverse_eq(
-            raw_line.astype(np.float32), 
-            clean_line.astype(np.float32), 
-            len(raw_line), 
-            kernel_a, 
-            kernel_b
-        )
-        
-        video_buf_filtered[loc : loc + line_length] = filtered_line
-
-    lti_params = derive_lti_parameters(line_kernels[16]) # TODO work on this
-
-    if debug:
-        full_win_size = max(front_porch_len + sync_len + back_porch_len, FIR_LEN)
-        pulse_ffts = []
-        delta_ffts = []
-        corrected_ffts = []
-        raw_pulses = []
-        corrected_pulses = []
-        line_indices = []
-
-        for idx, line in enumerate(range(line_start, line_end + 1)):
-            start_loc = line * line_length - front_porch_len
-            if start_loc >= 0 and start_loc + full_win_size < n_samples:
-                raw_p = video_buf[start_loc : start_loc + full_win_size].copy()
-                clean_p = video_clean[start_loc : start_loc + full_win_size].copy()
-                
-                kernel_a = line_kernels[idx]
-                kernel_b = line_kernels[idx + 1] if idx + 1 < len(line_kernels) else kernel_a
-
-                corr_p = _apply_interpolated_inverse_eq(
-                    raw_p.astype(np.float32), 
-                    clean_p.astype(np.float32), 
-                    full_win_size, 
-                    kernel_a,
-                    kernel_b
-                )
-
-                raw_pulses.append(raw_p)
-                corrected_pulses.append(corr_p)
-                line_indices.append(line)
-
-                pulse_fft = scipy.fft.fft(raw_p, n=FFT_LEN)
-                corrected_fft = scipy.fft.fft(corr_p, n=FFT_LEN)
-                delta_fft = corrected_fft - pulse_fft
-
-                pulse_ffts.append(pulse_fft)
-                corrected_ffts.append(corrected_fft)
-                delta_ffts.append(delta_fft)
-
-        all_corr_arr = np.array(corrected_pulses)
-        sync_tip_average, blanking_average = _get_levels(all_corr_arr.flatten())
-
-        ideal_debug = _build_ideal_hsync_pulse(
-            front_porch_len,
-            sync_len,
-            target_transition,
-            sync_tip_average,
-            blanking_average,
-            full_win_size,
-            phase_delay=0,
-        )
-                    
-        _show_group_delay_debug(
-            raw_pulses,
-            corrected_pulses,
-            ideal_debug,
-            line_kernels[16], # TODO add line kernels to debug plot
-            0,
-            line_indices,
-            pulse_ffts,
-            delta_ffts,
-            corrected_ffts,
-            FFT_LEN,
-        )
-
-    return _denormalize_inplace(video_buf_filtered, sync_tip_level, blanking_level), lti_params
-
-
 # Set `--debug_plot inverse_eq` to show this plot
 def _show_group_delay_debug(
     raw_pulses,
     corrected_pulses,
     ideal,
     fir_kernel,
-    calc_advance,
     line_indices,
     pulse_ffts,
     delta_ffts,
@@ -681,9 +516,10 @@ def _show_group_delay_debug(
     
     raw_line, = ax1.plot(raw_pulses[initial_idx], label=f'Raw Line {line_num}', color='#d62728', linewidth=1.8, alpha=0.85)
     corr_line, = ax1.plot(corrected_pulses[initial_idx], label=f'Equalized Line {line_num}', color='#1f77b4', linewidth=2.2)
-    ax1.plot(ideal, label='Target Reference', color='#7f7f7f', linestyle=':', linewidth=2)
     
-    ax1.set_title(f"Line Inspection [Line {line_num}] | Group Delay Advance: {calc_advance:.3f} samples", fontweight='bold')
+    ax1.plot(ideal, label='Unshifted Reference', color='#7f7f7f', linestyle=':', linewidth=2)
+    
+    ax1.set_title(f"Line Inspection [Line {line_num}", fontweight='bold')
     ax1.legend(loc='lower right')
     ax1.grid(True, alpha=0.35)
     ax1.set_ylabel("Amplitude")
@@ -697,8 +533,9 @@ def _show_group_delay_debug(
     ax2.grid(True, alpha=0.35)
     ax2.set_ylabel("Amplitude")
 
+    # Set up the dynamic kernel plot with the initial kernel
     x_axis = np.arange(len(fir_kernel))
-    ax3.plot(x_axis, fir_kernel, label='Causal Taps (t >= 0)', color='purple', marker='.', linewidth=1.2)
+    kernel_line, = ax3.plot(x_axis, fir_kernel, label='Causal Taps (t >= 0)', color='purple', marker='.', linewidth=1.2)
     ax3.set_title("Causal Equalization Kernel", fontweight='bold')
     ax3.axhline(0, color='black', alpha=0.3)
     ax3.set_xlim(0, len(fir_kernel) - 1)
@@ -716,6 +553,7 @@ def _show_group_delay_debug(
     pulse_spec_data = np.zeros((len(pulse_ffts), half_len + 1), dtype=np.float64)
     delta_spec_data = np.zeros((len(delta_ffts), half_len + 1), dtype=np.float64)
     corrected_spec_data = np.zeros((len(corrected_ffts), half_len + 1), dtype=np.float64)
+    
     for i in range(num_ffts):
         if i < pulse_spec_data.shape[0]:
             pulse_fft = pulse_ffts[i]
@@ -737,13 +575,13 @@ def _show_group_delay_debug(
     ax4.set_adjustable('box')
 
     ax5.imshow(delta_spec_data, aspect='auto', origin='lower', extent=[pos_freqs[0], pos_freqs[-1], min_line, max_line], cmap=green_neg)
-    ax5.set_title("Delta Y_delta", fontweight='bold')
+    ax5.set_title("Delta (Corrected - Raw)", fontweight='bold')
     ax5.set_xlabel("Frequency (MHz)")
     ax5.set_ylabel("Line Index")
     ax5.set_adjustable('box')
 
     ax6.imshow(corrected_spec_data, aspect='auto', origin='lower', extent=[pos_freqs[0], pos_freqs[-1], min_line, max_line], cmap=green_pos)
-    ax6.set_title("Corrected Y_delta - Y_raw", fontweight='bold')
+    ax6.set_title("Corrected Y_corr", fontweight='bold')
     ax6.set_adjustable('box')
     ax6.set_xlabel("Normalized Frequency")
 
@@ -771,38 +609,54 @@ def _show_group_delay_debug(
     def update(val):
         idx = int(slider.val)
         l_num = line_indices[idx]
-        raw_line.set_ydata(raw_pulses[idx])
+        
+        raw_line.set_data(np.arange(len(raw_pulses[idx])), raw_pulses[idx])
         raw_line.set_label(f'Raw Line {l_num}')
-        corr_line.set_ydata(corrected_pulses[idx])
+        
+        corr_line.set_data(np.arange(len(corrected_pulses[idx])), corrected_pulses[idx])
         corr_line.set_label(f'Equalized Line {l_num}')
-        ax1.set_title(f"Line Inspection [Line {l_num}] | Group Delay Advance: {calc_advance:.3f} samples", fontweight='bold')
+        
+        ax1.set_title(f"Line Inspection [Line {l_num}]", fontweight='bold')
         ax1.legend(loc='lower right')
+        
+        ax1.relim()
+        ax1.autoscale_view()
+        
         fig.canvas.draw_idle()
 
     slider.on_changed(update)
-
     plt.subplots_adjust(left=0.05, right=0.98, top=0.98, bottom=0.05, hspace=0.25)
     plt.show()
 
 
 # -----------------------------------------------------------------------------
-# LTI PARAMETER DERIVATION FUNCTION (Pulse-Profile Guided)
+# LTI PARAMETER DERIVATION FUNCTION
 # -----------------------------------------------------------------------------
-def derive_lti_parameters(fir_kernel):
+def derive_lti_parameters(fir_kernel, noise_threshold=0.2):
+    """
+    Derives optimal Luminance Transient Improvement (LTI) parameters
+    analytically from the derived causal group-delay FIR kernel.
+    """
+
+    # 1. Total energy vs. center tap energy
     total_energy = np.sum(fir_kernel**2)
     if total_energy <= 1e-12:
         return {'gain': 0.0, 'threshold': 0.1, 'blur_radius': 0.0}
 
     center_energy = fir_kernel[0]**2
     energy_dispersion = 1.0 - (center_energy / total_energy)
-    
+
+    # 2. Compute second moment (spatial spread radius)
     indices = np.arange(len(fir_kernel))
     weighted_spread = np.sum(indices * np.abs(fir_kernel)) / np.sum(np.abs(fir_kernel))
-    
-    noise_suppression_factor = max(0.2, 1.0 - 2.0)
+
+    # 3. Scale LTI Gain proportionally to dispersion and noise threshold
+    # High noise_threshold reduces max gain to prevent boosting noise floor
+    noise_suppression_factor = max(0.2, 1.0 - 2.0 * noise_threshold)
     lti_gain = np.clip(energy_dispersion * 1.5 * noise_suppression_factor, 0.0, 1.0)
-    
-    lti_threshold = np.clip(0.75, 0.02, 0.15)
+
+    # 4. Adaptive Threshold: Set above the residual high-frequency noise level
+    lti_threshold = np.clip(noise_threshold * 0.75, 0.02, 0.15)
 
     return {
         'gain': float(lti_gain),
@@ -824,11 +678,17 @@ def apply_adaptive_luma_transient_improvement(video_buf, gain, threshold):
         curr = video_buf[i]
         nxt = video_buf[i + 1]
 
+        # 1st derivative (span of 2 pixels) to check threshold
         abs_diff = abs(nxt - prev)
 
         if abs_diff > threshold:
+            # 2nd derivative (Laplacian) isolates the high-frequency edge energy symmetrically
             laplacian = prev - 2.0 * curr + nxt
+
+            # Non-linear gain taper
             edge_weight = min(1.0, abs_diff / (2.0 * threshold))
+            
+            # Subtracting the Laplacian acts as a symmetric unsharp mask / peaking filter
             video_buf[i] = curr - (gain * edge_weight * laplacian)
 
         prev = curr

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -3,56 +3,28 @@ import numba as nb
 import scipy.fft
 
 # -----------------------------------------------------------------------------
-# 1. NUMBA KERNEL: STRICTLY CAUSAL PHASE EQUALIZATION FIR
+# 1. NUMBA KERNEL: CAUSAL PHASE EQUALIZATION FIR
 # -----------------------------------------------------------------------------
 
-fir_len = 129
-fir_len_half = fir_len // 2
-
 @nb.njit(cache=True, nogil=True, fastmath=True)
-def _apply_global_inverse_eq(picture, n_samples, fir_kernel):
-    out = np.empty(n_samples, np.float32)
-    picture = picture.astype(np.float32)
-    fir_kernel = fir_kernel.astype(np.float32)
+def _apply_inverse_eq(picture, n_samples, causal_kernel):
+    """
+    Applies the causal FIR equalization filter to the video buffer.
+    """
+    out = np.zeros(n_samples, np.float32)
+    n_taps = len(causal_kernel)
 
-    last = n_samples - 1
-    center_end = n_samples - fir_len_half
-
-    # Left edge
-    for i in range(fir_len_half):
-        s = np.float32(0.0)
-        start = i + fir_len_half
-
-        for j in range(fir_len):
-            idx = start - j
-            if idx < 0:
-                idx = 0
-            s += picture[idx] * fir_kernel[j]
-
-        out[i] = s
-
-    # Center
-    for i in range(fir_len_half, center_end):
-        s = np.float32(0.0)
-        start = i + fir_len_half
-
-        for j in range(fir_len):
-            s += picture[start - j] * fir_kernel[j]
-
-        out[i] = s
-
-    # Right edge
-    for i in range(center_end, n_samples):
-        s = np.float32(0.0)
-        start = i + fir_len_half
-
-        for j in range(fir_len):
-            idx = start - j
-            if idx > last:
-                idx = last
-            s += picture[idx] * fir_kernel[j]
-
-        out[i] = s
+    # Outer loop over causal filter taps ensures sequential, contiguous reads
+    for j in range(n_taps):
+        coeff = causal_kernel[j]
+            
+        # Region 1: Left boundary clamping (i < j references indices < 0, clamped to picture[0])
+        for i in range(0, j):
+            out[i] += picture[0] * coeff
+            
+        # Region 2: Inner core (Pure sequential memory access: picture[i - j])
+        for i in range(j, n_samples):
+            out[i] += picture[i - j] * coeff
 
     return out
 
@@ -64,10 +36,11 @@ def _calc_phase_advance(S_xy, pad_len):
     """
     phase = np.unwrap(np.angle(S_xy))
     freqs = scipy.fft.fftfreq(pad_len)
+    freq_percent = 0.05 # carefully tuned
     
     # Active passband for a video sync pulse is concentrated in lower frequencies.
-    # Use the lower 15% of the spectrum to find the linear phase slope.
-    limit = max(2, int(pad_len * 0.15))
+    # Use the lower part of the spectrum to find the linear phase slope.
+    limit = max(2, int(pad_len * freq_percent))
     
     w = 2.0 * np.pi * freqs[1:limit]
     p = phase[1:limit]
@@ -87,10 +60,6 @@ def _show_group_delay_debug(
     calc_advance,
     line_indices,
 ):
-    """
-    Renders an interactive debug UI with a Slider to scrub through individual video lines,
-    plus an aggregate overlay of all lines showing frame-wide variance.
-    """
     try:
         import matplotlib.pyplot as plt
         from matplotlib.widgets import Slider
@@ -104,15 +73,11 @@ def _show_group_delay_debug(
 
     fig = plt.figure(figsize=(15, 11))
     
-    # Subplot grid layout
-    ax1 = plt.subplot2grid((3, 2), (0, 0), colspan=2) # Single Line View (Interactive)
-    ax2 = plt.subplot2grid((3, 2), (1, 0), colspan=1) # All Lines Overlay (Persistence)
-    ax3 = plt.subplot2grid((3, 2), (1, 1), colspan=1) # FIR Kernel Response
-    ax_slider = plt.subplot2grid((3, 2), (2, 0), colspan=2) # Slider Axis
+    ax1 = plt.subplot2grid((3, 2), (0, 0), colspan=2) 
+    ax2 = plt.subplot2grid((3, 2), (1, 0), colspan=1) 
+    ax3 = plt.subplot2grid((3, 2), (1, 1), colspan=1) 
+    ax_slider = plt.subplot2grid((3, 2), (2, 0), colspan=2) 
 
-    # -------------------------------------------------------------------------
-    # Panel 1: Single Line Inspector (Interactive)
-    # -------------------------------------------------------------------------
     initial_idx = 0
     line_num = line_indices[initial_idx]
     
@@ -120,14 +85,11 @@ def _show_group_delay_debug(
     corr_line, = ax1.plot(corrected_pulses[initial_idx], label=f'Equalized Line {line_num}', color='#1f77b4', linewidth=2.2)
     ax1.plot(ideal, label='Target Reference (Phase-Aligned)', color='#7f7f7f', linestyle=':', linewidth=2)
     
-    ax1.set_title(f"Line Inspection [Line {line_num}] | Sub-sample Advance: {calc_advance:.3f} samples", fontweight='bold')
+    ax1.set_title(f"Line Inspection [Line {line_num}] | Group Delay Advance: {calc_advance:.3f} samples", fontweight='bold')
     ax1.legend(loc='upper right')
     ax1.grid(True, alpha=0.35)
     ax1.set_ylabel("Normalized Amplitude")
 
-    # -------------------------------------------------------------------------
-    # Panel 2: Persistence Overlay (All Lines Overlaid)
-    # -------------------------------------------------------------------------
     for p in raw_pulses:
         ax2.plot(p, color='#d62728', alpha=min(0.25, max(0.02, 5.0 / n_lines)), linewidth=0.8)
     
@@ -147,22 +109,14 @@ def _show_group_delay_debug(
     ]
     ax2.legend(handles=custom_lines, loc='upper right')
 
-    # -------------------------------------------------------------------------
-    # Panel 3: Equalization Kernel
-    # -------------------------------------------------------------------------
-    center = len(fir_kernel) // 2
-    x_axis = np.arange(-center, center + 1)
-    
-    ax3.plot(x_axis, fir_kernel, label='Causal FIR Taps (t >= 0)', color='purple', marker='.', linewidth=1.2)
-    ax3.set_title("Derived Equalization Kernel", fontweight='bold')
+    x_axis = np.arange(len(fir_kernel))
+    ax3.plot(x_axis, fir_kernel, label='Causal Taps (t >= 0)', color='purple', marker='.', linewidth=1.2)
+    ax3.set_title("Derived Causal Equalization Kernel", fontweight='bold')
     ax3.axhline(0, color='black', alpha=0.3)
-    ax3.set_xlim(-40, 40)
+    ax3.set_xlim(0, len(fir_kernel) - 1)
     ax3.legend(loc='upper right')
     ax3.grid(True, alpha=0.35)
 
-    # -------------------------------------------------------------------------
-    # Slider Logic
-    # -------------------------------------------------------------------------
     slider = Slider(
         ax=ax_slider,
         label='Line Index ',
@@ -180,7 +134,7 @@ def _show_group_delay_debug(
         raw_line.set_label(f'Raw Line {l_num}')
         corr_line.set_ydata(corrected_pulses[idx])
         corr_line.set_label(f'Equalized Line {l_num}')
-        ax1.set_title(f"Line Inspection [Line {l_num}] | Sub-sample Advance: {calc_advance:.3f} samples", fontweight='bold')
+        ax1.set_title(f"Line Inspection [Line {l_num}] | Group Delay Advance: {calc_advance:.3f} samples", fontweight='bold')
         ax1.legend(loc='upper right')
         fig.canvas.draw_idle()
 
@@ -246,19 +200,21 @@ def _build_ideal_hsync_pulse(
     return ideal
 
 
-@nb.njit
+@nb.njit(cache=True, nogil=True, fastmath=True)
 def _normalize_inplace(video_buf, sync_tip_level, blanking_level):
     scale = 2.0 / (blanking_level - sync_tip_level)
     for i in range(video_buf.size):
         video_buf[i] = (video_buf[i] - sync_tip_level) * scale - 1.0
 
-@nb.njit
+
+@nb.njit(cache=True, nogil=True, fastmath=True)
 def _denormalize_inplace(video_buf, sync_tip_level, blanking_level):
     scale = 0.5 * (blanking_level - sync_tip_level)
     for i in range(video_buf.size):
         video_buf[i] = (video_buf[i] + 1.0) * scale + sync_tip_level
 
-@nb.njit
+
+@nb.njit(cache=True, nogil=True, fastmath=True)
 def _get_levels(data):
     n = data.size
     k = max(1, n // 4)
@@ -271,7 +227,7 @@ def _get_levels(data):
 # -----------------------------------------------------------------------------
 # Group Delay Correction
 # -----------------------------------------------------------------------------
-def correct_group_delay(
+def apply_inverse_equalization(
     video_buf, 
     line_start, 
     line_end, 
@@ -283,7 +239,7 @@ def correct_group_delay(
     back_porch_len,
     target_transition,
     group_delay_state,
-    noise_threshold=0.15,
+    noise_threshold=0.1,
     debug=False
 ):
     _normalize_inplace(video_buf, sync_tip_level, blanking_level)
@@ -400,17 +356,28 @@ def correct_group_delay(
     # IFFT back to time domain
     h_full = scipy.fft.fftshift(scipy.fft.ifft(H_inv).real)
     
-    # Do NOT roll the kernel here. Center extraction guarantees t=0 anchoring.
-    center_full = pad_len // 2
-    fir_kernel = h_full[center_full - fir_len_half : center_full + fir_len_half + 1].copy()
+    # NATIVE PHASE FIX: 
+    # The Wiener deconvolution naturally places the main impulse offset by int_adv.
+    # By shifting our extraction center to match this offset, we extract the causal tail 
+    # perfectly aligned
+    true_center = pad_len // 2 - int_adv
     
-    # 1. Enforce strict causality
-    fir_kernel[:fir_len_half] = 0.0
-    
-    # 2. Base DC normalization
-    fir_kernel[fir_len_half] = 1.0 - np.sum(fir_kernel[fir_len_half + 1:])
+    # Isolate causal tail taps for t >= 1
+    fir_tail = h_full[true_center + 1:].copy()
+    causal_fir_len = len(fir_tail) + 1
 
-    # Collect individual line traces if debug mode is requested
+    # Assemble half-size causal kernel (65 taps)
+    fir_kernel = np.zeros(causal_fir_len, dtype=np.float32)
+    fir_kernel[1:] = fir_tail
+ 
+    # Fade out the tail using a half-cosine window
+    fade_len = round(causal_fir_len * 0.15) # fade out last 15%
+    fade_axis = np.arange(fade_len, dtype=np.float64)
+    fir_kernel[causal_fir_len - fade_len:] *= 0.5 * (1.0 + np.cos(np.pi * fade_axis / fade_len))
+
+    # 3. Base DC Normalization: Enforce DC Unity strictly on the center tap (t=0)
+    fir_kernel[0] = 1.0 - np.sum(fir_tail)
+
     if debug:
         full_win_size = front_porch_len + sync_len + back_porch_len
         raw_pulses = []
@@ -421,25 +388,18 @@ def correct_group_delay(
             start_loc = line * line_length - front_porch_len
             if start_loc >= 0 and start_loc + full_win_size < n_samples:
                 raw_p = video_buf[start_loc : start_loc + full_win_size].copy()
-                
-                # Apply filter to individual line trace for inspection
-                delayed_p = np.roll(raw_p, int_adv)
-                filtered_p = _apply_global_inverse_eq(delayed_p, full_win_size, fir_kernel)
-                corr_p = np.roll(filtered_p, -int_adv)
+                corr_p = _apply_inverse_eq(raw_p, full_win_size, fir_kernel)
 
                 raw_pulses.append(raw_p)
                 corrected_pulses.append(corr_p)
                 line_indices.append(line)
 
     # =========================================================================
-    # PART 3: Apply Strictly Causal Equalization via Data Integer Shift
+    # PART 3: Apply Strictly Causal Equalization
     # =========================================================================
-    video_buf = np.roll(video_buf, int_adv)
-    video_buf = _apply_global_inverse_eq(video_buf, n_samples, fir_kernel)
-    video_buf = np.roll(video_buf, -int_adv)
+    video_buf = _apply_inverse_eq(video_buf, n_samples, fir_kernel)
 
     if debug and len(raw_pulses) > 0:
-        # Determine average levels from corrected set to construct target overlay
         all_corr_arr = np.array(corrected_pulses)
         sync_tip_average, blanking_average = _get_levels(all_corr_arr.flatten())
 
@@ -464,11 +424,9 @@ def correct_group_delay(
 
     _denormalize_inplace(video_buf, sync_tip_level, blanking_level)
 
-    # Calculate optimal LTI settings from the derived FIR kernel
     lti_params = derive_lti_parameters(
         fir_kernel, 
-        noise_threshold=noise_threshold,
-        max_gain=1 # TODO parameterize
+        noise_threshold=noise_threshold
     )
 
     return video_buf, lti_params
@@ -477,30 +435,28 @@ def correct_group_delay(
 # -----------------------------------------------------------------------------
 # LTI PARAMETER DERIVATION FUNCTION
 # -----------------------------------------------------------------------------
-def derive_lti_parameters(fir_kernel, noise_threshold, max_gain):
+def derive_lti_parameters(fir_kernel, noise_threshold):
     """
     Derives optimal Luminance Transient Improvement (LTI) parameters
     analytically from the derived causal group-delay FIR kernel.
     """
-    center = len(fir_kernel) // 2
-    causal_taps = fir_kernel[center:]
-    
+
     # 1. Total energy vs. center tap energy
-    total_energy = np.sum(causal_taps**2)
+    total_energy = np.sum(fir_kernel**2)
     if total_energy <= 1e-12:
         return {'gain': 0.0, 'threshold': 0.1, 'blur_radius': 0.0}
 
-    center_energy = causal_taps[0]**2
+    center_energy = fir_kernel[0]**2
     energy_dispersion = 1.0 - (center_energy / total_energy)
     
     # 2. Compute second moment (spatial spread radius)
-    indices = np.arange(len(causal_taps))
-    weighted_spread = np.sum(indices * np.abs(causal_taps)) / np.sum(np.abs(causal_taps))
+    indices = np.arange(len(fir_kernel))
+    weighted_spread = np.sum(indices * np.abs(fir_kernel)) / np.sum(np.abs(fir_kernel))
     
     # 3. Scale LTI Gain proportionally to dispersion and noise threshold
     # High noise_threshold reduces max gain to prevent boosting noise floor
     noise_suppression_factor = max(0.2, 1.0 - 2.0 * noise_threshold)
-    lti_gain = np.clip(energy_dispersion * 1.5 * noise_suppression_factor, 0.0, max_gain)
+    lti_gain = np.clip(energy_dispersion * 1.5 * noise_suppression_factor, 0.0, 1.0)
     
     # 4. Adaptive Threshold: Set above the residual high-frequency noise level
     lti_threshold = np.clip(noise_threshold * 0.75, 0.02, 0.15)
@@ -516,28 +472,32 @@ def derive_lti_parameters(fir_kernel, noise_threshold, max_gain):
 # -----------------------------------------------------------------------------
 # ADAPTIVE LTI PROCESSING KERNEL
 # -----------------------------------------------------------------------------
-@nb.njit(cache=True, fastmath=True)
+@nb.njit(cache=True, nogil=True, fastmath=True)
 def apply_adaptive_luma_transient_improvement(video_buf, gain, threshold):
     """
     Applies non-linear LTI using parameters derived from the group delay kernel.
+    Modifies video_buf in place.
     """
-    if gain <= 0.001:
-        return video_buf
-
     n = len(video_buf)
-    out = video_buf.copy()
-    
+
+    # Preserve original samples needed for the stencil
+    prev = video_buf[0]
+
     for i in range(1, n - 1):
-        diff = video_buf[i + 1] - video_buf[i - 1]
+        curr = video_buf[i]
+        nxt = video_buf[i + 1]
+
+        diff = nxt - prev
         abs_diff = abs(diff)
-        
+
         # Only boost active step transitions exceeding noise threshold
         if abs_diff > threshold:
             # Local slope estimate
-            grad = video_buf[i] - video_buf[i - 1]
-            
+            grad = curr - prev
+
             # Non-linear gain scaling (tapers off near plateaus to prevent ringing)
             edge_weight = min(1.0, abs_diff / (2.0 * threshold))
-            out[i] = video_buf[i] + (gain * edge_weight) * grad
+            video_buf[i] = curr + (gain * edge_weight) * grad
 
-    return out
+        # Advance cached original sample
+        prev = curr

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -7,15 +7,17 @@ from scipy.interpolate import UnivariateSpline
 
 from matplotlib.colors import LinearSegmentedColormap
 import matplotlib.ticker as mticker
+import matplotlib.pyplot as plt
 
 # -----------------------------------------------------------------------------
 # 1. NUMBA KERNEL: CAUSAL PHASE EQUALIZATION FIR
 # -----------------------------------------------------------------------------
 
-FSC = 3.579545 # TODO: parameterize (used only in debug)
+FSC = 3.579545 
 FPS = 525
 FSC_RATIO = 4
 
+MAX_HISTORY_PULSES = int(FPS / 2)
 FIR_LEN = 127
 FFT_LEN = 512
 DELAY_OFFSET = FIR_LEN // 2  # Anchors the causal peak
@@ -110,7 +112,7 @@ def _build_fsc_mask(n, width_bins=3):
 
 
 @nb.njit(cache=True, nogil=True, fastmath=True)
-def _build_ideal_step(
+def _build_ideal_rising_pulse(
     measured_center_rise,
     target_transition,
     local_sync,
@@ -263,6 +265,7 @@ def apply_inverse_equalization(
     back_porch_len,
     target_transition,
     group_delay_state,
+    burst_phase_avg,
     interpolate_amplitude=True,
     interpolate_phase=True,
     interpolate_time=True, # TODO: allow interpolation to be disabled for speed
@@ -303,8 +306,6 @@ def apply_inverse_equalization(
     # =========================================================================
     # PARTS 1 & 2: Pass 1 - Line Measurement & Pulse Ring Buffer Validation
     # =========================================================================
-    MAX_HISTORY_PULSES = 1000
-
     if len(group_delay_state) == 0:
         state_dict = {
             's_xy_history': np.zeros((MAX_HISTORY_PULSES, FFT_LEN), dtype=np.complex128),
@@ -330,21 +331,17 @@ def apply_inverse_equalization(
     freqs = np.abs(np.fft.fftfreq(FFT_LEN))
     hf_mask = freqs > 0.35  
 
-    raw_line_spectra = []
-    raw_line_rises = []
-    
-    last_valid_h_inv = np.ones(FFT_LEN, dtype=np.complex128)
-    last_valid_rise = float(offset_rise)
+    # --- PASS 1: Extract and Accumulate All Gradients ---
+    extracted_data = []
+    accum_d_pulse = np.zeros(FFT_LEN, dtype=np.float64)
+    valid_extraction_count = 0
 
     for line in range(line_start, line_end + 1):
         loc = line * line_length
         start_loc = loc + sync_len - pre_rise_samples
         
         measured_center_rise = float(offset_rise)
-        is_outlier = False
-        current_s_xy = np.zeros(FFT_LEN, dtype=np.complex128)
-        current_s_yy = np.zeros(FFT_LEN, dtype=np.float64)
-
+        
         if start_loc >= 0 and start_loc + win_size < n_samples:
             pulse = video_buf[start_loc : start_loc + win_size]
 
@@ -360,71 +357,114 @@ def apply_inverse_equalization(
                         measured_center_rise = float(i) + abs(y0) / abs(y1 - y0)
                     break
                     
-            sum_sync, count_sync = 0.0, 0
-            end_sync_idx = max(1, int(measured_center_rise - 2))
-            for i in range(0, end_sync_idx):
-                sum_sync += pulse[i]
-                count_sync += 1
-            local_sync = sum_sync / count_sync if count_sync > 0 else measured_sync_tip_level
-            
-            sum_bp, count_bp = 0.0, 0
-            start_bp_idx = min(win_size - 1, int(measured_center_rise + 2))
-            for i in range(start_bp_idx, win_size):
-                sum_bp += pulse[i]
-                count_bp += 1
-            local_blank_r = sum_bp / count_bp if count_bp > 0 else measured_blanking_level
-
-            ideal_for_fir = _build_ideal_step(
+            # 1. Generate the pure mathematical reference
+            ideal_rising_pulse = _build_ideal_rising_pulse(
                 measured_center_rise, target_transition,
-                local_sync, local_blank_r, win_size
+                measured_sync_tip_level, measured_blanking_level, win_size
             )
 
-            peak_idx = int(measured_center_rise)
+            # 2. DO NOT blend the raw pulse back into the ideal pulse.
+            # We want the ideal reference to remain perfectly flat on the back porch
+            # so the FFT captures the full length of the causal ringing tail as an error.
+            ideal_for_fir = ideal_rising_pulse.copy()
+
+            # 3. Use the Tukey window to handle boundary conditions smoothly.
             transient_win = np.zeros(win_size, dtype=np.float64)
             
-            if peak_idx > 0:
-                transient_win[0:peak_idx] = 0.5 * (1.0 - np.cos(np.pi * np.arange(peak_idx) / peak_idx))
+            # Slightly softer alpha (e.g., 0.10) ensures we don't accidentally clamp 
+            # the far end of the ringing tail before it naturally decays.
+            alpha = 0.10 
+            base_tukey = scipy.signal.windows.tukey(win_size, alpha=alpha)
             
-            ringing_tail_len = int(target_transition * 5.0) 
-            right_width = min(ringing_tail_len, win_size - peak_idx)
+            center_offset = win_size // 2
+            shift = int(measured_center_rise) - center_offset
+            transient_win = np.roll(base_tukey, shift)
             
-            if right_width > 0:
-                transient_win[peak_idx : peak_idx + right_width] = 0.5 * (1.0 + np.cos(np.pi * np.arange(right_width) / right_width))
-
+            if shift > 0:
+                transient_win[:shift] = 0.0
+            elif shift < 0:
+                transient_win[shift:] = 0.0
+            
+            # Now, d_ideal will be perfectly zero on the back porch, 
+            # and d_pulse will contain the FULL ringing tail.
             d_ideal = np.gradient(ideal_for_fir) * transient_win
             d_pulse = np.gradient(pulse) * transient_win
+            
+            pad_ideal = np.zeros(FFT_LEN, dtype=np.float64)
             
             pad_ideal = np.zeros(FFT_LEN, dtype=np.float64)
             pad_pulse = np.zeros(FFT_LEN, dtype=np.float64)
             pad_ideal[start_idx : start_idx + win_size] = d_ideal
             pad_pulse[start_idx : start_idx + win_size] = d_pulse
 
-            Y = scipy.fft.fft(pad_pulse)
-            X = scipy.fft.fft(pad_ideal)
+            extracted_data.append({
+                'valid': True,
+                'pad_pulse': pad_pulse,
+                'pad_ideal': pad_ideal,
+                'rise': measured_center_rise,
+                'pulse_raw': pulse
+            })
+            accum_d_pulse += pad_pulse
+            valid_extraction_count += 1
+        else:
+            extracted_data.append({'valid': False})
+
+    # Calculate the exact average gradient across the entire field
+    if valid_extraction_count > 0:
+        avg_d_pulse = accum_d_pulse / valid_extraction_count
+    else:
+        avg_d_pulse = np.zeros(FFT_LEN, dtype=np.float64)
+
+    # Compute Median Absolute Deviation (MAD) of the distances from the average gradient 
+    # to establish a robust threshold for outlier rejection.
+    distances = []
+    for data in extracted_data:
+        if data['valid']:
+            distances.append(np.mean(np.abs(data['pad_pulse'] - avg_d_pulse)))
+            
+    if len(distances) > 0:
+        median_dist = np.median(distances)
+        mad_dist = np.median(np.abs(distances - median_dist))
+        # Equivalent to 3-sigma rejection
+        dist_threshold = median_dist + 3.0 * mad_dist + 1e-6 
+    else:
+        dist_threshold = 0.0
+
+    # --- PASS 2: Filter Outliers and Execute Wiener Deconvolution Setup ---
+    raw_line_spectra = []
+    raw_line_rises = []
+    
+    last_valid_h_inv = np.ones(FFT_LEN, dtype=np.complex128)
+    last_valid_rise = float(offset_rise)
+
+    accum_raw_pulse = np.zeros(win_size, dtype=np.float64)
+    field_pulse_count = 0
+
+    for data in extracted_data:
+        is_outlier = True
+        
+        if data['valid']:
+            # Check individual gradient against the field average
+            dist = np.mean(np.abs(data['pad_pulse'] - avg_d_pulse))
+            if dist <= dist_threshold:
+                is_outlier = False
+
+        if not is_outlier:
+            Y = scipy.fft.fft(data['pad_pulse'])
+            X = scipy.fft.fft(data['pad_ideal'])
 
             current_s_xy = X * np.conj(Y)
             current_s_yy = np.abs(Y)**2
 
-            # Ring buffer outlier check against the 1000-pulse history
-            if state_dict['count'] > 10:
-                historical_mean_s_yy = np.mean(state_dict['s_yy_history'][:state_dict['count']], axis=0)
-                spectral_distance = np.mean(np.abs(current_s_yy - historical_mean_s_yy))
-                avg_power_magnitude = np.mean(historical_mean_s_yy) + 1e-12
-                relative_deviation = spectral_distance / avg_power_magnitude
-                
-                if relative_deviation > (0.4 * 0.20):
-                    is_outlier = True
+            ptr = state_dict['ptr']
+            state_dict['s_xy_history'][ptr] = current_s_xy
+            state_dict['s_yy_history'][ptr] = current_s_yy
+            state_dict['ptr'] = (ptr + 1) % MAX_HISTORY_PULSES
+            state_dict['count'] = min(MAX_HISTORY_PULSES, state_dict['count'] + 1)
 
-            if not is_outlier:
-                ptr = state_dict['ptr']
-                state_dict['s_xy_history'][ptr] = current_s_xy
-                state_dict['s_yy_history'][ptr] = current_s_yy
-                state_dict['ptr'] = (ptr + 1) % MAX_HISTORY_PULSES
-                state_dict['count'] = min(MAX_HISTORY_PULSES, state_dict['count'] + 1)
+            accum_raw_pulse += data['pulse_raw']
+            field_pulse_count += 1
         else:
-            is_outlier = True
-
-        if is_outlier:
             raw_line_spectra.append(last_valid_h_inv)
             raw_line_rises.append(last_valid_rise)
             continue
@@ -439,52 +479,55 @@ def apply_inverse_equalization(
         hf_mad = np.median(np.abs(hf_power - hf_median)) if len(hf_power) > 0 else 0.0
         noise_penalty = (hf_median + 3.0 * hf_mad)
 
-        num_passes = 5  
-        H_total = np.ones(FFT_LEN, dtype=np.complex128)
-
-        # Iteratively solve for the optimal equalizer response
-        for pass_idx in range(num_passes):
-            current_S_xy = accum_s_xy * np.conj(H_total)
-            current_S_yy = accum_s_yy * (np.abs(H_total) ** 2)
-
-            denom = current_S_yy + noise_penalty
-            denom[denom == 0] = 1e-12
-            H_step = current_S_xy / denom
-
-            alpha = 0.4 
-            H_total = H_total * (1.0 - alpha) + H_total * H_step * alpha
+        # EXACT ANALYTIC WIENER SOLUTION (Unchokes Phase)
+        denom = accum_s_yy + noise_penalty
+        denom[denom == 0] = 1e-12
+        
+        # This one-step calculation perfectly preserves the exact phase angle
+        # while applying the noise penalty strictly to the magnitude.
+        H_total = accum_s_xy / denom
 
         raw_line_spectra.append(H_total)
-        raw_line_rises.append(measured_center_rise)
+        raw_line_rises.append(data['rise'])
         
         last_valid_h_inv = H_total
-        last_valid_rise = measured_center_rise
+        last_valid_rise = data['rise']
 
     if state_dict['count'] == 0:
         _denormalize_inplace(video_buf, sync_tip_level, blanking_level)
         return video_buf, {'gain': 0.0, 'threshold': 0.1, 'blur_radius': 0.0}
 
     # =========================================================================
-    # PART 3: Field-Wide Statistical Averaging & Parameter Toggles
+    # PART 3: Field-Wide Statistical Averaging & Phase Equalization Extraction
     # =========================================================================
     field_magnitudes = [np.abs(h) for h in raw_line_spectra]
-    field_phases = [np.angle(h) for h in raw_line_spectra]
-
     avg_amplitude = np.mean(field_magnitudes, axis=0)
-    avg_phase = np.angle(np.mean([np.exp(1j * p) for p in field_phases], axis=0))
-    avg_rise = np.mean(raw_line_rises)
 
     line_kernels = []
     line_H_invs = []
 
-    # Compile the final FIR arrays for delta injection
     for i in range(len(raw_line_spectra)):
-        mag = np.abs(raw_line_spectra[i]) if interpolate_amplitude else avg_amplitude
-        phase = np.angle(raw_line_spectra[i]) if interpolate_phase else avg_phase
+        # 1. Extract pure per-line phase directly
+        phase = np.angle(raw_line_spectra[i])
         
-        H_inv_modified = mag * np.exp(1j * phase)
+        # 2. Extract magnitude but enforce the Phase Authority Floor
+        raw_mag = np.abs(raw_line_spectra[i]) if interpolate_amplitude else avg_amplitude
         
+        phase_authority_floor = 0.85
+        mag_clamped = np.clip(raw_mag, phase_authority_floor, 1.15)
+        
+        # 3. Recombine into a Phase-Dominant Equalizer
+        H_inv_modified = mag_clamped * np.exp(1j * phase)
+        
+        # 4. Taper the extreme high frequencies to pass-through
+        freqs_norm = np.abs(scipy.fft.fftfreq(FFT_LEN))
+        hf_taper = np.clip((0.48 - freqs_norm) / 0.08, 0.0, 1.0)
+        hf_taper_smooth = 0.5 * (1.0 - np.cos(np.pi * hf_taper))
+        
+        H_inv_modified = H_inv_modified * hf_taper_smooth + (1.0 + 0j) * (1.0 - hf_taper_smooth)
+
         fir_kernel = _build_causal_fir_from_spectrum(H_inv_modified, FFT_LEN, FIR_LEN, DELAY_OFFSET)
+
         line_kernels.append(fir_kernel)
         line_H_invs.append(H_inv_modified)
 
@@ -516,45 +559,7 @@ def apply_inverse_equalization(
         
         video_buf_filtered[loc : loc + line_length] = filtered_line
 
-    # =========================================================================
-    # PART 5: Exact Inverse Noise Floor Compensation
-    # =========================================================================
-    avg_H_inv = np.mean(line_H_invs, axis=0) if len(line_H_invs) > 0 else np.ones(FFT_LEN, dtype=np.complex128)
-
-    gd_mag = np.abs(avg_H_inv)
-    gd_boost = np.maximum(1.0, gd_mag)
-    inverse_multiplier = 1.0 / gd_boost
-
-    mean_noise = np.mean(noise_mag_profile)
-    noise_weight = np.clip((noise_mag_profile / (mean_noise + 1e-12)) * 2.0, 0.0, 1.0)
-
-    # Invert the static noise response characteristics
-    H_corrective = 1.0 - (noise_weight * (1.0 - inverse_multiplier))
-    H_corrective[0] = 1.0
-
-    h_corrective_time = scipy.fft.fftshift(
-        scipy.fft.ifft(H_corrective).real
-    )
-
-    center = FFT_LEN // 2
-    fir_corrective = np.zeros(FIR_LEN, dtype=np.float32)
-
-    start_idx_corr = center - (FIR_LEN // 2)
-    fir_corrective[:] = h_corrective_time[start_idx_corr:start_idx_corr + FIR_LEN]
-
-    fir_corrective *= scipy.signal.windows.hann(FIR_LEN)
-
-    fir_corr_sum = np.sum(fir_corrective)
-    if abs(fir_corr_sum) > 1e-12:
-        fir_corrective /= fir_corr_sum
-
-    video_buf_filtered = _apply_zero_phase_fir(
-        video_buf_filtered.astype(np.float32),
-        fir_corrective.astype(np.float32)
-    )
-
-    mid_kernel = line_kernels[len(line_kernels) // 2] if len(line_kernels) > 0 else np.zeros(FIR_LEN)
-    lti_params = derive_lti_parameters(mid_kernel)
+    lti_params = derive_lti_parameters(line_kernels[16]) # TODO work on this
 
     if debug:
         full_win_size = max(front_porch_len + sync_len + back_porch_len, FIR_LEN)
@@ -580,11 +585,6 @@ def apply_inverse_equalization(
                     full_win_size, 
                     kernel_a,
                     kernel_b
-                )
-                
-                corr_p = _apply_zero_phase_fir(
-                    corr_p.astype(np.float32), 
-                    fir_corrective.astype(np.float32)
                 )
 
                 raw_pulses.append(raw_p)
@@ -616,7 +616,7 @@ def apply_inverse_equalization(
             raw_pulses,
             corrected_pulses,
             ideal_debug,
-            mid_kernel,
+            line_kernels[16], # TODO add line kernels to debug plot
             0,
             line_indices,
             pulse_ffts,
@@ -786,7 +786,7 @@ def _show_group_delay_debug(
 
 
 # -----------------------------------------------------------------------------
-# LTI PARAMETER DERIVATION FUNCTION
+# LTI PARAMETER DERIVATION FUNCTION (Pulse-Profile Guided)
 # -----------------------------------------------------------------------------
 def derive_lti_parameters(fir_kernel):
     total_energy = np.sum(fir_kernel**2)

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -1,6 +1,6 @@
 import numpy as np
 import numba as nb
-import scipy.signal
+import scipy.fft
 
 # -----------------------------------------------------------------------------
 # 1. NUMBA KERNEL: STRICTLY CAUSAL PHASE EQUALIZATION FIR
@@ -9,7 +9,8 @@ import scipy.signal
 def _apply_global_inverse_eq(
     tbc_video,
     n_samples,
-    fir_kernel
+    fir_kernel,
+    scale
 ):
     out = np.empty_like(tbc_video)
     k_len = len(fir_kernel)
@@ -26,7 +27,7 @@ def _apply_global_inverse_eq(
                     val += tbc_video[0] * fir_kernel[j]
                 else:
                     val += tbc_video[n_samples - 1] * fir_kernel[j]
-        out[i] = val
+        out[i] = val * scale
         
     return out
 
@@ -108,21 +109,23 @@ def build_ideal_step(
 # -----------------------------------------------------------------------------
 # 3. MAIN CORRECTION FUNCTION
 # -----------------------------------------------------------------------------
-def apply_tbc_vhs_deemphasis_correction(
+def correct_group_delay(
     video_buf, 
     line_start, 
     line_end, 
     line_length, 
-    blanking_level_in, 
-    sync_tip_level_in, 
-    front_porch_len=15, 
-    sync_len=67,         
-    back_porch_len=67,   
-    target_transition=3.3,
+    front_porch_len, 
+    sync_len,         
+    back_porch_len,
+    target_transition,
     noise_threshold=0.01,
     fir_length=129,
     debug=False
 ):
+    # normalize
+    scale = np.max(np.abs(video_buf))
+    video_buf /= scale
+
     blanking_level = 0.0
     sync_tip_level = -40.0
     
@@ -132,7 +135,11 @@ def apply_tbc_vhs_deemphasis_correction(
     offset_rise = front_porch_len + sync_len
     mid_val = (blanking_level + sync_tip_level) / 2.0
     
-    pad_len = 2048 
+    # Compute optimal fast FFT size using scipy.fft.next_fast_len
+    # We need enough space for linear convolution without circular aliasing: length >= 2 * win_size - 1
+    min_required_len = 2 * win_size - 1
+    pad_len = scipy.fft.next_fast_len(min_required_len, real=False)
+    
     S_xy = np.zeros(pad_len, dtype=np.complex128)
     S_yy = np.zeros(pad_len, dtype=np.float64)
     
@@ -203,8 +210,9 @@ def apply_tbc_vhs_deemphasis_correction(
             pad_ideal[start_idx : start_idx + win_size] = d_ideal
             pad_pulse[start_idx : start_idx + win_size] = d_pulse
             
-            X = np.fft.fft(pad_ideal)
-            Y = np.fft.fft(pad_pulse)
+            # Utilize scipy.fft backend for maximum speed optimization
+            X = scipy.fft.fft(pad_ideal)
+            Y = scipy.fft.fft(pad_pulse)
             
             S_xy += X * np.conj(Y)
             S_yy += np.abs(Y)**2
@@ -222,7 +230,7 @@ def apply_tbc_vhs_deemphasis_correction(
     H_inv = S_xy / denom
 
     # --- Step 3: Extract Time-Domain Kernel and Enforce Strict Causality ---
-    h_full = np.fft.fftshift(np.fft.ifft(H_inv).real)
+    h_full = scipy.fft.fftshift(scipy.fft.ifft(H_inv).real)
     center_full = pad_len // 2
 
     if fir_length % 2 == 0:
@@ -254,14 +262,16 @@ def apply_tbc_vhs_deemphasis_correction(
     video_buf = _apply_global_inverse_eq(
         video_buf,
         n_samples,
-        fir_kernel
+        fir_kernel,
+        scale
     )
 
     if debug:
         corrected_pulse = _apply_global_inverse_eq(
             avg_pulse_shape,
             win_size,
-            fir_kernel
+            fir_kernel,
+            1
         )
         
         shared_blank = (blanking_level + blanking_level) / 2.0

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -57,10 +57,7 @@ def _apply_global_inverse_eq(picture, n_samples, fir_kernel):
     return out
 
 
-# -----------------------------------------------------------------------------
-# 2. HELPER FUNCTIONS
-# -----------------------------------------------------------------------------
-def calculate_optimal_advance(S_xy, pad_len):
+def _calc_phase_advance(S_xy, pad_len):
     """
     Calculates the exact group delay advance (in fractional samples) 
     from the cross-spectral density phase slope across the signal passband.
@@ -82,7 +79,7 @@ def calculate_optimal_advance(S_xy, pad_len):
     return -slope
 
 
-def _render_debug_plot_interactive(
+def _show_group_delay_debug(
     raw_pulses,
     corrected_pulses,
     ideal,
@@ -193,7 +190,7 @@ def _render_debug_plot_interactive(
     plt.show()
 
 
-def build_ideal_step(
+def _build_ideal_step(
     measured_center_rise,
     target_transition,
     local_sync,
@@ -215,7 +212,7 @@ def build_ideal_step(
     return ideal
 
 
-def build_ideal_hsync_pulse(
+def _build_ideal_hsync_pulse(
     front_porch_len,
     sync_len,
     target_transition,
@@ -250,19 +247,19 @@ def build_ideal_hsync_pulse(
 
 
 @nb.njit
-def normalize_inplace(video_buf, sync_tip_level, blanking_level):
+def _normalize_inplace(video_buf, sync_tip_level, blanking_level):
     scale = 2.0 / (blanking_level - sync_tip_level)
     for i in range(video_buf.size):
         video_buf[i] = (video_buf[i] - sync_tip_level) * scale - 1.0
 
 @nb.njit
-def denormalize_inplace(video_buf, sync_tip_level, blanking_level):
+def _denormalize_inplace(video_buf, sync_tip_level, blanking_level):
     scale = 0.5 * (blanking_level - sync_tip_level)
     for i in range(video_buf.size):
         video_buf[i] = (video_buf[i] + 1.0) * scale + sync_tip_level
 
 @nb.njit
-def get_levels(data):
+def _get_levels(data):
     n = data.size
     k = max(1, n // 4)
     part = np.sort(data.copy())
@@ -272,7 +269,7 @@ def get_levels(data):
 
 
 # -----------------------------------------------------------------------------
-# 3. MAIN CORRECTION FUNCTION
+# Group Delay Correction
 # -----------------------------------------------------------------------------
 def correct_group_delay(
     video_buf, 
@@ -289,7 +286,7 @@ def correct_group_delay(
     noise_threshold=0.15,
     debug=False
 ):
-    normalize_inplace(video_buf, sync_tip_level, blanking_level)
+    _normalize_inplace(video_buf, sync_tip_level, blanking_level)
     
     n_samples = len(video_buf)
     
@@ -316,7 +313,7 @@ def correct_group_delay(
         if start_loc >= 0 and start_loc + win_size < n_samples:
             
             pulse = video_buf[start_loc : start_loc + win_size]
-            measured_sync_tip_level, measured_blanking_level = get_levels(pulse)
+            measured_sync_tip_level, measured_blanking_level = _get_levels(pulse)
             mid_val = measured_sync_tip_level + (measured_blanking_level - measured_sync_tip_level) / 2.0
 
             count += 1
@@ -344,7 +341,7 @@ def correct_group_delay(
                 count_bp += 1
             local_blank_r = sum_bp / count_bp if count_bp > 0 else measured_blanking_level
 
-            ideal_for_fir = build_ideal_step(
+            ideal_for_fir = _build_ideal_step(
                 measured_center_rise, target_transition,
                 local_sync, local_blank_r, win_size
             )
@@ -370,7 +367,7 @@ def correct_group_delay(
         }
         group_delay_state.append(current_measurement)
     else:
-        denormalize_inplace(video_buf, sync_tip_level, blanking_level)
+        _denormalize_inplace(video_buf, sync_tip_level, blanking_level)
         return video_buf
 
     rolling_S_xy = np.zeros(pad_len, dtype=np.complex128)
@@ -384,7 +381,7 @@ def correct_group_delay(
     # PART 2: Analytical Advance & Deconvolution
     # =========================================================================
     # Dynamically extract the optimal floating-point advance from phase slope
-    advance_float = calculate_optimal_advance(rolling_S_xy, pad_len)
+    advance_float = _calc_phase_advance(rolling_S_xy, pad_len)
     
     # Split into integer video shift and fractional kernel phase-shift
     int_adv = int(np.round(advance_float))
@@ -444,9 +441,9 @@ def correct_group_delay(
     if debug and len(raw_pulses) > 0:
         # Determine average levels from corrected set to construct target overlay
         all_corr_arr = np.array(corrected_pulses)
-        sync_tip_average, blanking_average = get_levels(all_corr_arr.flatten())
+        sync_tip_average, blanking_average = _get_levels(all_corr_arr.flatten())
 
-        ideal_debug = build_ideal_hsync_pulse(
+        ideal_debug = _build_ideal_hsync_pulse(
             front_porch_len,
             sync_len,
             target_transition,
@@ -456,7 +453,7 @@ def correct_group_delay(
             phase_delay=-(advance_float+int_adv),
         )
         
-        _render_debug_plot_interactive(
+        _show_group_delay_debug(
             raw_pulses,
             corrected_pulses,
             ideal_debug,
@@ -465,6 +462,82 @@ def correct_group_delay(
             line_indices,
         )
 
-    denormalize_inplace(video_buf, sync_tip_level, blanking_level)
+    _denormalize_inplace(video_buf, sync_tip_level, blanking_level)
 
-    return video_buf
+    # Calculate optimal LTI settings from the derived FIR kernel
+    lti_params = derive_lti_parameters(
+        fir_kernel, 
+        noise_threshold=noise_threshold,
+        max_gain=1 # TODO parameterize
+    )
+
+    return video_buf, lti_params
+
+
+# -----------------------------------------------------------------------------
+# LTI PARAMETER DERIVATION FUNCTION
+# -----------------------------------------------------------------------------
+def derive_lti_parameters(fir_kernel, noise_threshold, max_gain):
+    """
+    Derives optimal Luminance Transient Improvement (LTI) parameters
+    analytically from the derived causal group-delay FIR kernel.
+    """
+    center = len(fir_kernel) // 2
+    causal_taps = fir_kernel[center:]
+    
+    # 1. Total energy vs. center tap energy
+    total_energy = np.sum(causal_taps**2)
+    if total_energy <= 1e-12:
+        return {'gain': 0.0, 'threshold': 0.1, 'blur_radius': 0.0}
+
+    center_energy = causal_taps[0]**2
+    energy_dispersion = 1.0 - (center_energy / total_energy)
+    
+    # 2. Compute second moment (spatial spread radius)
+    indices = np.arange(len(causal_taps))
+    weighted_spread = np.sum(indices * np.abs(causal_taps)) / np.sum(np.abs(causal_taps))
+    
+    # 3. Scale LTI Gain proportionally to dispersion and noise threshold
+    # High noise_threshold reduces max gain to prevent boosting noise floor
+    noise_suppression_factor = max(0.2, 1.0 - 2.0 * noise_threshold)
+    lti_gain = np.clip(energy_dispersion * 1.5 * noise_suppression_factor, 0.0, max_gain)
+    
+    # 4. Adaptive Threshold: Set above the residual high-frequency noise level
+    lti_threshold = np.clip(noise_threshold * 0.75, 0.02, 0.15)
+
+    return {
+        'gain': float(lti_gain),
+        'threshold': float(lti_threshold),
+        'blur_radius': float(weighted_spread),
+        'dispersion': float(energy_dispersion)
+    }
+
+
+# -----------------------------------------------------------------------------
+# ADAPTIVE LTI PROCESSING KERNEL
+# -----------------------------------------------------------------------------
+@nb.njit(cache=True, fastmath=True)
+def apply_adaptive_lti(video_buf, gain, threshold):
+    """
+    Applies non-linear LTI using parameters derived from the group delay kernel.
+    """
+    if gain <= 0.001:
+        return video_buf
+
+    n = len(video_buf)
+    out = video_buf.copy()
+    
+    for i in range(1, n - 1):
+        diff = video_buf[i + 1] - video_buf[i - 1]
+        abs_diff = abs(diff)
+        
+        # Only boost active step transitions exceeding noise threshold
+        if abs_diff > threshold:
+            # Local slope estimate
+            grad = video_buf[i] - video_buf[i - 1]
+            
+            # Non-linear gain scaling (tapers off near plateaus to prevent ringing)
+            edge_weight = min(1.0, abs_diff / (2.0 * threshold))
+            out[i] = video_buf[i] + (gain * edge_weight) * grad
+
+    return out

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -630,39 +630,49 @@ def _show_group_delay_debug(
 
 
 # -----------------------------------------------------------------------------
-# LTI PARAMETER DERIVATION FUNCTION
+# LTI Luma Transient Improvement
 # -----------------------------------------------------------------------------
-def derive_lti_parameters(fir_kernel, noise_threshold=0.2):
-    """
-    Derives optimal Luminance Transient Improvement (LTI) parameters
-    analytically from the derived causal group-delay FIR kernel.
-    """
 
-    # 1. Total energy vs. center tap energy
+LUMA_NOISE_FLOOR_DB = -45.0
+NOISE_REF_AMPLITUDE = 1.0
+
+LTI_GAIN_SCALE = 90.0
+LTI_GAIN_MAX = 8.0
+
+# How many noise-floors above the floor an edge needs to be before LTI treats
+# it as real, and how much that margin grows per unit of energy_dispersion
+# (a kernel doing more correction is also carrying more amplified noise).
+NOISE_MARGIN = 3.0
+DISPERSION_MARGIN_GAIN = 2.0
+
+
+def derive_lti_parameters(fir_kernel, noise_floor_db=LUMA_NOISE_FLOOR_DB):
+    """
+    Derives Luminance Transient Improvement (LTI) parameters from the shape
+    of the causal group-delay correction kernel.
+    """
     total_energy = np.sum(fir_kernel**2)
     if total_energy <= 1e-12:
-        return {'gain': 0.0, 'threshold': 0.1, 'blur_radius': 0.0}
+        return {'gain': 0.0, 'threshold': 0.1, 'blur_radius': 0.0, 'dispersion': 0.0}
 
-    center_energy = fir_kernel[0]**2
+
+    center_energy = fir_kernel[0] ** 2
     energy_dispersion = 1.0 - (center_energy / total_energy)
 
-    # 2. Compute second moment (spatial spread radius)
-    indices = np.arange(len(fir_kernel))
-    weighted_spread = np.sum(indices * np.abs(fir_kernel)) / np.sum(np.abs(fir_kernel))
 
-    # 3. Scale LTI Gain proportionally to dispersion and noise threshold
-    # High noise_threshold reduces max gain to prevent boosting noise floor
-    noise_suppression_factor = max(0.2, 1.0 - 2.0 * noise_threshold)
-    lti_gain = np.clip(energy_dispersion * 1.5 * noise_suppression_factor, 0.0, 1.0)
+    # Gain scales directly with how much correction the kernel had to do.
+    lti_gain = float(np.clip(energy_dispersion * LTI_GAIN_SCALE, 0.0, LTI_GAIN_MAX))
 
-    # 4. Adaptive Threshold: Set above the residual high-frequency noise level
-    lti_threshold = np.clip(noise_threshold * 0.75, 0.02, 0.15)
+    # Threshold sits a fixed margin above the known noise floor so
+    # noise doesn't trigger the peaking correction; the margin widens
+    # with energy_dispersion
+    noise_floor_amp = NOISE_REF_AMPLITUDE * (10.0 ** (noise_floor_db / 20.0))
+    lti_threshold = float(noise_floor_amp * (NOISE_MARGIN + DISPERSION_MARGIN_GAIN * energy_dispersion))
 
     return {
-        'gain': float(lti_gain),
-        'threshold': float(lti_threshold),
-        'blur_radius': float(weighted_spread),
-        'dispersion': float(energy_dispersion)
+        'gain': lti_gain,
+        'threshold': lti_threshold,
+        'dispersion': float(energy_dispersion),
     }
 
 

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -5,105 +5,270 @@ import scipy.fft
 # -----------------------------------------------------------------------------
 # 1. NUMBA KERNEL: STRICTLY CAUSAL PHASE EQUALIZATION FIR
 # -----------------------------------------------------------------------------
+
+fir_len = 129
+fir_len_half = fir_len // 2
+
 @nb.njit(cache=True, nogil=True, fastmath=True)
-def _apply_global_inverse_eq(
-    tbc_video,
-    n_samples,
-    fir_kernel,
-    scale
-):
-    out = np.empty_like(tbc_video)
-    k_len = len(fir_kernel)
-    half_k = k_len // 2
-    
-    for i in range(n_samples):
-        val = 0.0
-        for j in range(k_len):
-            idx = i + half_k - j
-            if 0 <= idx < n_samples:
-                val += tbc_video[idx] * fir_kernel[j]
-            else:
-                if idx < 0:
-                    val += tbc_video[0] * fir_kernel[j]
-                else:
-                    val += tbc_video[n_samples - 1] * fir_kernel[j]
-        out[i] = val * scale
-        
+def _apply_global_inverse_eq(picture, n_samples, fir_kernel):
+    out = np.empty(n_samples, np.float32)
+    picture = picture.astype(np.float32)
+    fir_kernel = fir_kernel.astype(np.float32)
+
+    last = n_samples - 1
+    center_end = n_samples - fir_len_half
+
+    # Left edge
+    for i in range(fir_len_half):
+        s = np.float32(0.0)
+        start = i + fir_len_half
+
+        for j in range(fir_len):
+            idx = start - j
+            if idx < 0:
+                idx = 0
+            s += picture[idx] * fir_kernel[j]
+
+        out[i] = s
+
+    # Center
+    for i in range(fir_len_half, center_end):
+        s = np.float32(0.0)
+        start = i + fir_len_half
+
+        for j in range(fir_len):
+            s += picture[start - j] * fir_kernel[j]
+
+        out[i] = s
+
+    # Right edge
+    for i in range(center_end, n_samples):
+        s = np.float32(0.0)
+        start = i + fir_len_half
+
+        for j in range(fir_len):
+            idx = start - j
+            if idx > last:
+                idx = last
+            s += picture[idx] * fir_kernel[j]
+
+        out[i] = s
+
     return out
 
 
 # -----------------------------------------------------------------------------
-# 2. DEBUG PLOT RENDERER
+# 2. HELPER FUNCTIONS
 # -----------------------------------------------------------------------------
-def _render_debug_plot(
-    avg_pulse_shape,
-    corrected_pulse,
+def calculate_optimal_advance(S_xy, pad_len):
+    """
+    Calculates the exact group delay advance (in fractional samples) 
+    from the cross-spectral density phase slope across the signal passband.
+    """
+    phase = np.unwrap(np.angle(S_xy))
+    freqs = scipy.fft.fftfreq(pad_len)
+    
+    # Active passband for a video sync pulse is concentrated in lower frequencies.
+    # Use the lower 15% of the spectrum to find the linear phase slope.
+    limit = max(2, int(pad_len * 0.15))
+    
+    w = 2.0 * np.pi * freqs[1:limit]
+    p = phase[1:limit]
+    
+    # Fit line: p = slope * w + intercept
+    slope, _ = np.polyfit(w, p, 1)
+    
+    # Group delay is the negative derivative of phase with respect to angular frequency
+    return -slope
+
+
+def _render_debug_plot_interactive(
+    raw_pulses,
+    corrected_pulses,
     ideal,
     fir_kernel,
-    target_transition
+    calc_advance,
+    line_indices,
 ):
+    """
+    Renders an interactive debug UI with a Slider to scrub through individual video lines,
+    plus an aggregate overlay of all lines showing frame-wide variance.
+    """
     try:
         import matplotlib.pyplot as plt
+        from matplotlib.widgets import Slider
     except ImportError:
         print("Matplotlib is required to render the debug plot.")
         return
 
-    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(14, 10), sharex=False)
+    n_lines = len(raw_pulses)
+    if n_lines == 0:
+        return
 
-    ax1.plot(avg_pulse_shape, label='Before (Raw Avg Pulse)', color='#d62728', linewidth=1.8)
-    ax1.plot(corrected_pulse, label='After (Causal Group Delay Equalization)', color='#1f77b4', linewidth=2.2)
-    ax1.plot(ideal, label=f'Target Spec Step (Trans: {target_transition})', color='#7f7f7f', linestyle=':', linewidth=2)
-    ax1.set_title("System Identification: Strictly Causal Group Delay Equalization")
-    ax1.legend()
-    ax1.grid(True, alpha=0.4)
+    fig = plt.figure(figsize=(15, 11))
+    
+    # Subplot grid layout
+    ax1 = plt.subplot2grid((3, 2), (0, 0), colspan=2) # Single Line View (Interactive)
+    ax2 = plt.subplot2grid((3, 2), (1, 0), colspan=1) # All Lines Overlay (Persistence)
+    ax3 = plt.subplot2grid((3, 2), (1, 1), colspan=1) # FIR Kernel Response
+    ax_slider = plt.subplot2grid((3, 2), (2, 0), colspan=2) # Slider Axis
 
+    # -------------------------------------------------------------------------
+    # Panel 1: Single Line Inspector (Interactive)
+    # -------------------------------------------------------------------------
+    initial_idx = 0
+    line_num = line_indices[initial_idx]
+    
+    raw_line, = ax1.plot(raw_pulses[initial_idx], label=f'Raw Line {line_num}', color='#d62728', linewidth=1.8, alpha=0.85)
+    corr_line, = ax1.plot(corrected_pulses[initial_idx], label=f'Equalized Line {line_num}', color='#1f77b4', linewidth=2.2)
+    ax1.plot(ideal, label='Target Reference (Phase-Aligned)', color='#7f7f7f', linestyle=':', linewidth=2)
+    
+    ax1.set_title(f"Line Inspection [Line {line_num}] | Sub-sample Advance: {calc_advance:.3f} samples", fontweight='bold')
+    ax1.legend(loc='upper right')
+    ax1.grid(True, alpha=0.35)
+    ax1.set_ylabel("Normalized Amplitude")
+
+    # -------------------------------------------------------------------------
+    # Panel 2: Persistence Overlay (All Lines Overlaid)
+    # -------------------------------------------------------------------------
+    for p in raw_pulses:
+        ax2.plot(p, color='#d62728', alpha=min(0.25, max(0.02, 5.0 / n_lines)), linewidth=0.8)
+    
+    for p in corrected_pulses:
+        ax2.plot(p, color='#1f77b4', alpha=min(0.25, max(0.02, 5.0 / n_lines)), linewidth=0.8)
+
+    ax2.plot(ideal, color='black', linestyle='--', linewidth=1.5, label='Target (Phase-Aligned)')
+    ax2.set_title(f"All Lines Overlay ({n_lines} Lines)", fontweight='bold')
+    ax2.grid(True, alpha=0.35)
+    ax2.set_ylabel("Normalized Amplitude")
+
+    from matplotlib.lines import Line2D
+    custom_lines = [
+        Line2D([0], [0], color='#d62728', lw=1.5, label='Raw Set'),
+        Line2D([0], [0], color='#1f77b4', lw=1.5, label='Corrected Set'),
+        Line2D([0], [0], color='black', lw=1.5, linestyle='--', label='Target')
+    ]
+    ax2.legend(handles=custom_lines, loc='upper right')
+
+    # -------------------------------------------------------------------------
+    # Panel 3: Equalization Kernel
+    # -------------------------------------------------------------------------
     center = len(fir_kernel) // 2
     x_axis = np.arange(-center, center + 1)
     
-    ax2.plot(x_axis, fir_kernel, label='Causal FIR Taps (t >= 0)', color='purple', marker='.', linewidth=1.5)
-    ax2.set_title("Derived Causal Group-Delay Kernel (Zero Pre-Shoot)")
-    ax2.axhline(0, color='black', alpha=0.3)
-    ax2.set_xlim(-40, 40)
-    ax2.legend()
-    ax2.grid(True, alpha=0.4)
+    ax3.plot(x_axis, fir_kernel, label='Causal FIR Taps (t >= 0)', color='purple', marker='.', linewidth=1.2)
+    ax3.set_title("Derived Equalization Kernel", fontweight='bold')
+    ax3.axhline(0, color='black', alpha=0.3)
+    ax3.set_xlim(-40, 40)
+    ax3.legend(loc='upper right')
+    ax3.grid(True, alpha=0.35)
+
+    # -------------------------------------------------------------------------
+    # Slider Logic
+    # -------------------------------------------------------------------------
+    slider = Slider(
+        ax=ax_slider,
+        label='Line Index ',
+        valmin=0,
+        valmax=n_lines - 1,
+        valinit=0,
+        valstep=1,
+        color='#1f77b4'
+    )
+
+    def update(val):
+        idx = int(slider.val)
+        l_num = line_indices[idx]
+        raw_line.set_ydata(raw_pulses[idx])
+        raw_line.set_label(f'Raw Line {l_num}')
+        corr_line.set_ydata(corrected_pulses[idx])
+        corr_line.set_label(f'Equalized Line {l_num}')
+        ax1.set_title(f"Line Inspection [Line {l_num}] | Sub-sample Advance: {calc_advance:.3f} samples", fontweight='bold')
+        ax1.legend(loc='upper right')
+        fig.canvas.draw_idle()
+
+    slider.on_changed(update)
 
     plt.tight_layout()
     plt.show()
 
 
 def build_ideal_step(
-    measured_center_fall,
     measured_center_rise,
     target_transition,
-    local_blank_f,
     local_sync,
     local_blank_r,
     win_size,
 ):
-    mid_sync = int(measured_center_fall + (measured_center_rise - measured_center_fall) / 2.0)
     ideal = np.zeros(win_size, dtype=np.float64)
     for i in range(win_size):
-        t_fall = float(i) - measured_center_fall
         t_rise = float(i) - measured_center_rise
 
-        if i <= mid_sync:
-            if t_fall < -target_transition / 2.0:
-                ideal[i] = local_blank_f
-            elif t_fall <= target_transition / 2.0:
-                phase = (t_fall + target_transition / 2.0) / target_transition * np.pi
-                ideal[i] = local_blank_f + (local_sync - local_blank_f) * (1.0 - np.cos(phase)) / 2.0
-            else:
-                ideal[i] = local_sync
+        if t_rise < -target_transition / 2.0:
+            ideal[i] = local_sync
+        elif t_rise <= target_transition / 2.0:
+            phase = (t_rise + target_transition / 2.0) / target_transition * np.pi
+            ideal[i] = local_sync + (local_blank_r - local_sync) * (1.0 - np.cos(phase)) / 2.0
         else:
-            if t_rise < -target_transition / 2.0:
-                ideal[i] = local_sync
-            elif t_rise <= target_transition / 2.0:
-                phase = (t_rise + target_transition / 2.0) / target_transition * np.pi
-                ideal[i] = local_sync + (local_blank_r - local_sync) * (1.0 - np.cos(phase)) / 2.0
-            else:
-                ideal[i] = local_blank_r
+            ideal[i] = local_blank_r
     
     return ideal
+
+
+def build_ideal_hsync_pulse(
+    front_porch_len,
+    sync_len,
+    target_transition,
+    sync_level,
+    blanking_level,
+    win_size,
+    phase_delay=0.0,
+):
+    """Generates an ideal full H-Sync pulse aligned with the signal's phase delay."""
+    ideal = np.full(win_size, blanking_level, dtype=np.float64)
+    
+    center_fall = float(front_porch_len) + phase_delay
+    center_rise = float(front_porch_len + sync_len) + phase_delay
+    
+    for i in range(win_size):
+        t_fall = float(i) - center_fall
+        t_rise = float(i) - center_rise
+        
+        # Falling Edge (Front Porch -> Sync Tip)
+        if t_fall >= -target_transition / 2.0 and t_fall <= target_transition / 2.0:
+            phase = (t_fall + target_transition / 2.0) / target_transition * np.pi
+            ideal[i] = blanking_level - (blanking_level - sync_level) * (1.0 - np.cos(phase)) / 2.0
+        # Sync Tip Region
+        elif t_fall > target_transition / 2.0 and t_rise < -target_transition / 2.0:
+            ideal[i] = sync_level
+        # Rising Edge (Sync Tip -> Back Porch)
+        elif t_rise >= -target_transition / 2.0 and t_rise <= target_transition / 2.0:
+            phase = (t_rise + target_transition / 2.0) / target_transition * np.pi
+            ideal[i] = sync_level + (blanking_level - sync_level) * (1.0 - np.cos(phase)) / 2.0
+            
+    return ideal
+
+
+@nb.njit
+def normalize_inplace(video_buf, sync_tip_level, blanking_level):
+    scale = 2.0 / (blanking_level - sync_tip_level)
+    for i in range(video_buf.size):
+        video_buf[i] = (video_buf[i] - sync_tip_level) * scale - 1.0
+
+@nb.njit
+def denormalize_inplace(video_buf, sync_tip_level, blanking_level):
+    scale = 0.5 * (blanking_level - sync_tip_level)
+    for i in range(video_buf.size):
+        video_buf[i] = (video_buf[i] + 1.0) * scale + sync_tip_level
+
+@nb.njit
+def get_levels(data):
+    n = data.size
+    k = max(1, n // 4)
+    part = np.sort(data.copy())
+    sync_tip_average = np.median(part[:k])
+    blanking_average = np.median(part[-k:])
+    return sync_tip_average, blanking_average
 
 
 # -----------------------------------------------------------------------------
@@ -113,30 +278,25 @@ def correct_group_delay(
     video_buf, 
     line_start, 
     line_end, 
-    line_length, 
-    front_porch_len, 
+    line_length,
+    sync_tip_level,
+    blanking_level,
+    front_porch_len,
     sync_len,         
     back_porch_len,
     target_transition,
-    noise_threshold=0.01,
-    fir_length=129,
+    group_delay_state,
+    noise_threshold=0.15,
     debug=False
 ):
-    # normalize
-    scale = np.max(np.abs(video_buf))
-    video_buf /= scale
-
-    blanking_level = 0.0
-    sync_tip_level = -40.0
+    normalize_inplace(video_buf, sync_tip_level, blanking_level)
     
     n_samples = len(video_buf)
-    win_size = front_porch_len + sync_len + back_porch_len
-    offset_fall = front_porch_len
-    offset_rise = front_porch_len + sync_len
-    mid_val = (blanking_level + sync_tip_level) / 2.0
     
-    # Compute optimal fast FFT size using scipy.fft.next_fast_len
-    # We need enough space for linear convolution without circular aliasing: length >= 2 * win_size - 1
+    pre_rise_samples = int(np.round(0.25 * sync_len))
+    win_size = pre_rise_samples + back_porch_len
+    offset_rise = pre_rise_samples
+    
     min_required_len = 2 * win_size - 1
     pad_len = scipy.fft.next_fast_len(min_required_len, real=False)
     
@@ -146,30 +306,23 @@ def correct_group_delay(
     win = np.hanning(win_size)
     start_idx = (pad_len - win_size) // 2
     count = 0
-    
-    avg_pulse_shape = np.zeros(win_size, dtype=np.float64)
 
-    # --- Step 1: Accumulate Cross-Spectral Density ---
+    # =========================================================================
+    # PART 1: Calculate Pulse Shape & Spectra (Rising Edge Only)
+    # =========================================================================
     for line in range(line_start, line_end + 1):
         loc = line * line_length
-        if loc - offset_fall >= 0 and loc + sync_len + back_porch_len < n_samples:
+        start_loc = loc + sync_len - pre_rise_samples
+        if start_loc >= 0 and start_loc + win_size < n_samples:
             
-            pulse = video_buf[loc - offset_fall : loc + sync_len + back_porch_len]
-            avg_pulse_shape += pulse
+            pulse = video_buf[start_loc : start_loc + win_size]
+            measured_sync_tip_level, measured_blanking_level = get_levels(pulse)
+            mid_val = measured_sync_tip_level + (measured_blanking_level - measured_sync_tip_level) / 2.0
+
             count += 1
             
-            measured_center_fall = float(offset_fall)
-            for i in range(win_size - 1):
-                if pulse[i] >= mid_val >= pulse[i+1]:
-                    y0 = pulse[i] - mid_val
-                    y1 = pulse[i+1] - mid_val
-                    if (y0 - y1) != 0.0:
-                        measured_center_fall = float(i) + abs(y0) / abs(y0 - y1)
-                    break
-
             measured_center_rise = float(offset_rise)
-            search_start = int(measured_center_fall + (sync_len // 2))
-            for i in range(search_start, win_size - 1):
+            for i in range(win_size - 1):
                 if pulse[i] <= mid_val <= pulse[i+1]:
                     y0 = pulse[i] - mid_val
                     y1 = pulse[i+1] - mid_val
@@ -177,29 +330,23 @@ def correct_group_delay(
                         measured_center_rise = float(i) + abs(y0) / abs(y1 - y0)
                     break
                     
-            sum_fp, count_fp = 0.0, 0
-            for i in range(0, max(1, int(measured_center_fall - 4))):
-                sum_fp += pulse[i]
-                count_fp += 1
-            local_blank_f = sum_fp / count_fp if count_fp > 0 else blanking_level
-            
             sum_sync, count_sync = 0.0, 0
-            for i in range(int(measured_center_fall + 12), int(measured_center_rise - 12)):
+            end_sync_idx = max(1, int(measured_center_rise - 2))
+            for i in range(0, end_sync_idx):
                 sum_sync += pulse[i]
                 count_sync += 1
-            local_sync = sum_sync / count_sync if count_sync > 0 else sync_tip_level
+            local_sync = sum_sync / count_sync if count_sync > 0 else measured_sync_tip_level
             
             sum_bp, count_bp = 0.0, 0
-            for i in range(int(measured_center_rise + 4), win_size):
+            start_bp_idx = min(win_size - 1, int(measured_center_rise + 2))
+            for i in range(start_bp_idx, win_size):
                 sum_bp += pulse[i]
                 count_bp += 1
-            local_blank_r = sum_bp / count_bp if count_bp > 0 else blanking_level
+            local_blank_r = sum_bp / count_bp if count_bp > 0 else measured_blanking_level
 
-            shared_blank = (local_blank_f + local_blank_r) / 2.0
-            
             ideal_for_fir = build_ideal_step(
-                measured_center_fall, measured_center_rise, target_transition,
-                shared_blank, local_sync, shared_blank, win_size
+                measured_center_rise, target_transition,
+                local_sync, local_blank_r, win_size
             )
 
             d_ideal = np.gradient(ideal_for_fir) * win
@@ -210,82 +357,114 @@ def correct_group_delay(
             pad_ideal[start_idx : start_idx + win_size] = d_ideal
             pad_pulse[start_idx : start_idx + win_size] = d_pulse
             
-            # Utilize scipy.fft backend for maximum speed optimization
             X = scipy.fft.fft(pad_ideal)
             Y = scipy.fft.fft(pad_pulse)
             
             S_xy += X * np.conj(Y)
             S_yy += np.abs(Y)**2
 
-    if count == 0:
+    if count > 0:
+        current_measurement = {
+            's_xy': S_xy,
+            's_yy': S_yy,
+        }
+        group_delay_state.append(current_measurement)
+    else:
+        denormalize_inplace(video_buf, sync_tip_level, blanking_level)
         return video_buf
-        
-    avg_pulse_shape /= float(count)
+
+    rolling_S_xy = np.zeros(pad_len, dtype=np.complex128)
+    rolling_S_yy = np.zeros(pad_len, dtype=np.float64)
+
+    for measurement in group_delay_state:
+        rolling_S_xy += measurement['s_xy']
+        rolling_S_yy += measurement['s_yy']
+
+    # =========================================================================
+    # PART 2: Analytical Advance & Deconvolution
+    # =========================================================================
+    # Dynamically extract the optimal floating-point advance from phase slope
+    advance_float = calculate_optimal_advance(rolling_S_xy, pad_len)
     
-    # --- Step 2: Inverse Deconvolution Model ---
-    reg = np.max(S_yy) * noise_threshold 
-    denom = S_yy + reg
+    # Split into integer video shift and fractional kernel phase-shift
+    int_adv = int(np.round(advance_float))
+    frac_adv = advance_float - int_adv
+    
+    reg = np.max(rolling_S_yy) * noise_threshold 
+    denom = rolling_S_yy + reg
     denom[denom == 0] = 1e-12
-    
-    H_inv = S_xy / denom
+    H_inv = rolling_S_xy / denom
 
-    # --- Step 3: Extract Time-Domain Kernel and Enforce Strict Causality ---
+    # Apply ONLY the fractional sub-sample advance to the kernel in frequency domain.
+    # This securely modifies the filter shape without needing to FFT the whole video buffer.
+    w_full = 2.0 * np.pi * scipy.fft.fftfreq(pad_len)
+    H_inv = H_inv * np.exp(-1j * w_full * frac_adv)
+
+    # IFFT back to time domain
     h_full = scipy.fft.fftshift(scipy.fft.ifft(H_inv).real)
+    
+    # Do NOT roll the kernel here. Center extraction guarantees t=0 anchoring.
     center_full = pad_len // 2
-
-    if fir_length % 2 == 0:
-        fir_length += 1
-        
-    half_fir = fir_length // 2
+    fir_kernel = h_full[center_full - fir_len_half : center_full + fir_len_half + 1].copy()
     
-    # Align $t=0$ precisely to index `half_fir`
-    peak_idx = np.argmax(np.abs(h_full))
-    h_full = np.roll(h_full, center_full - peak_idx)
+    # 1. Enforce strict causality
+    fir_kernel[:fir_len_half] = 0.0
     
-    fir_kernel = h_full[center_full - half_fir : center_full + half_fir + 1].copy()
+    # 2. Base DC normalization
+    fir_kernel[fir_len_half] = 1.0 - np.sum(fir_kernel[fir_len_half + 1:])
 
-    # 1. Zero out negative time (t < 0) to strictly enforce causality.
-    # This completely eliminates pre-shoot and future-looking phase errors.
-    fir_kernel[:half_fir] = 0.0
-
-    # 2. Smooth the causal forward-time tail (t >= 0) to prevent truncation ripples.
-    causal_len = len(fir_kernel) - half_fir
-    causal_window = np.hanning(2 * causal_len - 1)[causal_len - 1:]
-    fir_kernel[half_fir:] *= causal_window
-
-    # 3. Enforce strict DC unity gain (DC = 1.0)
-    fir_sum = np.sum(fir_kernel)
-    if fir_sum != 0.0:
-        fir_kernel /= fir_sum
-
-    # --- Step 4: Apply Strictly Causal Equalization ---
-    video_buf = _apply_global_inverse_eq(
-        video_buf,
-        n_samples,
-        fir_kernel,
-        scale
-    )
-
+    # Collect individual line traces if debug mode is requested
     if debug:
-        corrected_pulse = _apply_global_inverse_eq(
-            avg_pulse_shape,
-            win_size,
-            fir_kernel,
-            1
+        full_win_size = front_porch_len + sync_len + back_porch_len
+        raw_pulses = []
+        corrected_pulses = []
+        line_indices = []
+
+        for line in range(line_start, line_end + 1):
+            start_loc = line * line_length - front_porch_len
+            if start_loc >= 0 and start_loc + full_win_size < n_samples:
+                raw_p = video_buf[start_loc : start_loc + full_win_size].copy()
+                
+                # Apply filter to individual line trace for inspection
+                delayed_p = np.roll(raw_p, int_adv)
+                filtered_p = _apply_global_inverse_eq(delayed_p, full_win_size, fir_kernel)
+                corr_p = np.roll(filtered_p, -int_adv)
+
+                raw_pulses.append(raw_p)
+                corrected_pulses.append(corr_p)
+                line_indices.append(line)
+
+    # =========================================================================
+    # PART 3: Apply Strictly Causal Equalization via Data Integer Shift
+    # =========================================================================
+    video_buf = np.roll(video_buf, int_adv)
+    video_buf = _apply_global_inverse_eq(video_buf, n_samples, fir_kernel)
+    video_buf = np.roll(video_buf, -int_adv)
+
+    if debug and len(raw_pulses) > 0:
+        # Determine average levels from corrected set to construct target overlay
+        all_corr_arr = np.array(corrected_pulses)
+        sync_tip_average, blanking_average = get_levels(all_corr_arr.flatten())
+
+        ideal_debug = build_ideal_hsync_pulse(
+            front_porch_len,
+            sync_len,
+            target_transition,
+            sync_tip_average,
+            blanking_average,
+            full_win_size,
+            phase_delay=-(advance_float+int_adv),
         )
         
-        shared_blank = (blanking_level + blanking_level) / 2.0
-        ideal_debug = build_ideal_step(
-            offset_fall, offset_rise, target_transition,
-            shared_blank, sync_tip_level, shared_blank, win_size
-        )
-        
-        _render_debug_plot(
-            avg_pulse_shape,
-            corrected_pulse,
+        _render_debug_plot_interactive(
+            raw_pulses,
+            corrected_pulses,
             ideal_debug,
             fir_kernel,
-            target_transition
+            advance_float,
+            line_indices,
         )
+
+    denormalize_inplace(video_buf, sync_tip_level, blanking_level)
 
     return video_buf

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -1,30 +1,251 @@
 import numpy as np
 import numba as nb
+from scipy.optimize import curve_fit
 
-"""
-The transient response needs to model the two transitions
-Other noise should be ignored, I only need to model the transient's slope and then fit a response curve to it
-The ringing happens only in the forward direction and it appears to be following an exponential decay, vs. a following a raised cosine slope
-As the pulse progresses through time, it appears to shift very slightly up just before the transition upward,
-then progresses upwards, then overshoots a bit before setting back down exponentially
+# -----------------------------------------------------------------------------
+# 1. PHYSICAL DE-EMPHASIS TRANSIENT MODEL (LEAST SQUARES)
+# -----------------------------------------------------------------------------
+def vhs_deemphasis_transient_model(
+    t,
+    gain,
+    curvature,
+    A_rc,
+    alpha_rc,
+    A_dl,
+    alpha_dl,
+    time_offset,
+):
+    """
+    VHS de-emphasis ringing residual model.
 
-Maybe treat this like an attack / release, where the attack is the beginning slow increase, and the release is the decay at the top
+    The full physical model is:
+        nonlinear edge response
+      + RC settling
+      + delayed limiter ringing
 
-run a few passes to extrapolate the multistage deemphasis passes
-There is a non-linear deemphasis, and a sub deemphasis stage, I need to extrapolate the amount of correction to apply to each stage
+    For correction purposes we only return the residual error
+    relative to the monotonic edge response. This prevents the
+    correction from reshaping the actual transition.
 
-Get the different models for emphasis, fit the hsync pulses to those models, apply deemphasis through luma signal
+    Returns:
+        ringing residual only
+    """
 
-Non-linear filters
+    tp = np.maximum(0.0, t + time_offset)
 
-Perform least squares optimization on the filters for the averaged sync pulse
-Fit the filter parameters to the best parameters that correct the pulse
+    # JVC nonlinear edge response (desired signal component)
+    nonlinear = gain * np.tanh(curvature * tp)
 
-"""
+    # First-order RC settling (desired edge response component)
+    pre_emphasis = A_rc * np.exp(-alpha_rc * tp)
+
+    # Double limiter LPF phase/ringing component (undesired)
+    dl_lpf_effect = -A_dl * tp * np.exp(-alpha_dl * tp)
+
+    # Full modeled transient
+    full_transient = (
+        nonlinear
+        + pre_emphasis
+        + dl_lpf_effect
+    )
+
+    # Remove monotonic edge response.
+    # What remains is the ringing/distortion component only.
+    baseline = nonlinear + pre_emphasis
+
+    ringing_error = full_transient - baseline
+
+    # Force zero before transition
+    ringing_error[(t + time_offset) <= 0] = 0.0
+
+    return ringing_error
+
 
 @nb.njit(cache=True, nogil=True, fastmath=True)
-def apply_tbc_ringing_correction(
-    tbc_video, 
+def _apply_vhs_deemphasis_model(
+    tbc_video,
+    gain_scale,
+    gain,
+    curvature,
+    A_rc,
+    alpha_rc,
+    A_dl,
+    alpha_dl,
+    time_offset,
+    edge_delay,
+):
+    n_samples = len(tbc_video)
+    out = np.empty_like(tbc_video)
+
+    last_edge = -100000.0
+    edge_type = 0
+
+    mid_level = -20.0
+
+    prev = tbc_video[0]
+    out[0] = prev
+
+
+    for i in range(1, n_samples):
+
+        v = tbc_video[i]
+
+        # ---------------------------------------------------------
+        # Same edge detector as debug pulse extraction
+        # ---------------------------------------------------------
+
+        if prev >= mid_level and v < mid_level:
+
+            frac = (prev - mid_level) / max(prev - v, 1e-12)
+
+            last_edge = (i - 1) + frac
+            edge_type = -1
+
+        elif prev <= mid_level and v > mid_level:
+
+            frac = (mid_level - prev) / max(v - prev, 1e-12)
+
+            last_edge = (i - 1) + frac
+            edge_type = 1
+
+        prev = v
+        correction = 0.0
+
+        if last_edge > -99999.0:
+
+            t = i - last_edge - edge_delay
+            tp = t + time_offset
+
+            if tp > 0.0:
+                nonlinear = (
+                    gain *
+                    np.tanh(curvature * tp)
+                )
+
+                rc = (
+                    A_rc *
+                    np.exp(-alpha_rc * tp)
+                )
+
+                dl = (
+                    -A_dl *
+                    tp *
+                    np.exp(-alpha_dl * tp)
+                )
+
+                ringing = nonlinear + rc + dl
+                baseline = nonlinear + rc
+                residual = ringing - baseline
+
+
+                if edge_type < 0:
+                    correction = residual
+
+                else:
+                    correction = -residual
+
+
+
+        out[i] = v - gain_scale * correction
+
+
+    return out
+
+
+# -----------------------------------------------------------------------------
+# 3. DEBUG PLOT RENDERER
+# -----------------------------------------------------------------------------
+def _render_debug_plot(
+    avg_pulse_shape,
+    corrected_pulse,
+    ideal,
+    E_frac_fall,
+    E_frac_rise,
+    correction_applied,
+    blanking_level,
+    sync_tip_level,
+    target_transition
+):
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("Matplotlib is required to render the debug plot.")
+        return
+
+    win_size = len(avg_pulse_shape)
+    fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(14, 12), sharex=True)
+
+    # Top Pane: Before vs. After vs. Fitted Target
+    ax1.plot(avg_pulse_shape, label='Before (Raw Avg Pulse)', color='#d62728', linewidth=1.8)
+    ax1.plot(corrected_pulse, label='After (Fitted VHS De-emphasis Correction)', color='#1f77b4', linewidth=2.2)
+    ax1.plot(ideal, label=f'Target Spec Step (Trans: {target_transition})', color='#7f7f7f', linestyle=':', linewidth=2)
+    ax1.axhline(blanking_level, color='black', alpha=0.3, label='Global Blanking Ref')
+    ax1.axhline(sync_tip_level, color='black', alpha=0.3, label='Global Sync Ref')
+    ax1.set_title("VHS Pulse Structure Comparison: Before vs. After")
+    ax1.legend()
+    ax1.grid(True, alpha=0.4)
+
+    # Middle Pane: Fitted Error Fractional Profiles
+    ax2.plot(E_frac_fall, label='Averaged Fit Fall ($E_{avg}$)', color='purple', linewidth=1.5)
+    ax2.plot(E_frac_rise, label='Averaged Fit Rise ($E_{avg}$)', color='red', linewidth=1.5)
+    ax2.set_title("Least-Squares De-Emphasis Models (DC Offset Removed)")
+    ax2.axhline(0, color='black', alpha=0.3)
+    ax2.legend()
+    ax2.grid(True, alpha=0.4)
+
+    # Bottom Pane: Absolute Correction Amount
+    ax3.plot(correction_applied, label='Correction Delta', color='green', linewidth=1.5)
+    ax3.fill_between(range(win_size), 0, correction_applied, color='green', alpha=0.2)
+    ax3.axhline(0, color='black', alpha=0.3)
+    ax3.set_title("Absolute Correction Amount Applied Across Interval")
+    ax3.legend()
+    ax3.grid(True, alpha=0.4)
+
+    plt.tight_layout()
+    plt.show()
+
+
+def build_ideal_step(
+    measured_center_fall,
+    measured_center_rise,
+    target_transition,
+    local_blank_f,
+    local_sync,
+    local_blank_r,
+    win_size,
+):
+    mid_sync = int(measured_center_fall + (measured_center_rise - measured_center_fall) / 2.0)
+    ideal = np.zeros(win_size, dtype=np.float64)
+    for i in range(win_size):
+        t_fall = float(i) - measured_center_fall
+        t_rise = float(i) - measured_center_rise
+
+        if i <= mid_sync:
+            if t_fall < -target_transition / 2.0:
+                ideal[i] = local_blank_f
+            elif t_fall <= target_transition / 2.0:
+                phase = (t_fall + target_transition / 2.0) / target_transition * np.pi
+                ideal[i] = local_blank_f + (local_sync - local_blank_f) * (1.0 - np.cos(phase)) / 2.0
+            else:
+                ideal[i] = local_sync
+        else:
+            if t_rise < -target_transition / 2.0:
+                ideal[i] = local_sync
+            elif t_rise <= target_transition / 2.0:
+                phase = (t_rise + target_transition / 2.0) / target_transition * np.pi
+                ideal[i] = local_sync + (local_blank_r - local_sync) * (1.0 - np.cos(phase)) / 2.0
+            else:
+                ideal[i] = local_blank_r
+    
+    return ideal
+
+
+
+# -----------------------------------------------------------------------------
+# 4. MAIN CORRECTION FUNCTION
+# -----------------------------------------------------------------------------
+def apply_tbc_vhs_deemphasis_correction(
+    video_buf, 
     line_start, 
     line_end, 
     line_length, 
@@ -33,31 +254,36 @@ def apply_tbc_ringing_correction(
     front_porch_len=15, 
     sync_len=67,         
     back_porch_len=67,   
-    gain_scale=1.0,
-    target_transition=3.3 
+    gain_scale=0.15,
+    target_transition=3.3,
+    debug=False
 ):
-    n_samples = len(tbc_video)
+    video_buf = ((video_buf - sync_tip_level) / (blanking_level - sync_tip_level)) * 40 - 40
+    
+    n_samples = len(video_buf)
     win_size = front_porch_len + sync_len + back_porch_len
     offset_fall = front_porch_len
     offset_rise = front_porch_len + sync_len
 
-    # 1. Extract Full Average Pulse Shape
+    # --- Step 1: Extract Average Pulse Shape ---
     avg_pulse_shape = np.zeros(win_size, dtype=np.float64)
     count = 0
     
     for line in range(line_start, line_end + 1):
         loc = line * line_length
+        # Safely extract window around sample 0 of the current line
         if loc - offset_fall >= 0 and loc + sync_len + back_porch_len < n_samples:
-            for k in range(win_size):
-                avg_pulse_shape[k] += tbc_video[loc - offset_fall + k]
+            avg_pulse_shape += video_buf[loc - offset_fall : loc + sync_len + back_porch_len]
             count += 1
 
     if count > 0:
         avg_pulse_shape /= float(count)
     else:
-        return tbc_video.copy()
+        if debug:
+            print(f"DEBUG: 0 lines matched bounds! Check line_start ({line_start}), line_end ({line_end}), line_length ({line_length}), total samples ({n_samples}).")
+        return video_buf.copy()
 
-    # 2. Dynamic Subpixel Phase Alignment
+    # --- Step 2: Subpixel Phase Alignment ---
     mid_val = (blanking_level + sync_tip_level) / 2.0
     
     measured_center_fall = float(offset_fall)
@@ -79,6 +305,7 @@ def apply_tbc_ringing_correction(
                 measured_center_rise = float(i) + abs(y0) / abs(y1 - y0)
             break
 
+    # --- Step 3: Local Baseline Extraction (Shared Porch DC Offset) ---
     sum_fp, count_fp = 0.0, 0
     for i in range(0, max(1, int(measured_center_fall - 4))):
         sum_fp += avg_pulse_shape[i]
@@ -97,321 +324,198 @@ def apply_tbc_ringing_correction(
         count_bp += 1
     local_blank_r = sum_bp / count_bp if count_bp > 0 else blanking_level
 
+    # Enforce identical DC level across front and back porches
     shared_blank = (local_blank_f + local_blank_r) / 2.0
     local_blank_f = shared_blank
     local_blank_r = shared_blank
 
-    # 3. Build Phase & DC-Aligned Target
-    ideal = np.zeros(win_size, dtype=np.float64)
+    ideal = build_ideal_step(
+        measured_center_fall,
+        measured_center_rise,
+        target_transition,
+        local_blank_f,
+        local_sync,
+        local_blank_r,
+        win_size,
+    )
     mid_sync = int(measured_center_fall + (measured_center_rise - measured_center_fall) / 2.0)
+
+    # --- Step 5: Least-Squares Model Fitting of De-Emphasis Response ---
+
+    x = np.arange(win_size, dtype=np.float64)
+
+    def residual_model_combined(
+        x,
+        gain,
+        curvature,
+        A_rc,
+        alpha_rc,
+        A_dl,
+        alpha_dl,
+        time_offset,
+        transition,
+    ):
+        out = np.zeros_like(x)
+
+        fall_mask = x < win_size
+        rise_mask = x >= win_size
+
+        if np.any(fall_mask):
+            xf = x[fall_mask]
+
+            out[fall_mask] = vhs_deemphasis_transient_model(
+                xf - measured_center_fall,
+                gain,
+                curvature,
+                A_rc,
+                alpha_rc,
+                A_dl,
+                alpha_dl,
+                time_offset,
+            )
+
+        if np.any(rise_mask):
+            xr = x[rise_mask] - win_size
+
+            out[rise_mask] = vhs_deemphasis_transient_model(
+                xr - measured_center_rise,
+                gain,
+                curvature,
+                A_rc,
+                alpha_rc,
+                A_dl,
+                alpha_dl,
+                time_offset,
+            )
+
+        return out
+
+    # Regions to fit
+    t_vec_fall = x - measured_center_fall
+    mask_fall = (t_vec_fall >= -4.0) & (t_vec_fall <= 24.0)
+
+    t_vec_rise = x - measured_center_rise
+    mask_rise = (t_vec_rise >= -4.0) & (t_vec_rise <= 24.0)
     
-    for i in range(win_size):
-        t_fall = float(i) - measured_center_fall
-        t_rise = float(i) - measured_center_rise
+    amp_est = abs(local_sync - local_blank_f)
 
-        if i <= mid_sync: # Falling half
-            if t_fall < -target_transition / 2.0:
-                ideal[i] = local_blank_f
-            elif t_fall <= target_transition / 2.0:
-                phase = (t_fall + target_transition / 2.0) / target_transition * np.pi
-                ideal[i] = local_blank_f + (local_sync - local_blank_f) * (1.0 - np.cos(phase)) / 2.0
-            else:
-                ideal[i] = local_sync
-        else:             # Rising half
-            if t_rise < -target_transition / 2.0:
-                ideal[i] = local_sync
-            elif t_rise <= target_transition / 2.0:
-                phase = (t_rise + target_transition / 2.0) / target_transition * np.pi
-                ideal[i] = local_sync + (local_blank_r - local_sync) * (1.0 - np.cos(phase)) / 2.0
-            else:
-                ideal[i] = local_blank_r
+    # Initial guesses utilizing the Double Limiter LPF injection
+    p0 = [
+        0.0,               # gain
+        0.35,              # curvature
+        amp_est * 0.4,     # A_rc (RC decay amplitude)
+        0.8,               # alpha_rc (RC decay rate)
+        amp_est * 0.2,     # A_dl (Double Limiter LPF amplitude)
+        0.3,               # alpha_dl (Double Limiter LPF decay rate)
+        0.0,               # time_offset
+        target_transition,
+    ]
 
-    # 4. Split and Isolate Asymmetric Deficit Profiles
-    error = avg_pulse_shape - ideal
-    
-    error_fall = np.zeros(win_size, dtype=np.float64)
-    error_rise = np.zeros(win_size, dtype=np.float64)
-    
-    tail_len = 18.0
-    fade_len = 6.0
-    
-    for i in range(win_size):
-        dist_f = float(i) - measured_center_fall
-        if dist_f < -tail_len - fade_len: w_f = 0.0
-        elif dist_f < -tail_len: w_f = (dist_f + tail_len + fade_len) / fade_len
-        elif dist_f < tail_len: w_f = 1.0
-        elif dist_f < tail_len + fade_len: w_f = 1.0 - (dist_f - tail_len) / fade_len
-        else: w_f = 0.0
-        
-        error_fall[i] = error[i] * w_f
-        
-        dist_r = float(i) - measured_center_rise
-        if dist_r < -tail_len - fade_len: w_r = 0.0
-        elif dist_r < -tail_len: w_r = (dist_r + tail_len + fade_len) / fade_len
-        elif dist_r < tail_len: w_r = 1.0
-        elif dist_r < tail_len + fade_len: w_r = 1.0 - (dist_r - tail_len) / fade_len
-        else: w_r = 0.0
-        
-        error_rise[i] = error[i] * w_r
+    bounds = (
+        [
+            0.0,    # gain
+            0.01,   # curvature
+            0.0,    # A_rc
+            0.1,    # alpha_rc
+            0.0,    # A_dl
+            0.05,   # alpha_dl
+            -12.0,  # time_offset
+            1.0,    # transition
+        ],
+        [
+            50.0,   # gain
+            5.0,    # curvature
+            50.0,   # A_rc
+            5.0,    # alpha_rc
+            50.0,   # A_dl
+            0.5,    # alpha_dl
+            12.0,    # time_offset
+            25.0,   # transition
+        ],
+    )
 
-    amp_fall = local_sync - local_blank_f
-    amp_rise = local_blank_r - local_sync
-    E_frac_fall = error_fall / (amp_fall if amp_fall != 0 else 1.0)
-    E_frac_rise = error_rise / (amp_rise if amp_rise != 0 else 1.0)
+    fit_x = np.concatenate((x[mask_fall], x[mask_rise] + win_size))
 
-    # Remove DC bias from the error fraction so correction doesn't shift baseline
-    E_frac_fall -= np.mean(E_frac_fall)
-    E_frac_rise -= np.mean(E_frac_rise)
+    residual = avg_pulse_shape - ideal
+    fit_y = np.concatenate((
+        residual[mask_fall],
+        -residual[mask_rise],
+    ))
 
-    # 5. Macro-State Tracker
-    smooth_len = int(max(4.0, target_transition * 2.5))
-    half_w = smooth_len // 2
-    sig_sm = np.empty(n_samples, dtype=np.float64)
-    
-    run_sum = 0.0
-    for i in range(smooth_len):
-        idx = max(0, min(n_samples - 1, i - half_w))
-        run_sum += tbc_video[idx]
-        
-    for i in range(n_samples):
-        sig_sm[i] = run_sum / smooth_len
-        sub_idx = max(0, i - half_w)
-        add_idx = min(n_samples - 1, i + half_w + 1)
-        run_sum += tbc_video[add_idx] - tbc_video[sub_idx]
-
-    state = np.zeros(n_samples, dtype=np.float64)
-    curr = 0.5
-    thresh = abs(amp_fall) * 0.03
-    for i in range(1, n_samples):
-        dx = sig_sm[i] - sig_sm[i-1]
-        if dx > thresh: curr = 1.0
-        elif dx < -thresh: curr = 0.0
-        state[i] = curr
-
-    state_sm = np.empty(n_samples, dtype=np.float64)
-    run_sum = 0.0
-    for i in range(smooth_len):
-        idx = max(0, min(n_samples - 1, i - half_w))
-        run_sum += state[idx]
-        
-    for i in range(n_samples):
-        state_sm[i] = run_sum / smooth_len
-        sub_idx = max(0, i - half_w)
-        add_idx = min(n_samples - 1, i + half_w + 1)
-        run_sum += state_sm[add_idx] - state_sm[sub_idx] if add_idx < n_samples else 0.0
-
-    # 6. Dual-Profile Linear Convolution
-    out = np.empty_like(tbc_video)
-    
-    for i in range(n_samples):
-        corr_fall = 0.0
-        corr_rise = 0.0
-        
-        for k in range(1, win_size):
-            tap_f = i + offset_fall - k
-            if 1 <= tap_f < n_samples:
-                dx = tbc_video[tap_f] - tbc_video[tap_f - 1]
-                corr_fall += dx * E_frac_fall[k]
-                
-        for k in range(1, win_size):
-            tap_r = i + offset_rise - k
-            if 1 <= tap_r < n_samples:
-                dx = tbc_video[tap_r] - tbc_video[tap_r - 1]
-                corr_rise += dx * E_frac_rise[k]
-                
-        w = state_sm[i]
-        correction = corr_rise * w + corr_fall * (1.0 - w)
-        out[i] = tbc_video[i] - (correction * gain_scale)
-        
-    return out
-
-
-
-def plot_tbc_correction_debug(
-    tbc_video,
-    line_start,
-    line_end,
-    line_length,
-    blanking_level,
-    sync_tip_level,
-    front_porch_len=15, 
-    sync_len=67,
-    back_porch_len=67,
-    gain_scale=1.0,
-    target_transition=3.3
-):
     try:
-        import matplotlib.pyplot as plt
-    except ImportError:
-        print("Matplotlib is required to render the debug plot.")
-        return
+        popt, _ = curve_fit(
+            residual_model_combined,
+            fit_x,
+            fit_y,
+            p0=p0,
+            bounds=bounds,
+            maxfev=10000,
+        )
 
-    n_samples = len(tbc_video)
-    win_size = front_porch_len + sync_len + back_porch_len
-    offset_fall = front_porch_len
-    offset_rise = front_porch_len + sync_len
+        gain, curvature, A_rc, alpha_rc, A_dl, alpha_dl, time_offset, transition = popt
+        edge_delay = -transition
 
-    # 1. Extract Average Pulse Shape Internally
-    avg_pulse_shape = np.zeros(win_size, dtype=np.float64)
-    count = 0
-    for line in range(line_start, line_end + 1):
-        loc = line * line_length
-        if loc - offset_fall >= 0 and loc + sync_len + back_porch_len < n_samples:
-            avg_pulse_shape += tbc_video[loc - offset_fall : loc + sync_len + back_porch_len]
-            count += 1
+    except Exception as e:
+        print("combined fit failed:", e)
 
-    if count > 0: avg_pulse_shape /= float(count)
-    else: return
 
-    # 2. Dynamic Subpixel Phase Alignment
-    mid_val = (blanking_level + sync_tip_level) / 2.0
-    
-    measured_center_fall = float(offset_fall)
-    for i in range(win_size - 1):
-        if avg_pulse_shape[i] >= mid_val >= avg_pulse_shape[i+1]:
-            y0 = avg_pulse_shape[i] - mid_val
-            y1 = avg_pulse_shape[i+1] - mid_val
-            if (y0 - y1) != 0.0:
-                measured_center_fall = float(i) + abs(y0) / abs(y0 - y1)
-            break
+    if debug:
+        corrected_pulse = avg_pulse_shape.copy()
 
-    measured_center_rise = float(offset_rise)
-    search_start = int(measured_center_fall + (sync_len // 2))
-    for i in range(search_start, win_size - 1):
-        if avg_pulse_shape[i] <= mid_val <= avg_pulse_shape[i+1]:
-            y0 = avg_pulse_shape[i] - mid_val
-            y1 = avg_pulse_shape[i+1] - mid_val
-            if (y1 - y0) != 0.0:
-                measured_center_rise = float(i) + abs(y0) / abs(y1 - y0)
-            break
+        fall = vhs_deemphasis_transient_model(
+            t_vec_fall,
+            gain,
+            curvature,
+            A_rc,
+            alpha_rc,
+            A_dl,
+            alpha_dl,
+            time_offset,
+        )
 
-    # 3. Measure Local Baseline Levels
-    sum_fp, count_fp = 0.0, 0
-    for i in range(0, max(1, int(measured_center_fall - 4))):
-        sum_fp += avg_pulse_shape[i]
-        count_fp += 1
-    local_blank_f = sum_fp / count_fp if count_fp > 0 else blanking_level
-    
-    sum_sync, count_sync = 0.0, 0
-    for i in range(int(measured_center_fall + 12), int(measured_center_rise - 12)):
-        sum_sync += avg_pulse_shape[i]
-        count_sync += 1
-    local_sync = sum_sync / count_sync if count_sync > 0 else sync_tip_level
-    
-    sum_bp, count_bp = 0.0, 0
-    for i in range(int(measured_center_rise + 4), win_size):
-        sum_bp += avg_pulse_shape[i]
-        count_bp += 1
-    local_blank_r = sum_bp / count_bp if count_bp > 0 else blanking_level
+        rise = vhs_deemphasis_transient_model(
+            t_vec_rise,
+            gain,
+            curvature,
+            A_rc,
+            alpha_rc,
+            A_dl,
+            alpha_dl,
+            time_offset,
+        )
 
-    shared_blank = (local_blank_f + local_blank_r) / 2.0
-    local_blank_f = shared_blank
-    local_blank_r = shared_blank
+        for i in range(win_size):
+            if i <= mid_sync:
+                corrected_pulse[i] -= fall[i]
+            else:
+                corrected_pulse[i] += rise[i]
 
-    # 4. Synthesize Phase & DC-Aligned Target
-    ideal = np.zeros(win_size, dtype=np.float64)
-    mid_sync = int(measured_center_fall + (measured_center_rise - measured_center_fall) / 2.0)
+        correction_applied = corrected_pulse - avg_pulse_shape
 
-    for i in range(win_size):
-        t_fall = float(i) - measured_center_fall
-        t_rise = float(i) - measured_center_rise
-        
-        if i <= mid_sync:
-            if t_fall < -target_transition / 2.0: 
-                ideal[i] = local_blank_f
-            elif t_fall <= target_transition / 2.0:
-                ideal[i] = local_blank_f + (local_sync - local_blank_f) * (1.0 - np.cos((t_fall + target_transition / 2.0) / target_transition * np.pi)) / 2.0
-            else: 
-                ideal[i] = local_sync
-        else:
-            if t_rise < -target_transition / 2.0: 
-                ideal[i] = local_sync
-            elif t_rise <= target_transition / 2.0:
-                ideal[i] = local_sync + (local_blank_r - local_sync) * (1.0 - np.cos((t_rise + target_transition / 2.0) / target_transition * np.pi)) / 2.0
-            else: 
-                ideal[i] = local_blank_r
+        _render_debug_plot(
+            avg_pulse_shape,
+            corrected_pulse,
+            ideal,
+            fall,
+            rise,
+            correction_applied,
+            0,
+            -40,
+            target_transition
+        )
 
-    # 5. Split Asymmetric Profiles
-    error = avg_pulse_shape - ideal
-    error_fall = np.zeros(win_size, dtype=np.float64)
-    error_rise = np.zeros(win_size, dtype=np.float64)
-    
-    tail_len = 18.0
-    fade_len = 6.0
-    
-    for i in range(win_size):
-        dist_f = float(i) - measured_center_fall
-        if dist_f < -tail_len - fade_len: w_f = 0.0
-        elif dist_f < -tail_len: w_f = (dist_f + tail_len + fade_len) / fade_len
-        elif dist_f < tail_len: w_f = 1.0
-        elif dist_f < tail_len + fade_len: w_f = 1.0 - (dist_f - tail_len) / fade_len
-        else: w_f = 0.0
-        error_fall[i] = error[i] * w_f
-        
-        dist_r = float(i) - measured_center_rise
-        if dist_r < -tail_len - fade_len: w_r = 0.0
-        elif dist_r < -tail_len: w_r = (dist_r + tail_len + fade_len) / fade_len
-        elif dist_r < tail_len: w_r = 1.0
-        elif dist_r < tail_len + fade_len: w_r = 1.0 - (dist_r - tail_len) / fade_len
-        else: w_r = 0.0
-        error_rise[i] = error[i] * w_r
+    video_buf = _apply_vhs_deemphasis_model(
+        video_buf,
+        gain_scale,
+        gain,
+        curvature,
+        A_rc,
+        alpha_rc,
+        A_dl,
+        alpha_dl,
+        time_offset,
+        edge_delay
+    )
 
-    amp_fall = local_sync - local_blank_f
-    amp_rise = local_blank_r - local_sync
-    E_frac_fall = error_fall / (amp_fall if amp_fall != 0 else 1.0)
-    E_frac_rise = error_rise / (amp_rise if amp_rise != 0 else 1.0)
-
-    # Remove DC bias from the error fraction so correction doesn't shift baseline
-    E_frac_fall -= np.mean(E_frac_fall)
-    E_frac_rise -= np.mean(E_frac_rise)
-
-    # 6. Simulate State-Blended Correction
-    corrected = np.empty_like(avg_pulse_shape)
-    pad_shape = np.pad(avg_pulse_shape, (win_size, win_size), mode='edge')
-
-    for i in range(win_size):
-        corr_fall = 0.0
-        corr_rise = 0.0
-        padded_i = i + win_size
-        
-        for k in range(1, win_size):
-            tap_f = padded_i + offset_fall - k
-            corr_fall += (pad_shape[tap_f] - pad_shape[tap_f - 1]) * E_frac_fall[k]
-            
-            tap_r = padded_i + offset_rise - k
-            corr_rise += (pad_shape[tap_r] - pad_shape[tap_r - 1]) * E_frac_rise[k]
-
-        w = 1.0 if i > mid_sync else 0.0
-        correction = corr_rise * w + corr_fall * (1.0 - w)
-        corrected[i] = pad_shape[padded_i] - (correction * gain_scale)
-
-    correction_applied = avg_pulse_shape - corrected
-
-    # 7. Render 3-Pane Plot
-    fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(14, 12), sharex=True)
-
-    ax1.plot(avg_pulse_shape, label='Before (Raw Avg Pulse)', color='#d62728', linewidth=1.8)
-    ax1.plot(corrected, label='After (Dual-FIR Corrected)', color='#1f77b4', linewidth=2.2)
-    ax1.plot(ideal, label=f'Local DC & Phase-Aligned Target Spec', color='#7f7f7f', linestyle=':', linewidth=2)
-    ax1.axhline(blanking_level, color='black', alpha=0.3, label='Global Blanking Ref')
-    ax1.axhline(sync_tip_level, color='black', alpha=0.3, label='Global Sync Ref')
-    ax1.set_title("4Fsc Localized Pulse Structure Comparison")
-    ax1.legend()
-    ax1.grid(True, alpha=0.4)
-
-    ax2.plot(E_frac_fall, label='Falling Deficit ($E_{fall}$)', color='purple', linewidth=1.5)
-    ax2.plot(E_frac_rise, label='Rising Deficit ($E_{rise}$)', color='orange', linewidth=1.5)
-    ax2.set_title("Split Filtering Models (DC Bias Eliminated)")
-    ax2.axhline(0, color='black', alpha=0.3)
-    ax2.legend()
-    ax2.grid(True, alpha=0.4)
-
-    ax3.plot(correction_applied, label='Correction Delta', color='green', linewidth=1.5)
-    ax3.fill_between(range(win_size), 0, correction_applied, color='green', alpha=0.2)
-    ax3.axhline(0, color='black', alpha=0.3)
-    ax3.set_title("Absolute Correction Amount (Transients Only)")
-    ax3.legend()
-    ax3.grid(True, alpha=0.4)
-
-    plt.tight_layout()
-    plt.show()
+    # denomalized data # TODO, run this after the data is already denomalized
+    return ((video_buf + 40) / 40) * (blanking_level - sync_tip_level) + sync_tip_level

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -517,7 +517,7 @@ def derive_lti_parameters(fir_kernel, noise_threshold, max_gain):
 # ADAPTIVE LTI PROCESSING KERNEL
 # -----------------------------------------------------------------------------
 @nb.njit(cache=True, fastmath=True)
-def apply_adaptive_lti(video_buf, gain, threshold):
+def apply_adaptive_luma_transient_improvement(video_buf, gain, threshold):
     """
     Applies non-linear LTI using parameters derived from the group delay kernel.
     """

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -16,52 +16,87 @@ FSC_RATIO = 4 # sets ratio of FFT length to fsc
 
 FIR_LEN = 127
 FFT_LEN = 512
+DELAY_OFFSET = FIR_LEN // 2  # Anchors the causal peak
 
-def _make_inverse_eq(fir_len):
+
+def _make_interpolated_inverse_eq(fir_len, delay_offset):
     @nb.njit(
-        "float32[:](float32[::1], int64, float32[::1])",
+        "float32[:](float32[::1], float32[::1], int64, float32[::1], float32[::1])",
         cache=True,
         nogil=True,
         fastmath=True
     )
-    def _apply_inverse_eq(picture, n_samples, causal_kernel):
-        causal_kernel = causal_kernel[::-1].copy()
-        out = np.empty(n_samples, np.float32)
+    def _apply_interpolated_inverse_eq(picture_raw, picture_clean, n_samples, kernel_a, kernel_b):
+        out = np.empty(n_samples, dtype=np.float32)
+        first = picture_clean[0]
+        last = picture_clean[n_samples - 1]
 
-        first = picture[0]
+        # Pre-allocate tap buffer for the per-pixel interpolated kernel
+        h_interp = np.empty(fir_len, dtype=np.float32)
 
-        for i in nb.prange(n_samples):
+        for k in range(n_samples):
+            # 1. Calculate linear interpolation factor alpha along the line (0.0 to 1.0)
+            alpha = np.float32(k) / np.float32(n_samples - 1) if n_samples > 1 else np.float32(0.0)
+            one_minus_alpha = np.float32(1.0) - alpha
+
+            # 2. Interpolate FIR taps directly for current pixel k
+            for j in range(fir_len):
+                h_interp[j] = one_minus_alpha * kernel_a[j] + alpha * kernel_b[j]
+
+            # 3. Apply the causal filter sweep for pixel k
+            read_head = k + delay_offset
             acc = 0.0
 
-            if i < fir_len - 1:
-                start = fir_len - 1 - i
+            for j in range(fir_len):
+                idx = read_head - j
+                
+                # Boundary clamping
+                if idx < 0:
+                    val = first
+                elif idx >= n_samples:
+                    val = last
+                else:
+                    val = picture_clean[idx]
 
-                for j in range(start, fir_len):
-                    acc += picture[i - fir_len + 1 + j] * causal_kernel[j]
+                acc += val * h_interp[j]
 
-                for j in range(start):
-                    acc += first * causal_kernel[j]
-
-            else:
-                base = i - fir_len + 1
-
-                for j in range(fir_len):
-                    acc += picture[base + j] * causal_kernel[j]
-
-            out[i] = acc
+            # 4. Delta Injection
+            delta = acc - picture_clean[k]
+            out[k] = picture_raw[k] + delta
 
         return out
-    return _apply_inverse_eq
+    return _apply_interpolated_inverse_eq
 
-_apply_inverse_eq = _make_inverse_eq(FIR_LEN)
+_apply_interpolated_inverse_eq = _make_interpolated_inverse_eq(FIR_LEN, DELAY_OFFSET)
+
+
+@nb.njit("float32[:](float32[::1], float32[::1])", cache=True, nogil=True, fastmath=True)
+def _apply_zero_phase_fir(picture, fir_kernel):
+    n_samples = len(picture)
+    fir_len = len(fir_kernel)
+    half_fir = fir_len // 2
+    out = np.empty(n_samples, np.float32)
+    
+    first = picture[0]
+    last = picture[n_samples - 1]
+
+    for i in nb.prange(n_samples):
+        acc = 0.0
+        for j in range(fir_len):
+            idx = i + j - half_fir
+            if idx < 0:
+                val = first
+            elif idx >= n_samples:
+                val = last
+            else:
+                val = picture[idx]
+            acc += val * fir_kernel[j]
+        out[i] = acc
+        
+    return out
 
 
 def _build_fsc_mask(n, width_bins=3):
-    """
-    Creates a soft mask around the color subcarrier.
-    Returns values 0..1.
-    """
-
     freq = np.abs(np.fft.fftfreq(n))
     fsc = 1.0 / FSC_RATIO
 
@@ -73,8 +108,8 @@ def _build_fsc_mask(n, width_bins=3):
     mask[inside] = 0.5 * (
         1.0 + np.cos(np.pi * dist[inside] / width)
     )
-
     return mask
+
 
 @nb.njit(cache=True, nogil=True, fastmath=True)
 def _build_ideal_step(
@@ -95,7 +130,6 @@ def _build_ideal_step(
             ideal[i] = local_sync + (local_blank_r - local_sync) * (1.0 - np.cos(phase)) / 2.0
         else:
             ideal[i] = local_blank_r
-    
     return ideal
 
 
@@ -109,7 +143,6 @@ def _build_ideal_hsync_pulse(
     win_size,
     phase_delay=0.0,
 ):
-    """Generates an ideal full H-Sync pulse aligned with the signal's phase delay."""
     ideal = np.full(win_size, blanking_level, dtype=np.float64)
     
     center_fall = float(front_porch_len) + phase_delay
@@ -119,14 +152,11 @@ def _build_ideal_hsync_pulse(
         t_fall = float(i) - center_fall
         t_rise = float(i) - center_rise
         
-        # Falling Edge (Front Porch -> Sync Tip)
         if t_fall >= -target_transition / 2.0 and t_fall <= target_transition / 2.0:
             phase = (t_fall + target_transition / 2.0) / target_transition * np.pi
             ideal[i] = blanking_level - (blanking_level - sync_level) * (1.0 - np.cos(phase)) / 2.0
-        # Sync Tip Region
         elif t_fall > target_transition / 2.0 and t_rise < -target_transition / 2.0:
             ideal[i] = sync_level
-        # Rising Edge (Sync Tip -> Back Porch)
         elif t_rise >= -target_transition / 2.0 and t_rise <= target_transition / 2.0:
             phase = (t_rise + target_transition / 2.0) / target_transition * np.pi
             ideal[i] = sync_level + (blanking_level - sync_level) * (1.0 - np.cos(phase)) / 2.0
@@ -139,7 +169,6 @@ def _normalize_inplace(video_buf, sync_tip_level, blanking_level):
     scale = 2.0 / (blanking_level - sync_tip_level)
     for i in range(video_buf.size):
         video_buf[i] = (video_buf[i] - sync_tip_level) * scale - 1.0
-
     return video_buf
 
 
@@ -148,7 +177,6 @@ def _denormalize_inplace(video_buf, sync_tip_level, blanking_level):
     scale = 0.5 * (blanking_level - sync_tip_level)
     for i in range(video_buf.size):
         video_buf[i] = (video_buf[i] + 1.0) * scale + sync_tip_level
-
     return video_buf
 
 
@@ -161,54 +189,13 @@ def _get_levels(data):
     blanking_average = np.median(part[-k:])
     return sync_tip_average, blanking_average
 
-def _suppress_color_carrier(x, harmonics=0):
-    """
-    Remove a coherent carrier and its harmonics using quadrature projection.
-
-    Parameters
-    ----------
-    x : ndarray
-        Real signal.
-    harmonics : int
-        Number of harmonics to suppress, including the fundamental.
-    """
-
-    n = np.arange(len(x))
-    y = x.copy()
-
-    for h in range(1, harmonics + 1):
-        phase = 2.0 * np.pi * h * n / FSC
-
-        c = np.cos(phase)
-        s = np.sin(phase)
-
-        cc = np.dot(c, c)
-        ss = np.dot(s, s)
-
-        if cc > 1e-12:
-            ac = np.dot(y, c) / cc
-            y -= ac * c
-
-        if ss > 1e-12:
-            bs = np.dot(y, s) / ss
-            y -= bs * s
-
-    return y
 
 def _suppress_color_carrier_fft(samples):
-    """
-    Remove a pure Fs/4 carrier using quadrature estimation.
-    """
-
     out = samples.copy()
-
-    # Accumulate I/Q over the whole pulse
     i = 0.0
     q = 0.0
-
     for n, x in enumerate(samples):
         phase = (n & 3)
-
         if phase == 0:
             i += x
         elif phase == 2:
@@ -217,15 +204,13 @@ def _suppress_color_carrier_fft(samples):
             q -= x
         else:
             q += x
-
-    # Remove estimated carrier
+            
     scale = 2.0 / len(samples)
     i *= scale
     q *= scale
-
+    
     for n in range(len(out)):
         phase = n & 3
-
         if phase == 0:
             out[n] -= i
         elif phase == 1:
@@ -234,24 +219,36 @@ def _suppress_color_carrier_fft(samples):
             out[n] -= -i
         else:
             out[n] -= q
-
     return out
 
-def _taper_delta_fft(fft):
-    freqs = np.abs(np.fft.fftfreq(len(fft)))
 
-    mask = np.ones_like(freqs)
+def _build_causal_fir_from_spectrum(H_inv, fft_len, fir_len, delay_offset):
+    freqs_norm = np.abs(np.fft.fftfreq(fft_len))
+    
+    taper = np.clip((0.45 - freqs_norm) / 0.10, 0.0, 1.0)
+    taper_smooth = 0.5 * (1.0 - np.cos(np.pi * taper)) 
+    H_inv_tapered = H_inv * taper_smooth
 
-    start = 0.20   # 1 fsc
-    end = 0.25     # Nyquist (2 fsc)
+    omega = 2.0 * np.pi * np.fft.fftfreq(fft_len)
+    causal_phase_shift = np.exp(-1j * omega * delay_offset)
+    H_inv_tapered *= causal_phase_shift
 
-    idx = (freqs >= start) & (freqs <= end)
+    h_time = scipy.fft.ifft(H_inv_tapered).real
+    fir_kernel = np.zeros(fir_len, dtype=np.float32)
+    fir_kernel[:] = h_time[0 : fir_len]
 
-    t = (freqs[idx] - start) / (end - start)
-    mask[idx] = 0.5 * (1.0 + np.cos(np.pi * t))
-    mask[freqs > end] = 0.0
+    fir_kernel[0 : delay_offset] = 0.0
 
-    return fft * mask
+    tail_len = fir_len - delay_offset
+    tail_window = scipy.signal.windows.tukey(tail_len * 2, alpha=0.5)[tail_len:]
+    fir_kernel[delay_offset : fir_len] *= tail_window
+
+    kernel_sum = np.sum(fir_kernel)
+    if abs(kernel_sum) > 1e-12:
+        fir_kernel /= kernel_sum
+
+    return fir_kernel
+
 
 # -----------------------------------------------------------------------------
 # Group Delay Correction
@@ -268,52 +265,97 @@ def apply_inverse_equalization(
     back_porch_len,
     target_transition,
     group_delay_state,
-    noise_threshold=1, # TODO, determine automatically; set frequency scaling based on noise floor, or MAD between frequencies
+    noise_threshold=1,
+    interpolate_amplitude=True,
+    interpolate_phase=True,
+    interpolate_time=True, # TODO: allow interpolation to be disabled for speed
     debug=False
 ):
     _normalize_inplace(video_buf, sync_tip_level, blanking_level)
-
     n_samples = len(video_buf)
 
     # =========================================================================
-    # PART 1: Calculate Pulse Shape & Spectra (Rising Edge Only)
+    # PART 0: Measure the Constant Noise Floor
     # =========================================================================
+    noise_power_sum = np.zeros(FFT_LEN, dtype=np.float64)
+    noise_count = 0
+    
+    sync_tip_flat_len = int(sync_len * 0.4)
+    win_noise = scipy.signal.windows.hann(sync_tip_flat_len)
+    start_idx_noise = (FFT_LEN - sync_tip_flat_len) // 2
+
+    for line in range(line_start, line_end + 1):
+        loc = line * line_length
+        tip_start = loc + front_porch_len + int(sync_len * 0.3)
+        if tip_start >= 0 and tip_start + sync_tip_flat_len < n_samples:
+            tip_chunk = video_buf[tip_start : tip_start + sync_tip_flat_len]
+            d_tip = np.gradient(tip_chunk) * win_noise
+            
+            pad_tip = np.zeros(FFT_LEN, dtype=np.float64)
+            pad_tip[start_idx_noise : start_idx_noise + sync_tip_flat_len] = d_tip
+            
+            noise_power_sum += np.abs(scipy.fft.fft(pad_tip))**2
+            noise_count += 1
+
+    if noise_count > 0:
+        noise_mag_profile = np.sqrt(noise_power_sum / noise_count) * 1.5
+    else:
+        noise_mag_profile = np.zeros(FFT_LEN, dtype=np.float64)
+
+    # =========================================================================
+    # PARTS 1, 2, 3: Per-Line Wiener Deconvolution with 1000-Pulse Ring Buffer
+    # =========================================================================
+    MAX_HISTORY_PULSES = 1000
+
+    if len(group_delay_state) == 0:
+        state_dict = {
+            's_xy_history': np.zeros((MAX_HISTORY_PULSES, FFT_LEN), dtype=np.complex128),
+            's_yy_history': np.zeros((MAX_HISTORY_PULSES, FFT_LEN), dtype=np.float64),
+            'ptr': 0,
+            'count': 0
+        }
+        group_delay_state.append(state_dict)
+    else:
+        state_dict = group_delay_state[0]
+        if 's_xy_history' not in state_dict:
+            state_dict['s_xy_history'] = np.zeros((MAX_HISTORY_PULSES, FFT_LEN), dtype=np.complex128)
+            state_dict['s_yy_history'] = np.zeros((MAX_HISTORY_PULSES, FFT_LEN), dtype=np.float64)
+            state_dict['ptr'] = 0
+            state_dict['count'] = 0
+
     pre_rise_samples = int(np.round(0.25 * sync_len))
     win_size = pre_rise_samples + back_porch_len
     win_size -= win_size % 4 
     offset_rise = pre_rise_samples
-
-    win = scipy.signal.windows.tukey(win_size, alpha=0.05)
     start_idx = (FFT_LEN - win_size) // 2
+
+    freqs = np.abs(np.fft.fftfreq(FFT_LEN))
+    hf_mask = freqs > 0.35  
+
     count = 0
-
-    S_xy = np.zeros(FFT_LEN, dtype=np.complex128)
-    S_xx = np.zeros(FFT_LEN, dtype=np.complex128)
-    S_yy = np.zeros(FFT_LEN, dtype=np.float64)
-
-    rolling_S_xy = np.zeros(FFT_LEN, dtype=np.complex128)
-    rolling_S_xx = np.zeros(FFT_LEN, dtype=np.complex128)
-    rolling_S_yy = np.zeros(FFT_LEN, dtype=np.float64)
-
-    # get previous iteration's rolling averages
-    for measurement in group_delay_state:
-        rolling_S_xy += measurement['s_xy']
-        rolling_S_xx += measurement['s_xx']
-        rolling_S_yy += measurement['s_yy']
+    raw_line_spectra = []
+    raw_line_rises = []
+    
+    default_kernel = np.zeros(FIR_LEN, dtype=np.float32)
+    default_kernel[DELAY_OFFSET] = 1.0
+    last_valid_kernel = default_kernel
+    last_valid_h_inv = np.ones(FFT_LEN, dtype=np.complex128)
 
     for line in range(line_start, line_end + 1):
         loc = line * line_length
         start_loc = loc + sync_len - pre_rise_samples
+        
+        S_xy = np.zeros(FFT_LEN, dtype=np.complex128)
+        S_yy = np.zeros(FFT_LEN, dtype=np.float64)
+        measured_center_rise = float(offset_rise)
+        is_outlier = False
+
         if start_loc >= 0 and start_loc + win_size < n_samples:
             pulse = video_buf[start_loc : start_loc + win_size]
-            # pulse = _suppress_color_carrier(pulse)
 
             measured_sync_tip_level, measured_blanking_level = _get_levels(pulse)
             mid_val = measured_sync_tip_level + (measured_blanking_level - measured_sync_tip_level) / 2.0
 
-            count += 1
-            
-            measured_center_rise = float(offset_rise)
             for i in range(win_size - 1):
                 if pulse[i] <= mid_val <= pulse[i+1]:
                     y0 = pulse[i] - mid_val
@@ -341,127 +383,180 @@ def apply_inverse_equalization(
                 local_sync, local_blank_r, win_size
             )
 
-            d_ideal = np.gradient(ideal_for_fir) * win
-            d_pulse = np.gradient(pulse) * win
+            peak_idx = int(measured_center_rise)
+            transient_win = np.zeros(win_size, dtype=np.float64)
+            
+            if peak_idx > 0:
+                transient_win[0:peak_idx] = 0.5 * (1.0 - np.cos(np.pi * np.arange(peak_idx) / peak_idx))
+            
+            ringing_tail_len = int(target_transition * 5.0) 
+            right_width = min(ringing_tail_len, win_size - peak_idx)
+            
+            if right_width > 0:
+                transient_win[peak_idx : peak_idx + right_width] = 0.5 * (1.0 + np.cos(np.pi * np.arange(right_width) / right_width))
+
+            d_ideal = np.gradient(ideal_for_fir) * transient_win
+            d_pulse = np.gradient(pulse) * transient_win
             
             pad_ideal = np.zeros(FFT_LEN, dtype=np.float64)
             pad_pulse = np.zeros(FFT_LEN, dtype=np.float64)
             pad_ideal[start_idx : start_idx + win_size] = d_ideal
             pad_pulse[start_idx : start_idx + win_size] = d_pulse
 
-            # measure pulse's actual frequency response
             Y = scipy.fft.fft(pad_pulse)
-            # measure the pulse's expected frequency response, given the sync pulse parameters
             X = scipy.fft.fft(pad_ideal)
 
-            # ONLY accumulate here. No Wiener math inside this loop.
-            S_xy += X * np.conj(Y)
-            S_xx += np.abs(X)**2
-            S_yy += np.abs(Y)**2
+            current_s_xy = X * np.conj(Y)
+            current_s_yy = np.abs(Y)**2
 
-    # Save current chunk to state (Added missing 's_yy')
-    if count > 0:
-        current_measurement = {
-            's_xy': S_xy,
-            's_xx': S_xx,
-            's_yy': S_yy,  
-        }
-        group_delay_state.append(current_measurement)
-    else:
+            # --- 1000-PULSE RING BUFFER OUTLIER REJECTION ---
+            if state_dict['count'] > (525 / 2): # roughly a field's work of lines in order to honor the rolling average
+                historical_mean_s_yy = np.mean(state_dict['s_yy_history'][:state_dict['count']], axis=0)
+                spectral_distance = np.mean(np.abs(current_s_yy - historical_mean_s_yy))
+                avg_power_magnitude = np.mean(historical_mean_s_yy) + 1e-12
+                relative_deviation = spectral_distance / avg_power_magnitude
+                
+                if relative_deviation > (0.4 * noise_threshold + 0.20):
+                    is_outlier = True
+
+            if not is_outlier:
+                ptr = state_dict['ptr']
+                state_dict['s_xy_history'][ptr] = current_s_xy
+                state_dict['s_yy_history'][ptr] = current_s_yy
+                state_dict['ptr'] = (ptr + 1) % MAX_HISTORY_PULSES
+                state_dict['count'] = min(MAX_HISTORY_PULSES, state_dict['count'] + 1)
+                count += 1
+        else:
+            is_outlier = True
+
+        if is_outlier:
+            raw_line_spectra.append(last_valid_h_inv)
+            raw_line_rises.append(measured_center_rise)
+            continue
+
+        # Compute averaged spectra over the entire 1000-pulse training set history
+        valid_count = state_dict['count']
+        accum_s_xy = np.mean(state_dict['s_xy_history'][:valid_count], axis=0)
+        accum_s_yy = np.mean(state_dict['s_yy_history'][:valid_count], axis=0)
+
+        hf_power = accum_s_yy[hf_mask]
+        hf_median = np.median(hf_power) if len(hf_power) > 0 else 0.0
+        hf_mad = np.median(np.abs(hf_power - hf_median)) if len(hf_power) > 0 else 0.0
+        noise_penalty = (hf_median + 3.0 * hf_mad) * noise_threshold
+
+        num_passes = 5  
+        H_total = np.ones(FFT_LEN, dtype=np.complex128)
+
+        for pass_idx in range(num_passes):
+            current_S_xy = accum_s_xy * np.conj(H_total)
+            current_S_yy = accum_s_yy * (np.abs(H_total) ** 2)
+
+            denom = current_S_yy + noise_penalty
+            denom[denom == 0] = 1e-12
+            H_step = current_S_xy / denom
+
+            alpha = 0.4 
+            H_total = H_total * (1.0 - alpha) + H_total * H_step * alpha
+
+        raw_line_spectra.append(H_total)
+        raw_line_rises.append(measured_center_rise)
+        last_valid_h_inv = H_total
+
+    if count == 0 and state_dict['count'] == 0:
         _denormalize_inplace(video_buf, sync_tip_level, blanking_level)
         return video_buf, {'gain': 0.0, 'threshold': 0.1, 'blur_radius': 0.0}
 
-    # COMBINE historical rolling state with the current chunk's measurements
-    total_S_xy = rolling_S_xy + S_xy
-    total_S_yy = rolling_S_yy + S_yy
-
     # =========================================================================
-    # PART 2: Iterative Feed-Forward Wiener Deconvolution
+    # FIELD-WIDE STATISTICAL AVERAGING (For disabled interpolation toggles)
     # =========================================================================
-    num_passes = 5  # Optimize by dialing this between 2 and 5
-    
-    # Initialize the integrated frequency-domain filter
-    H_total = np.ones(FFT_LEN, dtype=np.complex128)
-    
-    freqs = np.abs(np.fft.fftfreq(FFT_LEN))
-    hf_mask = freqs > 0.35  
+    field_magnitudes = [np.abs(h) for h in raw_line_spectra]
+    field_phases = [np.angle(h) for h in raw_line_spectra]
 
-    for pass_idx in range(num_passes):
-        # 1. Update spectra based on the current integrated correction
-        # Use total_S_xy and total_S_yy so the current frame is included!
-        current_S_xy = total_S_xy * np.conj(H_total)
-        current_S_yy = total_S_yy * (np.abs(H_total) ** 2)
+    avg_amplitude = np.mean(field_magnitudes, axis=0)
+    avg_phase = np.angle(np.mean([np.exp(1j * p) for p in field_phases], axis=0))
 
-        # 2. Extract noise floor dynamically using standard NumPy MAD
-        hf_power = current_S_yy[hf_mask]
-        hf_median = np.median(hf_power)
-        hf_mad = np.median(np.abs(hf_power - hf_median))
+    line_kernels = []
+    line_H_invs = []
+
+    for i in range(len(raw_line_spectra)):
+        mag = np.abs(raw_line_spectra[i]) if interpolate_amplitude else avg_amplitude
+        phase = np.angle(raw_line_spectra[i]) if interpolate_phase else avg_phase
         
-        noise_floor = hf_median + 3.0 * hf_mad
-        nsr_penalty = noise_floor * noise_threshold
-
-        # 3. Calculate the residual Wiener correction step
-        denom = current_S_yy + nsr_penalty
-        denom[denom == 0] = 1e-12
+        H_inv_modified = mag * np.exp(1j * phase)
         
-        H_step = current_S_xy / denom
-
-        # 4. Integrate the residual step into the total filter
-        H_total *= H_step
-
-    # Pass the final integrated filter into Part 3 for IFFT and causality windowing
-    H_inv = H_total
-
-    ######################################################
-    # TODO: Might be able to detect head switching pulses.
-    #       The ringing pattern clearly differs when the head switch occurs.
-    #       Detect the switching position, measure it, and correct it's slope
-    ######################################################
+        fir_kernel = _build_causal_fir_from_spectrum(H_inv_modified, FFT_LEN, FIR_LEN, DELAY_OFFSET)
+        line_kernels.append(fir_kernel)
+        line_H_invs.append(H_inv_modified)
 
     # =========================================================================
-    # PART 3: Build Causal Inverse Equalization FIR Filter
+    # PART 4: Execute Delta Injection via Sliding Interpolation
     # =========================================================================
+    video_clean = _suppress_color_carrier_fft(video_buf)
+    video_buf_filtered = video_buf.copy()
     
-    # 1. Anti-Aliasing Frequency Taper (Roll-off near Nyquist)
-    # Smoothly attenuates H_inv between 0.35 and 0.45 normalized frequency
+    for i, line in enumerate(range(line_start, line_end + 1)):
+        loc = line * line_length
+        if loc >= len(video_buf):
+            break
+            
+        raw_line = video_buf[loc : loc + line_length]
+        clean_line = video_clean[loc : loc + line_length]
+        
+        kernel_a = line_kernels[i]
+        kernel_b = line_kernels[i + 1] if i + 1 < len(line_kernels) else kernel_a
+        
+        filtered_line = _apply_interpolated_inverse_eq(
+            raw_line.astype(np.float32), 
+            clean_line.astype(np.float32), 
+            len(raw_line), 
+            kernel_a, 
+            kernel_b
+        )
+        
+        video_buf_filtered[loc : loc + line_length] = filtered_line
+
+    # =========================================================================
+    # PART 5: Exact Inverse Noise Floor Compensation (Frequency-Gated)
+    # =========================================================================
+    avg_H_inv = np.mean(line_H_invs, axis=0) if len(line_H_invs) > 0 else np.ones(FFT_LEN, dtype=np.complex128)
+
+    gd_mag = np.abs(avg_H_inv)
+    gd_boost = np.maximum(1.0, gd_mag)
+    inverse_multiplier = 1.0 / gd_boost
+
     freqs_norm = np.abs(np.fft.fftfreq(FFT_LEN))
-    taper = np.clip((0.45 - freqs_norm) / 0.10, 0.0, 1.0)
-    # Cosine smoothing for the transition band
-    taper_smooth = 0.5 * (1.0 - np.cos(np.pi * taper)) 
-    H_inv *= taper_smooth
+    luma_protection = np.clip((freqs_norm - 0.10) / 0.10, 0.0, 1.0)
 
-    # 2. IFFT back to time domain
-    h_full = scipy.fft.fftshift(scipy.fft.ifft(H_inv).real)
-    
-    # Make FIR causal
-    true_center = FFT_LEN // 2
+    mean_noise = np.mean(noise_mag_profile)
+    noise_weight = np.clip((noise_mag_profile / (mean_noise + 1e-12)) * 2.0, 0.0, 1.0)
+    noise_weight *= luma_protection
 
-    # Assemble half-size causal kernel
-    fir_kernel = np.zeros(FIR_LEN, dtype=np.float32)
-    fir_kernel[0] = h_full[true_center]
-    fir_kernel[1:] = h_full[
-        true_center + 1:
-        true_center + FIR_LEN
-    ]
-    
-    # 3. Anti-Aliasing Time Window (Prevent Gibbs Truncation)
-    # Create a right-sided Tukey window: flat at the center tap, fading to 0 at the tail
-    # alpha=0.5 means the final 50% of the kernel gently tapers down
-    tail_window = scipy.signal.windows.tukey(FIR_LEN * 2, alpha=0.5)[FIR_LEN:]
-    fir_kernel *= tail_window
+    H_corrective = 1.0 - (noise_weight * (1.0 - inverse_multiplier))
+    H_corrective[0] = 1.0
 
-    # Normalize to preserve DC gain
-    fir_kernel /= np.sum(fir_kernel)
-
-    # =========================================================================
-    # PART 4: Apply Inverse Equalization FIR Filter
-    # =========================================================================
-    video_buf_filtered = _apply_inverse_eq(video_buf, n_samples, fir_kernel)
-
-    lti_params = derive_lti_parameters(
-        fir_kernel, 
-        noise_threshold=noise_threshold
+    h_corrective_time = scipy.fft.fftshift(
+        scipy.fft.ifft(H_corrective).real
     )
+
+    center = FFT_LEN // 2
+    fir_corrective = np.zeros(FIR_LEN, dtype=np.float32)
+
+    start_idx_corr = center - (FIR_LEN // 2)
+    fir_corrective[:] = h_corrective_time[start_idx_corr:start_idx_corr + FIR_LEN]
+
+    fir_corrective *= scipy.signal.windows.hann(FIR_LEN)
+
+    fir_corr_sum = np.sum(fir_corrective)
+    if abs(fir_corr_sum) > 1e-12:
+        fir_corrective /= fir_corr_sum
+
+    video_buf_filtered = _apply_zero_phase_fir(
+        video_buf_filtered.astype(np.float32),
+        fir_corrective.astype(np.float32)
+    )
+
+    mid_kernel = line_kernels[len(line_kernels) // 2] if len(line_kernels) > 0 else np.zeros(FIR_LEN)
+    lti_params = derive_lti_parameters(mid_kernel, noise_threshold=noise_threshold)
 
     if debug:
         full_win_size = max(front_porch_len + sync_len + back_porch_len, FIR_LEN)
@@ -472,12 +567,27 @@ def apply_inverse_equalization(
         corrected_pulses = []
         line_indices = []
 
-        for line in range(line_start, line_end + 1):
+        for idx, line in enumerate(range(line_start, line_end + 1)):
             start_loc = line * line_length - front_porch_len
             if start_loc >= 0 and start_loc + full_win_size < n_samples:
                 raw_p = video_buf[start_loc : start_loc + full_win_size].copy()
-                corr_p = _apply_inverse_eq(raw_p, full_win_size, fir_kernel)
-                # raw_p = _suppress_color_carrier(raw_p)
+                clean_p = video_clean[start_loc : start_loc + full_win_size].copy()
+                
+                kernel_a = line_kernels[idx]
+                kernel_b = line_kernels[idx + 1] if idx + 1 < len(line_kernels) else kernel_a
+
+                corr_p = _apply_interpolated_inverse_eq(
+                    raw_p.astype(np.float32), 
+                    clean_p.astype(np.float32), 
+                    full_win_size, 
+                    kernel_a,
+                    kernel_b
+                )
+                
+                corr_p = _apply_zero_phase_fir(
+                    corr_p.astype(np.float32), 
+                    fir_corrective.astype(np.float32)
+                )
 
                 raw_pulses.append(raw_p)
                 corrected_pulses.append(corr_p)
@@ -494,7 +604,6 @@ def apply_inverse_equalization(
         all_corr_arr = np.array(corrected_pulses)
         sync_tip_average, blanking_average = _get_levels(all_corr_arr.flatten())
 
-        # build ideal pulse
         ideal_debug = _build_ideal_hsync_pulse(
             front_porch_len,
             sync_len,
@@ -509,7 +618,7 @@ def apply_inverse_equalization(
             raw_pulses,
             corrected_pulses,
             ideal_debug,
-            fir_kernel,
+            mid_kernel,
             0,
             line_indices,
             pulse_ffts,
@@ -517,7 +626,6 @@ def apply_inverse_equalization(
             corrected_ffts,
             FFT_LEN,
         )
-
 
     return _denormalize_inplace(video_buf_filtered, sync_tip_level, blanking_level), lti_params
 
@@ -546,7 +654,6 @@ def _show_group_delay_debug(
     if n_lines == 0:
         return
 
-    # Expand figure layout to fit 6 subplots
     plt.style.use("dark_background")
     plt.rcParams.update({
         "figure.facecolor": "#121212",
@@ -562,15 +669,14 @@ def _show_group_delay_debug(
     })
     fig = plt.figure(figsize=(16, 20))
     
-    ax1 = plt.subplot2grid((6, 2), (0, 0), colspan=2) # Line Inspection
-    ax2 = plt.subplot2grid((6, 2), (1, 0), colspan=1) # All Lines Overlay
-    ax3 = plt.subplot2grid((6, 2), (1, 1), colspan=1) # Causal Kernel Taps
-    ax_slider = plt.subplot2grid((6, 1), (2, 0), colspan=2) # Slider
+    ax1 = plt.subplot2grid((6, 2), (0, 0), colspan=2)
+    ax2 = plt.subplot2grid((6, 2), (1, 0), colspan=1)
+    ax3 = plt.subplot2grid((6, 2), (1, 1), colspan=1)
+    ax_slider = plt.subplot2grid((6, 1), (2, 0), colspan=2)
 
-    # FFT section
-    ax4 = plt.subplot2grid((6, 2), (3, 0), colspan=2) # Raw Pulse
-    ax5 = plt.subplot2grid((6, 2), (4, 0), colspan=2, sharex=ax4, sharey=ax4) # Delta
-    ax6 = plt.subplot2grid((6, 2), (5, 0), colspan=2, sharex=ax4, sharey=ax4) # Corrected Pulse
+    ax4 = plt.subplot2grid((6, 2), (3, 0), colspan=2)
+    ax5 = plt.subplot2grid((6, 2), (4, 0), colspan=2, sharex=ax4, sharey=ax4)
+    ax6 = plt.subplot2grid((6, 2), (5, 0), colspan=2, sharex=ax4, sharey=ax4)
 
     initial_idx = 0
     line_num = line_indices[initial_idx]
@@ -579,7 +685,7 @@ def _show_group_delay_debug(
     corr_line, = ax1.plot(corrected_pulses[initial_idx], label=f'Equalized Line {line_num}', color='#1f77b4', linewidth=2.2)
     ax1.plot(ideal, label='Target Reference', color='#7f7f7f', linestyle=':', linewidth=2)
     
-    ax1.set_title(f"Line Inspection [Line 1] | Group Delay Advance: {calc_advance:.3f} samples", fontweight='bold')
+    ax1.set_title(f"Line Inspection [Line {line_num}] | Group Delay Advance: {calc_advance:.3f} samples", fontweight='bold')
     ax1.legend(loc='lower right')
     ax1.grid(True, alpha=0.35)
     ax1.set_ylabel("Amplitude")
@@ -601,9 +707,6 @@ def _show_group_delay_debug(
     ax3.legend(loc='upper right')
     ax3.grid(True, alpha=0.35)
 
-    # =========================================================================
-    # Build FFTs
-    # =========================================================================
     freqs = scipy.fft.fftfreq(FFT_LEN)
     half_len = FFT_LEN // 2
     pos_freqs = freqs[:half_len] * FSC_RATIO * FSC
@@ -628,55 +731,21 @@ def _show_group_delay_debug(
             corrected_fft = corrected_ffts[i]
             corrected_spec_data[i, :] = 20 * np.log10(np.maximum(np.abs(corrected_fft[:half_len + 1]), 1e-12))
 
-    # Custom Audacity-style multi-stop gradient: Black -> Deep Green -> Neon Green -> White
-    green_pos = LinearSegmentedColormap.from_list(
-        "green", 
-        ["#000000", "#00ff00"]
-    )   
-    green_neg = LinearSegmentedColormap.from_list(
-        "green", 
-        ["#00ff00", "#000000"]
-    )
+    green_pos = LinearSegmentedColormap.from_list("green", ["#000000", "#00ff00"])   
+    green_neg = LinearSegmentedColormap.from_list("green", ["#00ff00", "#000000"])
 
-    # =========================================================================
-    # PULSE SPECTROGRAM
-    # =========================================================================
-    ax4.imshow(
-        pulse_spec_data,
-        aspect='auto',
-        origin='lower',
-        extent=[pos_freqs[0], pos_freqs[-1], min_line, max_line],
-        cmap=green_pos
-    )
-    ax4.set_title("Raw $Y_{raw}$", fontweight='bold')
+    ax4.imshow(pulse_spec_data, aspect='auto', origin='lower', extent=[pos_freqs[0], pos_freqs[-1], min_line, max_line], cmap=green_pos)
+    ax4.set_title("Raw Y_raw", fontweight='bold')
     ax4.set_adjustable('box')
 
-    # =========================================================================
-    # SUBTRACTION SPECTROGRAM
-    # =========================================================================
-    ax5.imshow(
-        delta_spec_data,
-        aspect='auto',
-        origin='lower',
-        extent=[pos_freqs[0], pos_freqs[-1], min_line, max_line],
-        cmap=green_neg
-    )
-    ax5.set_title("Delta $Y_{delta}$", fontweight='bold')
+    ax5.imshow(delta_spec_data, aspect='auto', origin='lower', extent=[pos_freqs[0], pos_freqs[-1], min_line, max_line], cmap=green_neg)
+    ax5.set_title("Delta Y_delta", fontweight='bold')
     ax5.set_xlabel("Frequency (MHz)")
     ax5.set_ylabel("Line Index")
     ax5.set_adjustable('box')
 
-    # =========================================================================
-    # CORRECTED SPECTROGRAM
-    # =========================================================================
-    ax6.imshow(
-        corrected_spec_data,
-        aspect='auto',
-        origin='lower',
-        extent=[pos_freqs[0], pos_freqs[-1], min_line, max_line],
-        cmap=green_pos
-    )
-    ax6.set_title("Corrected $Y_{delta} - Y_{raw}$", fontweight='bold')
+    ax6.imshow(corrected_spec_data, aspect='auto', origin='lower', extent=[pos_freqs[0], pos_freqs[-1], min_line, max_line], cmap=green_pos)
+    ax6.set_title("Corrected Y_delta - Y_raw", fontweight='bold')
     ax6.set_adjustable('box')
     ax6.set_xlabel("Normalized Frequency")
 
@@ -687,10 +756,6 @@ def _show_group_delay_debug(
         ax.set_xlim(pos_freqs[0], pos_freqs[-1])
         ax.set_ylim(min_line, max_line)
 
-
-    # =========================================================================
-    # Slider
-    # =========================================================================
     slider = Slider(
         ax=ax_slider,
         label='Line Index ',
@@ -718,29 +783,14 @@ def _show_group_delay_debug(
 
     slider.on_changed(update)
 
-    plt.subplots_adjust(
-        left=0.05,
-        right=0.98,
-        top=0.98,
-        bottom=0.05,
-        hspace=0.25
-    )
-    
+    plt.subplots_adjust(left=0.05, right=0.98, top=0.98, bottom=0.05, hspace=0.25)
     plt.show()
-
-
 
 
 # -----------------------------------------------------------------------------
 # LTI PARAMETER DERIVATION FUNCTION
 # -----------------------------------------------------------------------------
 def derive_lti_parameters(fir_kernel, noise_threshold):
-    """
-    Derives optimal Luminance Transient Improvement (LTI) parameters
-    analytically from the derived causal group-delay FIR kernel.
-    """
-
-    # 1. Total energy vs. center tap energy
     total_energy = np.sum(fir_kernel**2)
     if total_energy <= 1e-12:
         return {'gain': 0.0, 'threshold': 0.1, 'blur_radius': 0.0}
@@ -748,16 +798,12 @@ def derive_lti_parameters(fir_kernel, noise_threshold):
     center_energy = fir_kernel[0]**2
     energy_dispersion = 1.0 - (center_energy / total_energy)
     
-    # 2. Compute second moment (spatial spread radius)
     indices = np.arange(len(fir_kernel))
     weighted_spread = np.sum(indices * np.abs(fir_kernel)) / np.sum(np.abs(fir_kernel))
     
-    # 3. Scale LTI Gain proportionally to dispersion and noise threshold
-    # High noise_threshold reduces max gain to prevent boosting noise floor
     noise_suppression_factor = max(0.2, 1.0 - 2.0 * noise_threshold)
     lti_gain = np.clip(energy_dispersion * 1.5 * noise_suppression_factor, 0.0, 1.0)
     
-    # 4. Adaptive Threshold: Set above the residual high-frequency noise level
     lti_threshold = np.clip(noise_threshold * 0.75, 0.02, 0.15)
 
     return {
@@ -780,17 +826,11 @@ def apply_adaptive_luma_transient_improvement(video_buf, gain, threshold):
         curr = video_buf[i]
         nxt = video_buf[i + 1]
 
-        # 1st derivative (span of 2 pixels) to check threshold
         abs_diff = abs(nxt - prev)
 
         if abs_diff > threshold:
-            # 2nd derivative (Laplacian) isolates the high-frequency edge energy symmetrically
             laplacian = prev - 2.0 * curr + nxt
-
-            # Non-linear gain taper
             edge_weight = min(1.0, abs_diff / (2.0 * threshold))
-            
-            # Subtracting the Laplacian acts as a symmetric unsharp mask / peaking filter
             video_buf[i] = curr - (gain * edge_weight * laplacian)
 
         prev = curr

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -17,27 +17,43 @@ FSC_RATIO = 4 # sets ratio of FFT length to fsc
 FIR_LEN = 63
 FFT_LEN = 512
 
-@nb.njit(cache=True, nogil=True, fastmath=True)
-def _apply_inverse_eq(picture, n_samples, causal_kernel):
-    """
-    Applies the causal FIR equalization filter to the video buffer.
-    """
-    out = np.zeros(n_samples, np.float32)
+def _make_inverse_eq(fir_len):
+    @nb.njit(
+        "float32[:](float32[::1], int64, float32[::1])",
+        cache=True,
+        nogil=True,
+        fastmath=True
+    )
+    def _apply_inverse_eq(picture, n_samples, causal_kernel):
+        causal_kernel = causal_kernel[::-1].copy()
+        out = np.empty(n_samples, np.float32)
 
-    # Outer loop over causal filter taps ensures sequential, contiguous reads
-    for j in range(FIR_LEN):
-        coeff = causal_kernel[j]
-            
-        # Region 1: Left boundary clamping (i < j references indices < 0, clamped to picture[0])
-        for i in range(0, j):
-            out[i] += picture[0] * coeff
-            
-        # Region 2: Inner core (Pure sequential memory access: picture[i - j])
-        for i in range(j, n_samples):
-            out[i] += picture[i - j] * coeff
+        first = picture[0]
 
-    return out
+        for i in nb.prange(n_samples):
+            acc = 0.0
 
+            if i < fir_len - 1:
+                start = fir_len - 1 - i
+
+                for j in range(start, fir_len):
+                    acc += picture[i - fir_len + 1 + j] * causal_kernel[j]
+
+                for j in range(start):
+                    acc += first * causal_kernel[j]
+
+            else:
+                base = i - fir_len + 1
+
+                for j in range(fir_len):
+                    acc += picture[base + j] * causal_kernel[j]
+
+            out[i] = acc
+
+        return out
+    return _apply_inverse_eq
+
+_apply_inverse_eq = _make_inverse_eq(FIR_LEN)
 
 def _fit_smooth_phase(S_xy, smooth=1):
     phase = -np.unwrap(np.angle(S_xy))
@@ -72,6 +88,7 @@ def _fit_smooth_phase(S_xy, smooth=1):
 
     return phase_corr, -slope
 
+
 def _build_fsc_mask(n, width_bins=3):
     """
     Creates a soft mask around the color subcarrier.
@@ -92,6 +109,7 @@ def _build_fsc_mask(n, width_bins=3):
 
     return mask
 
+@nb.njit(cache=True, nogil=True, fastmath=True)
 def _build_ideal_step(
     measured_center_rise,
     target_transition,
@@ -114,6 +132,7 @@ def _build_ideal_step(
     return ideal
 
 
+@nb.njit(cache=True, nogil=True, fastmath=True)
 def _build_ideal_hsync_pulse(
     front_porch_len,
     sync_len,
@@ -289,26 +308,21 @@ def apply_inverse_equalization(
 
     n_samples = len(video_buf)
 
+    # =========================================================================
+    # PART 1: Calculate Pulse Shape & Spectra (Rising Edge Only)
+    # =========================================================================
     pre_rise_samples = int(np.round(0.25 * sync_len))
     win_size = pre_rise_samples + back_porch_len
     win_size -= win_size % 4 
     offset_rise = pre_rise_samples
 
-    S_xy = np.zeros(FFT_LEN, dtype=np.complex128)
-    S_xx = np.zeros(FFT_LEN, dtype=np.complex128)
-    S_yy = np.zeros(FFT_LEN, dtype=np.float64)
-
-    pulse_ffts = []
-    delta_ffts = []
-    corrected_ffts = []
-
     win = scipy.signal.windows.tukey(win_size, alpha=0.05)
     start_idx = (FFT_LEN - win_size) // 2
     count = 0
 
-    # =========================================================================
-    # PART 1: Calculate Pulse Shape & Spectra (Rising Edge Only)
-    # =========================================================================
+    pulses_padded = []
+    pulses_ideal = []
+
     for line in range(line_start, line_end + 1):
         loc = line * line_length
         start_loc = loc + sync_len - pre_rise_samples
@@ -357,20 +371,24 @@ def apply_inverse_equalization(
             pad_ideal[start_idx : start_idx + win_size] = d_ideal
             pad_pulse[start_idx : start_idx + win_size] = d_pulse
 
-            # measure pulse's actual frequency response
-            Y = scipy.fft.fft(pad_pulse)
-            # measure the pulse's expected frequency response, given the sync pulse parameters
-            X = scipy.fft.fft(pad_ideal)
-            
-            S_xy += X * np.conj(Y)
-            S_xx += np.abs(X)**2
-            S_yy += np.abs(Y)**2
+            pulses_padded.append(pad_pulse)
+            pulses_ideal.append(pad_pulse)
 
     if count > 0:
+        F_batch = scipy.fft.fft(
+            np.asarray(pulses_padded + pulses_ideal),
+            axis=1,
+        )
+
+        # measure pulse's actual frequency response
+        Y = F_batch[:len(pulses_padded)]
+        # measure expected frequency response
+        X = F_batch[len(pulses_padded):]
+
         current_measurement = {
-            's_xy': S_xy,
-            's_xx': S_xx,
-            's_yy': S_yy,
+            's_xy': np.sum(X * np.conj(Y), axis=0),
+            's_xx': np.sum(np.abs(X)**2, axis=0),
+            's_yy': np.sum(np.abs(Y)**2, axis=0),
         }
         group_delay_state.append(current_measurement)
     else:
@@ -519,7 +537,7 @@ def apply_inverse_equalization(
     ######################################################
     # TODO: Might be able to detect head switching pulses.
     #       The ringing pattern clearly differs when the head switch occurs.
-    #       This could be used to detect the switching position, measure it, and correct it's slope
+    #       Detect the switching position, measure it, and correct it's slope
     ######################################################
 
     # =========================================================================
@@ -553,6 +571,9 @@ def apply_inverse_equalization(
 
     if debug:
         full_win_size = max(front_porch_len + sync_len + back_porch_len, FIR_LEN)
+        pulse_ffts = []
+        delta_ffts = []
+        corrected_ffts = []
         raw_pulses = []
         corrected_pulses = []
         line_indices = []

--- a/vhsdecode/addons/ringing_cancellation.py
+++ b/vhsdecode/addons/ringing_cancellation.py
@@ -14,7 +14,7 @@ import matplotlib.ticker as mticker
 FSC=3.579545 # TODO: parameterize (used only in debug)
 FSC_RATIO = 4 # sets ratio of FFT length to fsc
 
-FIR_LEN = 63
+FIR_LEN = 127
 FFT_LEN = 512
 
 def _make_inverse_eq(fir_len):
@@ -54,39 +54,6 @@ def _make_inverse_eq(fir_len):
     return _apply_inverse_eq
 
 _apply_inverse_eq = _make_inverse_eq(FIR_LEN)
-
-def _fit_smooth_phase(S_xy, smooth=1):
-    phase = -np.unwrap(np.angle(S_xy))
-    mag = np.abs(S_xy)
-
-    # frequency bins to mask for horizontal smearing
-    w = 2 * np.pi * np.fft.fftfreq(len(S_xy))
-    mask = (w > 0.01 * np.pi) & (w < 0.2 * np.pi)
-
-    w_fit = w[mask]
-    phase_fit = phase[mask]
-
-    weight = mag[mask]
-    weight /= np.max(weight)
-
-    slope, intercept = np.polyfit(
-        w_fit, phase_fit, 1, w=weight,
-    )
-
-    excess = phase_fit - (slope * w_fit + intercept)
-    spline = UnivariateSpline(
-        w_fit, excess, w=weight, s=smooth*len(w_fit)
-    )
-
-    phase_corr = np.zeros_like(phase)
-    phase_corr[mask] = slope * w_fit + intercept + spline(w_fit)
-
-    half = len(phase) // 2
-    phase_corr[half + 1:] = -phase_corr[1:half][::-1]
-    phase_corr[0] = 0.0
-    phase_corr[half] = 0.0
-
-    return phase_corr, -slope
 
 
 def _build_fsc_mask(n, width_bins=3):
@@ -324,6 +291,16 @@ def apply_inverse_equalization(
     S_xx = np.zeros(FFT_LEN, dtype=np.complex128)
     S_yy = np.zeros(FFT_LEN, dtype=np.float64)
 
+    rolling_S_xy = np.zeros(FFT_LEN, dtype=np.complex128)
+    rolling_S_xx = np.zeros(FFT_LEN, dtype=np.complex128)
+    rolling_S_yy = np.zeros(FFT_LEN, dtype=np.float64)
+
+    # get previous iteration's rolling averages
+    for measurement in group_delay_state:
+        rolling_S_xy += measurement['s_xy']
+        rolling_S_xx += measurement['s_xx']
+        rolling_S_yy += measurement['s_yy']
+
     for line in range(line_start, line_end + 1):
         loc = line * line_length
         start_loc = loc + sync_len - pre_rise_samples
@@ -376,156 +353,64 @@ def apply_inverse_equalization(
             Y = scipy.fft.fft(pad_pulse)
             # measure the pulse's expected frequency response, given the sync pulse parameters
             X = scipy.fft.fft(pad_ideal)
-            
+
+            # ONLY accumulate here. No Wiener math inside this loop.
             S_xy += X * np.conj(Y)
             S_xx += np.abs(X)**2
+            S_yy += np.abs(Y)**2
 
+    # Save current chunk to state (Added missing 's_yy')
     if count > 0:
         current_measurement = {
             's_xy': S_xy,
             's_xx': S_xx,
+            's_yy': S_yy,  
         }
         group_delay_state.append(current_measurement)
     else:
         _denormalize_inplace(video_buf, sync_tip_level, blanking_level)
-        return video_buf
+        return video_buf, {'gain': 0.0, 'threshold': 0.1, 'blur_radius': 0.0}
 
-    rolling_S_xy = np.zeros(FFT_LEN, dtype=np.complex128)
-    rolling_S_xx = np.zeros(FFT_LEN, dtype=np.complex128)
-
-    for measurement in group_delay_state:
-        rolling_S_xy += measurement['s_xy']
-        rolling_S_xx += measurement['s_xx']
+    # COMBINE historical rolling state with the current chunk's measurements
+    total_S_xy = rolling_S_xy + S_xy
+    total_S_yy = rolling_S_yy + S_yy
 
     # =========================================================================
-    # PART 2: Analyze Pulse Structure
-    #     2A: Group Delay (Horizontal Smear)
-    #     2B: Ringing
-    #     2C: Chroma carrier leakage
+    # PART 2: Iterative Feed-Forward Wiener Deconvolution
     # =========================================================================
+    num_passes = 5  # Optimize by dialing this between 2 and 5
+    
+    # Initialize the integrated frequency-domain filter
+    H_total = np.ones(FFT_LEN, dtype=np.complex128)
+    
+    freqs = np.abs(np.fft.fftfreq(FFT_LEN))
+    hf_mask = freqs > 0.35  
 
-    # rolling_S_xy = _suppress_color_carrier_fft(rolling_S_xy)
-    # rolling_S_xy = _taper_delta_fft(rolling_S_xy)
+    for pass_idx in range(num_passes):
+        # 1. Update spectra based on the current integrated correction
+        # Use total_S_xy and total_S_yy so the current frame is included!
+        current_S_xy = total_S_xy * np.conj(H_total)
+        current_S_yy = total_S_yy * (np.abs(H_total) ** 2)
 
-    phase_error, advance_float = _fit_smooth_phase(
-        rolling_S_xy
-    )
+        # 2. Extract noise floor dynamically using standard NumPy MAD
+        hf_power = current_S_yy[hf_mask]
+        hf_median = np.median(hf_power)
+        hf_mad = np.median(np.abs(hf_power - hf_median))
+        
+        noise_floor = hf_median + 3.0 * hf_mad
+        nsr_penalty = noise_floor * noise_threshold
 
-    H_measured = (rolling_S_xy / np.maximum(rolling_S_xx, 1e-12))
-    # Normalize DC
-    H_measured /= max(np.abs(H_measured[0]), 1e-12)
+        # 3. Calculate the residual Wiener correction step
+        denom = current_S_yy + nsr_penalty
+        denom[denom == 0] = 1e-12
+        
+        H_step = current_S_xy / denom
 
-    # ------------------------------------------------------------
-    # 2A Remove horizontal smear (phase only)
-    # ------------------------------------------------------------
-    smear_strength = 1
-    smear_gd_sigma = FFT_LEN / FIR_LEN # group delay measurement smoothing
-    smear_weight_sigma = FFT_LEN / (2 * FIR_LEN) # correction transition smoothing
+        # 4. Integrate the residual step into the total filter
+        H_total *= H_step
 
-    # Estimate group delay stability
-    phase = -np.unwrap(np.angle(H_measured))
-    w = 2.0 * np.pi * np.fft.fftfreq(len(H_measured))
-    group_delay = -np.gradient(phase, w)
-
-    # Smooth group delay to find broad delay behavior
-    gd_smooth = scipy.ndimage.gaussian_filter1d(
-        group_delay, smear_gd_sigma
-    )
-
-    # Difference from smooth delay = non-smear behavior
-    gd_error = np.abs(group_delay - gd_smooth)
-    gd_scale = np.percentile(gd_error, 95)
-
-    smear_weight = np.clip(
-        1.0 - gd_error / max(gd_scale, 1e-12), 0.0, 1.0
-    )
-    smear_weight = scipy.ndimage.gaussian_filter1d(
-        smear_weight, smear_weight_sigma
-    )
-
-    phase_error_weighted = phase_error * smear_weight
-
-    # Apply phase-only correction
-    H_smear = np.exp(
-        -1j *
-        smear_strength *
-        phase_error_weighted
-    )
-
-    # ------------------------------------------------------------
-    # 2B Remove ringing
-    # ------------------------------------------------------------
-    ring_strength = 1
-    ring_sigma = 1 # FFT_LEN / FIR_LEN
-
-    # remove color carrier leakage from this measurement
-    fsc_mask = _build_fsc_mask(FFT_LEN, width_bins=4)
-    H_after_smear = H_measured * H_smear * (1.0 - fsc_mask) + fsc_mask
-
-    H_target = np.abs(H_after_smear) * np.exp(
-        1j * scipy.ndimage.gaussian_filter1d(
-            np.unwrap(np.angle(H_after_smear)), ring_sigma
-        )
-    )
-
-    H_residual = H_after_smear - H_target
-
-    # Keep causal ringing tail only
-    h_residual=scipy.fft.ifft(H_residual).real
-
-    peak=np.argmax(np.abs(h_residual))
-    h_residual[:peak + 1] = 0
-
-    ring_window=scipy.signal.windows.tukey(
-        FIR_LEN, alpha=0.25
-    )
-
-    h_residual[peak + 1:peak + 1 + FIR_LEN] *= ring_window[:min(
-        FIR_LEN, len(h_residual) - peak - 1
-    )]
-
-    h_residual[peak+1+FIR_LEN:] = 0
-
-    H_ring_error = scipy.fft.fft(h_residual)
-
-    ring_gain = np.sqrt(
-        np.sum(np.abs(H_residual) ** 2) /
-        max(np.sum(np.abs(H_ring_error) ** 2), 1e-12)
-    )
-
-    H_ring = 1.0 - ring_strength * H_ring_error * ring_gain
-
-    # ------------------------------------------------------------
-    # 2C Remove chroma leakage following smear slope
-    # ------------------------------------------------------------
-    chroma_strength = 1
-
-    # Use same phase slope as smear correction
-    H_chroma_slope = np.exp(-1j * phase_error)
-    # Limit correction to carrier region
-    H_chroma_slope = H_chroma_slope * fsc_mask + (1.0 - fsc_mask)
-
-    # Measure remaining carrier error
-    H_after_chroma_slope = H_after_smear * H_chroma_slope
-    H_chroma_residual = (H_after_chroma_slope - 1.0) * fsc_mask
-
-    # Convert residual to causal correction
-    h_chroma = scipy.fft.ifft(H_chroma_residual).real
-    h_chroma[0] = 0
-    h_chroma[FIR_LEN:] = 0
-    h_chroma[1:FIR_LEN] *= scipy.signal.windows.tukey(
-        FIR_LEN-1, alpha=0.25
-    )
-    H_chroma_error = scipy.fft.fft(h_chroma)
-
-    H_chroma = 1.0 - chroma_strength * H_chroma_error
-
-    ### assemble the filters
-    H_inv = (
-        H_smear
-      * H_ring
-      * H_chroma
-    )
+    # Pass the final integrated filter into Part 3 for IFFT and causality windowing
+    H_inv = H_total
 
     ######################################################
     # TODO: Might be able to detect head switching pulses.
@@ -536,8 +421,16 @@ def apply_inverse_equalization(
     # =========================================================================
     # PART 3: Build Causal Inverse Equalization FIR Filter
     # =========================================================================
+    
+    # 1. Anti-Aliasing Frequency Taper (Roll-off near Nyquist)
+    # Smoothly attenuates H_inv between 0.35 and 0.45 normalized frequency
+    freqs_norm = np.abs(np.fft.fftfreq(FFT_LEN))
+    taper = np.clip((0.45 - freqs_norm) / 0.10, 0.0, 1.0)
+    # Cosine smoothing for the transition band
+    taper_smooth = 0.5 * (1.0 - np.cos(np.pi * taper)) 
+    H_inv *= taper_smooth
 
-    # IFFT back to time domain
+    # 2. IFFT back to time domain
     h_full = scipy.fft.fftshift(scipy.fft.ifft(H_inv).real)
     
     # Make FIR causal
@@ -550,6 +443,14 @@ def apply_inverse_equalization(
         true_center + 1:
         true_center + FIR_LEN
     ]
+    
+    # 3. Anti-Aliasing Time Window (Prevent Gibbs Truncation)
+    # Create a right-sided Tukey window: flat at the center tap, fading to 0 at the tail
+    # alpha=0.5 means the final 50% of the kernel gently tapers down
+    tail_window = scipy.signal.windows.tukey(FIR_LEN * 2, alpha=0.5)[FIR_LEN:]
+    fir_kernel *= tail_window
+
+    # Normalize to preserve DC gain
     fir_kernel /= np.sum(fir_kernel)
 
     # =========================================================================

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -1772,7 +1772,7 @@ def _chroma_phase_correction_from_sync(
     valid_count = state_dict['count']
     
     # 2. Compute the aggregate S_xy directly from the history buffer
-    rolling_S_xy = np.sum(state_dict['s_xy_history'][:valid_count], axis=0)
+    rolling_S_xy = np.sum(state_dict['s_xy_delay_history'][:valid_count], axis=0)
     
     # 3. Calculate Phase Error
     phase_error_base = -np.unwrap(np.angle(rolling_S_xy))

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -1761,18 +1761,17 @@ def _chroma_phase_correction_from_sync(
     freqs_up = sps_fft.rfftfreq(fft_len, d=1.0 / (fsc * 4.0))
     
     # Fast exit if no valid measurements have been accumulated
-    if len(group_delay_state) == 0 or group_delay_state[0].get('count', 0) == 0:
+    if not group_delay_state or group_delay_state.get('count', 0) == 0:
         return np.ones_like(freqs_up, dtype=np.complex128)
 
     phase_correction = np.zeros_like(freqs_up, dtype=np.float64)
     scale_factor = GROUP_DELAY_FFT_LEN / fft_len
     
     # 1. Extract the new state shape (Ring Buffer)
-    state_dict = group_delay_state[0]
+    state_dict = group_delay_state
     valid_count = state_dict['count']
     
     # 2. Compute the aggregate S_xy directly from the history buffer
-    # (Summing the complex vectors achieves the same phase as the old iterative += method)
     rolling_S_xy = np.sum(state_dict['s_xy_history'][:valid_count], axis=0)
     
     # 3. Calculate Phase Error
@@ -1805,7 +1804,7 @@ def _chroma_phase_correction_from_sync(
     # is in sync pulse based fft vs. the burst phase fft, burst phase is higher resolution
     scaling_weight = np.clip(scale_factor, 0.0, 1.0)
 
-    # Apply weighted phase correction (now done once instead of re-written iteratively)
+    # Apply weighted phase correction
     phase_correction[chroma_band_mask] = (
         phase_error[chroma_band_mask] * 
         delay_modulation[chroma_band_mask] * 

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -34,6 +34,8 @@ def chroma_automatic_gain(
     phase_sequence,
     burst_detected_line,
     sync_tip_len,
+    decode_average,
+    decode_average_count,
     smoothing_window=8,
     k=2.0
 ):
@@ -43,6 +45,18 @@ def chroma_automatic_gain(
     valid_gains = np.empty(burst_count, dtype=np.float64)
     valid_amps = np.empty(burst_count, dtype=np.float64)
     valid_count = 0
+
+    # scale the reference gain based on the average previous decodes
+    # decode average is the uncorrected average amplitude, burst abs ref is the target reference.
+    #   For example, with a decode average consisting of 8 fields, and this is current processing field 9, 
+    #   Scale the amount of gain applied to use 8/9 the ratio of these values and 1/9 the ratio of the actual measurement
+    if decode_average_count > 0:
+        decode_average_numerator = decode_average_count / (decode_average_count + 1)
+        decode_average_denominator = 1 / (decode_average_count + 1)
+        decode_average_gain = (burst_abs_ref / decode_average) * decode_average_numerator
+    else:
+        decode_average_gain = 0
+        decode_average_denominator = 1
 
     # extract gain values and track valid amplitudes
     for i in range(burst_count):
@@ -63,11 +77,16 @@ def chroma_automatic_gain(
         median_gain = np.median(active_gains)
         mad_gain = np.median(np.abs(active_gains - median_gain))
         max_allowable_gain = median_gain + (k * mad_gain)
+        min_allowable_gain = median_gain - k * mad_gain
     else:
-        max_allowable_gain = 1.0
+        max_allowable_gain = 1
+        min_allowable_gain = 0
 
     # clamp gains
-    clamped_gains = np.minimum(raw_gains, max_allowable_gain)
+    clamped_gains = np.clip(raw_gains, min_allowable_gain, max_allowable_gain)
+
+    # apply gain averaging across fields
+    clamped_gains = decode_average_gain + (clamped_gains * decode_average_denominator)
 
     # calculate smoothing
     smoothed_gains = np.empty(burst_count, dtype=np.float64)
@@ -1695,9 +1714,6 @@ def _process_chroma_secam_method1(field, chroma, linesout, outwidth, burstarea):
         porch_rms_total += lddu.rms(
             uphet[linestart + burstarea[0] : linestart + burstarea[1]]
         )
-    field.rf.field_averages.chroma_level.push(
-        porch_rms_total / (linesout - STARTING_LINE)
-    )
 
     return uphet
 
@@ -1970,15 +1986,31 @@ def process_chroma(
             uphet = comb_c_pal(uphet, outwidth)
 
     # Chroma AGC
-    mean_rms, chroma_noise_floor = chroma_automatic_gain(
+    # average ACG over each field
+    # save a separate gain per field
+    chroma_average_state = (
+        field.rf.field_averages.chroma_level_even
+        if field.field_number % 2 == 0 else
+        field.rf.field_averages.chroma_level_odd
+    )
+
+    decode_average_count = len(chroma_average_state)
+    if decode_average_count > 0:
+        decode_average = np.mean([c[0] for c in chroma_average_state])
+    else:
+        decode_average = 0
+
+    field_average, chroma_noise_floor = chroma_automatic_gain(
         uphet,
         field.rf.SysParams["burst_abs_ref"],
         field.phase_sequence,
         field.burst_detected_line,
-        math.floor(field.usectooutpx(field.rf.SysParams["hsyncPulseUS"]))
+        math.floor(field.usectooutpx(field.rf.SysParams["hsyncPulseUS"])),
+        decode_average,
+        decode_average_count
     )
 
-    field.rf.field_averages.chroma_level.push(mean_rms)
+    chroma_average_state.append((field_average, chroma_noise_floor))
 
     if field.rf.options.cti_mix != 0:
         chroma_transient_improvement(

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -1717,6 +1717,7 @@ def _process_chroma_secam_method1(field, chroma, linesout, outwidth, burstarea):
 
     return uphet
 
+FFT_LEN=512
 
 @cache
 def _gen_chroma_fft_filter(
@@ -1751,10 +1752,66 @@ def _gen_chroma_fft_filter(
     return mask
 
 
+def _chroma_phase_correction_from_sync(
+    fsc,
+    color_under_carrier_f,
+    group_delay_state,
+    fft_len
+) -> np.ndarray:
+    freqs_up = sps_fft.rfftfreq(fft_len, d=1.0 / (fsc * 4.0))
+    group_delay_state_fft_len = 512
+
+    phase_correction = np.zeros_like(freqs_up, dtype=np.float64)
+    rolling_S_xy = np.zeros(group_delay_state_fft_len, dtype=np.complex128)
+
+    scale_factor = group_delay_state_fft_len / fft_len
+    
+    for measurement in group_delay_state:
+        rolling_S_xy += measurement.get('s_xy')
+        phase_error_base = -np.unwrap(np.angle(rolling_S_xy))
+            
+        # Upscale the base 512 phase error vector to match the rfft bin count
+        old_x = np.linspace(0.0, 1.0, len(phase_error_base))
+        new_x = np.linspace(0.0, 1.0, len(freqs_up))
+        
+        base_complex = np.exp(-1j * phase_error_base)
+        upscaled_complex = (
+            np.interp(new_x, old_x, base_complex.real) + 
+            1j * np.interp(new_x, old_x, base_complex.imag)
+        )
+        phase_error = -np.unwrap(np.angle(upscaled_complex))
+
+        w_axis = 2.0 * np.pi * np.linspace(0.0, 0.5, len(freqs_up))
+        w_safe = np.where(np.abs(w_axis) < 1e-6, 1e-6, w_axis)
+        measured_group_delay = -np.gradient(phase_error, w_safe)
+
+        cu_norm_f = color_under_carrier_f / (fsc * 4.0)
+        chroma_band_mask = (freqs_up > (cu_norm_f - 0.08 * fsc)) & (freqs_up < (cu_norm_f + 0.08 * fsc))
+
+        delay_modulation = np.clip(
+            measured_group_delay / np.maximum(np.percentile(np.abs(measured_group_delay), 90), 1e-12), 
+            0.5, 2.5
+        )
+
+        # Weigh this scaling statistically based on how much theroetical reslution
+        # is in sync pulse based fft vs. the burst phase fft, burst phase is higher resolution
+        scaling_weight = np.clip(scale_factor, 0.0, 1.0)
+
+        # Apply weighted phase correction
+        phase_correction[chroma_band_mask] = (
+            phase_error[chroma_band_mask] * 
+            delay_modulation[chroma_band_mask] * 
+            scaling_weight
+        )
+
+    return np.exp(-1j * phase_correction)
+
+
 def filter_chroma_fft(
     uphet: np.ndarray, 
     fsc: float,
     color_under_carrier_f: float,
+    group_delay_state,
     bw_lower_hz: float,               # Lower chroma bandwidth (1.3 MHz below fsc)
     heterodyne_attenuation_db: float, # Rejection target at sum product (dB)
     order: int = 2,                   # filter order
@@ -1777,23 +1834,40 @@ def filter_chroma_fft(
 
     x_padded = np.pad(uphet, (pad_left, pad_right), mode='reflect')
 
-    mask = _gen_chroma_fft_filter(
+    # Generates the Super-Gaussian bandpass + luma group delay phase correction combined
+    chroma_filter_fft = _gen_chroma_fft_filter(
         N_up,
         fsc,
         color_under_carrier_f,
         bw_lower_hz,
         heterodyne_attenuation_db,
-        order
+        order,
     )
 
-    # apply filter against Forward Real FFT
+    # Also uses impulse response curves from the luma data for phase delay and amplitude
+    chroma_sync_group_delay_fft = _chroma_phase_correction_from_sync(
+        fsc,
+        color_under_carrier_f,
+        group_delay_state=group_delay_state,
+        fft_len=len(x_padded)
+    )
+
+
     F_filtered = sps_fft.rfft(x_padded)
-    F_filtered *= mask
+    F_filtered *= chroma_filter_fft  # Applies both attenuation and group delay pre-correction simultaneously
+    F_filtered *= chroma_sync_group_delay_fft  # Applies the phase group delay in terms of color under fs to use it to correct phase issues (blurry reds)
+    # this acts as a way to derive the original frequency information and exact timeings by using
+    # the differential of the signals to derive the luma and chroma filters
+    # optimized over aa known spec
 
-    # return to real signal
+    # this links the two TBCs together sync -> burst phase; and burst_phase -> sync
+    # Closed-Loop Time Based Correction
+    # uses FFT theories to influence the both TBC paths for feed forward correction
+
+    # TODO: incorporate downscaled RF data to get the real part of this feedfoward data
+    #       so we can get the real part of luma / chroma amplitude (luma has constant amplitude, no phase change)
+
     chroma_padded = sps_fft.irfft(F_filtered, n=N_up)
-
-    # remove padding
     return chroma_padded[pad_left : pad_left + N_raw]
 
 
@@ -1970,6 +2044,7 @@ def process_chroma(
         uphet,
         field.rf.SysParams["fsc_mhz"] * 1e6,
         field.rf.DecoderParams["color_under_carrier"],
+        field.rf.field_averages.group_delay,
         1.3e6, # lower chroma bandwidth (roughly this for PAL / NTSC)
         80.0   # heterodyne up-mixing attenuation
     )

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -5,6 +5,7 @@ import lddecode.core as ldd
 import scipy.signal as sps
 import scipy.fft as sps_fft
 from vhsdecode.rust_utils import sosfiltfilt_rust
+from vhsdecode.addons.ringing_cancellation import FFT_LEN as GROUP_DELAY_FFT_LEN
 
 import numba
 from numba import njit
@@ -1758,14 +1759,13 @@ def _chroma_phase_correction_from_sync(
     fft_len
 ) -> np.ndarray:
     freqs_up = sps_fft.rfftfreq(fft_len, d=1.0 / (fsc * 4.0))
-    group_delay_state_fft_len = 512
     
     # Fast exit if no valid measurements have been accumulated
     if len(group_delay_state) == 0 or group_delay_state[0].get('count', 0) == 0:
         return np.ones_like(freqs_up, dtype=np.complex128)
 
     phase_correction = np.zeros_like(freqs_up, dtype=np.float64)
-    scale_factor = group_delay_state_fft_len / fft_len
+    scale_factor = GROUP_DELAY_FFT_LEN / fft_len
     
     # 1. Extract the new state shape (Ring Buffer)
     state_dict = group_delay_state[0]

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -1751,7 +1751,6 @@ def _gen_chroma_fft_filter(
 
     return mask
 
-
 def _chroma_phase_correction_from_sync(
     fsc,
     color_under_carrier_f,
@@ -1760,49 +1759,58 @@ def _chroma_phase_correction_from_sync(
 ) -> np.ndarray:
     freqs_up = sps_fft.rfftfreq(fft_len, d=1.0 / (fsc * 4.0))
     group_delay_state_fft_len = 512
+    
+    # Fast exit if no valid measurements have been accumulated
+    if len(group_delay_state) == 0 or group_delay_state[0].get('count', 0) == 0:
+        return np.ones_like(freqs_up, dtype=np.complex128)
 
     phase_correction = np.zeros_like(freqs_up, dtype=np.float64)
-    rolling_S_xy = np.zeros(group_delay_state_fft_len, dtype=np.complex128)
-
     scale_factor = group_delay_state_fft_len / fft_len
     
-    for measurement in group_delay_state:
-        rolling_S_xy += measurement.get('s_xy')
-        phase_error_base = -np.unwrap(np.angle(rolling_S_xy))
-            
-        # Upscale the base 512 phase error vector to match the rfft bin count
-        old_x = np.linspace(0.0, 1.0, len(phase_error_base))
-        new_x = np.linspace(0.0, 1.0, len(freqs_up))
+    # 1. Extract the new state shape (Ring Buffer)
+    state_dict = group_delay_state[0]
+    valid_count = state_dict['count']
+    
+    # 2. Compute the aggregate S_xy directly from the history buffer
+    # (Summing the complex vectors achieves the same phase as the old iterative += method)
+    rolling_S_xy = np.sum(state_dict['s_xy_history'][:valid_count], axis=0)
+    
+    # 3. Calculate Phase Error
+    phase_error_base = -np.unwrap(np.angle(rolling_S_xy))
         
-        base_complex = np.exp(-1j * phase_error_base)
-        upscaled_complex = (
-            np.interp(new_x, old_x, base_complex.real) + 
-            1j * np.interp(new_x, old_x, base_complex.imag)
-        )
-        phase_error = -np.unwrap(np.angle(upscaled_complex))
+    # Upscale the base 512 phase error vector to match the rfft bin count
+    old_x = np.linspace(0.0, 1.0, len(phase_error_base))
+    new_x = np.linspace(0.0, 1.0, len(freqs_up))
+    
+    base_complex = np.exp(-1j * phase_error_base)
+    upscaled_complex = (
+        np.interp(new_x, old_x, base_complex.real) + 
+        1j * np.interp(new_x, old_x, base_complex.imag)
+    )
+    phase_error = -np.unwrap(np.angle(upscaled_complex))
 
-        w_axis = 2.0 * np.pi * np.linspace(0.0, 0.5, len(freqs_up))
-        w_safe = np.where(np.abs(w_axis) < 1e-6, 1e-6, w_axis)
-        measured_group_delay = -np.gradient(phase_error, w_safe)
+    w_axis = 2.0 * np.pi * np.linspace(0.0, 0.5, len(freqs_up))
+    w_safe = np.where(np.abs(w_axis) < 1e-6, 1e-6, w_axis)
+    measured_group_delay = -np.gradient(phase_error, w_safe)
 
-        cu_norm_f = color_under_carrier_f / (fsc * 4.0)
-        chroma_band_mask = (freqs_up > (cu_norm_f - 0.08 * fsc)) & (freqs_up < (cu_norm_f + 0.08 * fsc))
+    cu_norm_f = color_under_carrier_f / (fsc * 4.0)
+    chroma_band_mask = (freqs_up > (cu_norm_f - 0.08 * fsc)) & (freqs_up < (cu_norm_f + 0.08 * fsc))
 
-        delay_modulation = np.clip(
-            measured_group_delay / np.maximum(np.percentile(np.abs(measured_group_delay), 90), 1e-12), 
-            0.5, 2.5
-        )
+    delay_modulation = np.clip(
+        measured_group_delay / np.maximum(np.percentile(np.abs(measured_group_delay), 90), 1e-12), 
+        0.5, 2.5
+    )
 
-        # Weigh this scaling statistically based on how much theroetical reslution
-        # is in sync pulse based fft vs. the burst phase fft, burst phase is higher resolution
-        scaling_weight = np.clip(scale_factor, 0.0, 1.0)
+    # Weigh this scaling statistically based on how much theoretical resolution
+    # is in sync pulse based fft vs. the burst phase fft, burst phase is higher resolution
+    scaling_weight = np.clip(scale_factor, 0.0, 1.0)
 
-        # Apply weighted phase correction
-        phase_correction[chroma_band_mask] = (
-            phase_error[chroma_band_mask] * 
-            delay_modulation[chroma_band_mask] * 
-            scaling_weight
-        )
+    # Apply weighted phase correction (now done once instead of re-written iteratively)
+    phase_correction[chroma_band_mask] = (
+        phase_error[chroma_band_mask] * 
+        delay_modulation[chroma_band_mask] * 
+        scaling_weight
+    )
 
     return np.exp(-1j * phase_correction)
 

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -11,7 +11,7 @@ import vhsdecode.sync as sync
 import vhsdecode.formats as formats
 from vhsdecode.doc import detect_dropouts_rf
 from vhsdecode.chroma import decode_chroma, decode_chroma_phase_rotation
-from vhsdecode.addons.ringing_cancellation import apply_tbc_ringing_correction, plot_tbc_correction_debug
+from vhsdecode.addons.ringing_cancellation import apply_tbc_vhs_deemphasis_correction
 
 from vhsdecode.debug_plot import plot_data_and_pulses
 
@@ -1142,39 +1142,26 @@ class FieldShared:
     def downscale(self, final=False, *args, **kwargs):
         dsout, dsaudio, dsefm = super(FieldShared, self).downscale(final=False, *args, **kwargs)
 
-        front_porch_len = 15
+        front_porch_len = 10
         sync_len = 67
-        back_porch_len = 67
+        back_porch_len = 30
         gain_scale = 1
         target_transition = 3.3
 
-        #plot_tbc_correction_debug(
-        #    dsout,
-        #    self.lineoffset,
-        #    self.linecount + self.lineoffset,
-        #    self.outlinelen,
-        #    self.blanking_level,
-        #    self.sync_tip_level,
-        #    front_porch_len=front_porch_len,
-        #    sync_len=sync_len,
-        #    back_porch_len=back_porch_len,
-        #    gain_scale=gain_scale,
-        #    target_transition=target_transition,
-        #)
-#
-        #dsout = apply_tbc_ringing_correction(
-        #    dsout,
-        #    self.lineoffset,
-        #    self.linecount + self.lineoffset,
-        #    self.outlinelen,
-        #    self.blanking_level,
-        #    self.sync_tip_level,
-        #    front_porch_len=front_porch_len,
-        #    sync_len=sync_len,
-        #    back_porch_len=back_porch_len,
-        #    gain_scale=gain_scale,
-        #    target_transition=target_transition,
-        #)
+        dsout = apply_tbc_vhs_deemphasis_correction(
+            dsout,
+            self.lineoffset,
+            self.linecount + self.lineoffset,
+            self.outlinelen,
+            self.blanking_level,
+            self.sync_tip_level,
+            front_porch_len=front_porch_len,
+            sync_len=sync_len,
+            back_porch_len=back_porch_len,
+            gain_scale=gain_scale,
+            target_transition=target_transition,
+            debug=True
+        )
 
         # hpf = utils.filter_simple(dsout, self.rf.Filters["NLHighPass"])
         # dsout = ynr(dsout, hpf, self.outlinelen)

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -11,7 +11,6 @@ import vhsdecode.sync as sync
 import vhsdecode.formats as formats
 from vhsdecode.doc import detect_dropouts_rf
 from vhsdecode.chroma import decode_chroma, decode_chroma_phase_rotation
-from vhsdecode.addons.ringing_cancellation import apply_tbc_vhs_deemphasis_correction
 
 from vhsdecode.debug_plot import plot_data_and_pulses
 
@@ -1141,27 +1140,6 @@ class FieldShared:
 
     def downscale(self, final=False, *args, **kwargs):
         dsout, dsaudio, dsefm = super(FieldShared, self).downscale(final=False, *args, **kwargs)
-
-        front_porch_len = 10
-        sync_len = 67
-        back_porch_len = 30
-        gain_scale = 1
-        target_transition = 3.3
-
-        dsout = apply_tbc_vhs_deemphasis_correction(
-            dsout,
-            self.lineoffset,
-            self.linecount + self.lineoffset,
-            self.outlinelen,
-            self.blanking_level,
-            self.sync_tip_level,
-            front_porch_len=front_porch_len,
-            sync_len=sync_len,
-            back_porch_len=back_porch_len,
-            gain_scale=gain_scale,
-            target_transition=target_transition,
-            debug=True
-        )
 
         # hpf = utils.filter_simple(dsout, self.rf.Filters["NLHighPass"])
         # dsout = ynr(dsout, hpf, self.outlinelen)

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1165,7 +1165,7 @@ class FieldShared:
                     self.outlinelen,
                     self.rf.DecoderParams["ire0"] + self.rf.DecoderParams["vsync_ire"] * self.rf.DecoderParams["hz_ire"], # sync tip level
                     self.rf.DecoderParams["ire0"], # blanking level
-                    burst_phase_avg=self.burst_phase_avg,
+                    color_under_carrier_fsc_ratio=self.rf.SysParams["fsc_mhz"] / (self.rf.DecoderParams["color_under_carrier"] / 1e6), # TODO might remove crosshatch
                     front_porch_len=front_porch_len,
                     sync_len=sync_len,
                     back_porch_len=back_porch_len,

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1160,11 +1160,13 @@ class FieldShared:
                 self.lineoffset,
                 self.linecount + self.lineoffset,
                 self.outlinelen,
+                self.rf.DecoderParams["ire0"] + self.rf.DecoderParams["vsync_ire"] * self.rf.DecoderParams["hz_ire"], # sync tip level
+                self.rf.DecoderParams["ire0"], # blanking level
                 front_porch_len=front_porch_len,
                 sync_len=sync_len,
                 back_porch_len=back_porch_len,
                 target_transition=target_transition,
-                # state_deque=self.rf.group_delay_state,
+                group_delay_state=self.rf.group_delay_state,
                 debug=False
             )
 

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -11,6 +11,7 @@ import vhsdecode.sync as sync
 import vhsdecode.formats as formats
 from vhsdecode.doc import detect_dropouts_rf
 from vhsdecode.chroma import decode_chroma, decode_chroma_phase_rotation
+from vhsdecode.addons.ringing_cancellation import apply_tbc_ringing_correction, plot_tbc_correction_debug
 
 from vhsdecode.debug_plot import plot_data_and_pulses
 
@@ -1140,6 +1141,40 @@ class FieldShared:
 
     def downscale(self, final=False, *args, **kwargs):
         dsout, dsaudio, dsefm = super(FieldShared, self).downscale(final=False, *args, **kwargs)
+
+        front_porch_len = 15
+        sync_len = 67
+        back_porch_len = 67
+        gain_scale = 1
+        target_transition = 3.3
+
+        #plot_tbc_correction_debug(
+        #    dsout,
+        #    self.lineoffset,
+        #    self.linecount + self.lineoffset,
+        #    self.outlinelen,
+        #    self.blanking_level,
+        #    self.sync_tip_level,
+        #    front_porch_len=front_porch_len,
+        #    sync_len=sync_len,
+        #    back_porch_len=back_porch_len,
+        #    gain_scale=gain_scale,
+        #    target_transition=target_transition,
+        #)
+#
+        #dsout = apply_tbc_ringing_correction(
+        #    dsout,
+        #    self.lineoffset,
+        #    self.linecount + self.lineoffset,
+        #    self.outlinelen,
+        #    self.blanking_level,
+        #    self.sync_tip_level,
+        #    front_porch_len=front_porch_len,
+        #    sync_len=sync_len,
+        #    back_porch_len=back_porch_len,
+        #    gain_scale=gain_scale,
+        #    target_transition=target_transition,
+        #)
 
         # hpf = utils.filter_simple(dsout, self.rf.Filters["NLHighPass"])
         # dsout = ynr(dsout, hpf, self.outlinelen)

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -6,7 +6,7 @@ import lddecode.utils as lddu
 from lddecode.utils import inrange
 from lddecode.utils import hz_to_output_array
 import matplotlib.pyplot as plt
-from vhsdecode.addons.ringing_cancellation import correct_group_delay, apply_adaptive_lti
+from vhsdecode.addons.ringing_cancellation import correct_group_delay, apply_adaptive_luma_transient_improvement
 
 import vhsdecode.sync as sync
 import vhsdecode.formats as formats
@@ -1155,26 +1155,33 @@ class FieldShared:
             back_porch_len = 60
             target_transition = 3.3
 
-            dsout, lti_params = correct_group_delay(
-                dsout,
-                self.lineoffset,
-                self.linecount + self.lineoffset,
-                self.outlinelen,
-                self.rf.DecoderParams["ire0"] + self.rf.DecoderParams["vsync_ire"] * self.rf.DecoderParams["hz_ire"], # sync tip level
-                self.rf.DecoderParams["ire0"], # blanking level
-                front_porch_len=front_porch_len,
-                sync_len=sync_len,
-                back_porch_len=back_porch_len,
-                target_transition=target_transition,
-                group_delay_state=self.rf.field_averages.group_delay,
-                debug=False
-            )
+            # Cancels ringing with an inverse equalization fir filter.
+            # The filter is created from the difference between measured and expected sync pulse shape.
+            if self.rf.options.inverse_eq > -1:
+                dsout, lti_params = correct_group_delay(
+                    dsout,
+                    self.lineoffset,
+                    self.linecount + self.lineoffset,
+                    self.outlinelen,
+                    self.rf.DecoderParams["ire0"] + self.rf.DecoderParams["vsync_ire"] * self.rf.DecoderParams["hz_ire"], # sync tip level
+                    self.rf.DecoderParams["ire0"], # blanking level
+                    front_porch_len=front_porch_len,
+                    sync_len=sync_len,
+                    back_porch_len=back_porch_len,
+                    target_transition=target_transition,
+                    group_delay_state=self.rf.field_averages.group_delay,
+                    debug=self.rf.debug_plot and self.rf.debug_plot.is_plot_requested("inverse_eq")
+                )
 
-            dsout = apply_adaptive_lti(
-                dsout,
-                gain=lti_params['gain'], # TODO Parameterize
-                threshold=lti_params['threshold']  # TODO Parameterize
-            )
+            # run luma transient improvement that restores sharp edges
+            # measurements in group delay correction can inform parameters so no artificial sharpening happens, and only the original slope is restored
+            if self.rf.options.inverse_eq > -1 and self.rf.options.lti_gain != 0:
+                lti_gain = self.rf.options.lti_gain if self.rf.options.lti_gain is not None else lti_params['gain']
+                dsout = apply_adaptive_luma_transient_improvement(
+                    dsout,
+                    gain=lti_gain,
+                    threshold=lti_params['threshold']
+                )
 
             dsout = self.hz_to_output(dsout)
             self.dspicture = dsout

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -6,7 +6,7 @@ import lddecode.utils as lddu
 from lddecode.utils import inrange
 from lddecode.utils import hz_to_output_array
 import matplotlib.pyplot as plt
-from vhsdecode.addons.ringing_cancellation import correct_group_delay, apply_adaptive_luma_transient_improvement
+from vhsdecode.addons.ringing_cancellation import apply_inverse_equalization, apply_adaptive_luma_transient_improvement
 
 import vhsdecode.sync as sync
 import vhsdecode.formats as formats
@@ -1158,7 +1158,7 @@ class FieldShared:
             # Cancels ringing with an inverse equalization fir filter.
             # The filter is created from the difference between measured and expected sync pulse shape.
             if self.rf.options.inverse_eq > -1:
-                dsout, lti_params = correct_group_delay(
+                dsout, lti_params = apply_inverse_equalization(
                     dsout,
                     self.lineoffset,
                     self.linecount + self.lineoffset,
@@ -1177,7 +1177,7 @@ class FieldShared:
             # measurements in group delay correction can inform parameters so no artificial sharpening happens, and only the original slope is restored
             if self.rf.options.inverse_eq > -1 and self.rf.options.lti_gain != 0:
                 lti_gain = self.rf.options.lti_gain if self.rf.options.lti_gain is not None else lti_params['gain']
-                dsout = apply_adaptive_luma_transient_improvement(
+                apply_adaptive_luma_transient_improvement(
                     dsout,
                     gain=lti_gain,
                     threshold=lti_params['threshold']

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1166,7 +1166,7 @@ class FieldShared:
                 sync_len=sync_len,
                 back_porch_len=back_porch_len,
                 target_transition=target_transition,
-                group_delay_state=self.rf.group_delay_state,
+                group_delay_state=self.rf.field_averages.group_delay,
                 debug=False
             )
 

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -6,6 +6,7 @@ import lddecode.utils as lddu
 from lddecode.utils import inrange
 from lddecode.utils import hz_to_output_array
 import matplotlib.pyplot as plt
+from vhsdecode.addons.ringing_cancellation import correct_group_delay
 
 import vhsdecode.sync as sync
 import vhsdecode.formats as formats
@@ -1148,6 +1149,25 @@ class FieldShared:
             dsout = y_comb(dsout, self.outlinelen, y_comb_value)
 
         if final:
+            # TODO parameterize
+            front_porch_len = 10
+            sync_len = 67
+            back_porch_len = 60
+            target_transition = 3.3
+
+            dsout = correct_group_delay(
+                dsout,
+                self.lineoffset,
+                self.linecount + self.lineoffset,
+                self.outlinelen,
+                front_porch_len=front_porch_len,
+                sync_len=sync_len,
+                back_porch_len=back_porch_len,
+                target_transition=target_transition,
+                # state_deque=self.rf.group_delay_state,
+                debug=False
+            )
+
             dsout = self.hz_to_output(dsout)
             self.dspicture = dsout
 

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1165,6 +1165,7 @@ class FieldShared:
                     self.outlinelen,
                     self.rf.DecoderParams["ire0"] + self.rf.DecoderParams["vsync_ire"] * self.rf.DecoderParams["hz_ire"], # sync tip level
                     self.rf.DecoderParams["ire0"], # blanking level
+                    burst_phase_avg=self.burst_phase_avg,
                     front_porch_len=front_porch_len,
                     sync_len=sync_len,
                     back_porch_len=back_porch_len,

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -6,7 +6,7 @@ import lddecode.utils as lddu
 from lddecode.utils import inrange
 from lddecode.utils import hz_to_output_array
 import matplotlib.pyplot as plt
-from vhsdecode.addons.ringing_cancellation import correct_group_delay
+from vhsdecode.addons.ringing_cancellation import correct_group_delay, apply_adaptive_lti
 
 import vhsdecode.sync as sync
 import vhsdecode.formats as formats
@@ -1155,7 +1155,7 @@ class FieldShared:
             back_porch_len = 60
             target_transition = 3.3
 
-            dsout = correct_group_delay(
+            dsout, lti_params = correct_group_delay(
                 dsout,
                 self.lineoffset,
                 self.linecount + self.lineoffset,
@@ -1168,6 +1168,12 @@ class FieldShared:
                 target_transition=target_transition,
                 group_delay_state=self.rf.group_delay_state,
                 debug=False
+            )
+
+            dsout = apply_adaptive_lti(
+                dsout,
+                gain=lti_params['gain'], # TODO Parameterize
+                threshold=lti_params['threshold']  # TODO Parameterize
             )
 
             dsout = self.hz_to_output(dsout)

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1170,7 +1170,7 @@ class FieldShared:
                     sync_len=sync_len,
                     back_porch_len=back_porch_len,
                     target_transition=target_transition,
-                    group_delay_state=self.rf.field_averages.group_delay,
+                    state=self.rf.field_averages.group_delay,
                     debug=self.rf.debug_plot and self.rf.debug_plot.is_plot_requested("inverse_eq")
                 )
 

--- a/vhsdecode/field_averages.py
+++ b/vhsdecode/field_averages.py
@@ -16,7 +16,7 @@ class FieldAverage:
             group_delay_len = 0
 
         self.group_delay_len = group_delay_len
-        self._group_delay = deque(maxlen=self.group_delay_len)
+        self._group_delay = {}
         # self.line_length = StackableMA()
         # self.vsync_dist = StackableMA
 

--- a/vhsdecode/field_averages.py
+++ b/vhsdecode/field_averages.py
@@ -3,17 +3,19 @@ from collections import deque
 
 
 class FieldAverage:
-    def __init__(self):
+    def __init__(self, chroma_agc_fields, group_delay_len):
         self._rf_level = StackableMA()
         
-        # TODO: parameterize
         # disabled by default, add docs indicating that this should be enable for noisy / home video
-        self.chroma_level_len = 0
+        self.chroma_level_len = chroma_agc_fields
         self._chroma_level_even = deque(maxlen=self.chroma_level_len)
         self._chroma_level_odd = deque(maxlen=self.chroma_level_len)
         
-        # TODO: parameterize
-        self.group_delay_len = 8
+        # -1 means this is disabled
+        if group_delay_len == -1:
+            group_delay_len = 0
+
+        self.group_delay_len = group_delay_len
         self._group_delay = deque(maxlen=self.group_delay_len)
         # self.line_length = StackableMA()
         # self.vsync_dist = StackableMA

--- a/vhsdecode/field_averages.py
+++ b/vhsdecode/field_averages.py
@@ -1,10 +1,20 @@
 from vhsdecode.utils import StackableMA
+from collections import deque
 
 
 class FieldAverage:
     def __init__(self):
         self._rf_level = StackableMA()
-        self._chroma_level = StackableMA()
+        
+        # TODO: parameterize
+        # disabled by default, add docs indicating that this should be enable for noisy / home video
+        self.chroma_level_len = 0
+        self._chroma_level_even = deque(maxlen=self.chroma_level_len)
+        self._chroma_level_odd = deque(maxlen=self.chroma_level_len)
+        
+        # TODO: parameterize
+        self.group_delay_len = 8
+        self._group_delay = deque(maxlen=self.group_delay_len)
         # self.line_length = StackableMA()
         # self.vsync_dist = StackableMA
 
@@ -12,6 +22,17 @@ class FieldAverage:
     def rf_level(self):
         return self._rf_level
 
+    # even field state for the chroma automatic gain control
     @property
-    def chroma_level(self):
-        return self._chroma_level
+    def chroma_level_even(self):
+        return self._chroma_level_even
+    
+    # odd field state for the chroma automatic gain control
+    @property
+    def chroma_level_odd(self):
+        return self._chroma_level_odd
+    
+    # state for the group delay processing that happens in FieldShared.downscale
+    @property
+    def group_delay(self):
+        return self._group_delay

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -188,6 +188,28 @@ def main(args=None, use_gui=False):
         ),
     )
     luma_group.add_argument(
+        "--inverse_eq",
+        type=int,
+        default=4,
+        help=(
+            "Number of fields to average when applying sync pulse inverse equalization (i.e. de-ringing based on the sync pulse)"
+            "\n  Default is 4. 0 disables averaging. Set to -1 to disable inverse equalization."
+        ),
+    )
+    luma_group.add_argument(
+        "--lti_gain",
+        type=float,
+        default=None,
+        help=(
+            "Sets the amount of Luma Transient Improvement to apply. `--inverse_eq` is required to be enabled for this to take effect."
+            "\n  This performs a subtle sharpening of the luma transients based on data gathered by the inverse eq process."
+            "\n  Default is determined automatically by inverse eq."
+            "\n  * 0   disabled"
+            "\n  * 0.5 half"
+            "\n  * 1   full"
+        ),
+    )
+    luma_group.add_argument(
         "--high_boost",
         metavar="High frequency boost multiplier",
         type=float,
@@ -291,6 +313,16 @@ def main(args=None, use_gui=False):
         help="Enable y comb filter, optionally specifying IRE limit.",
     )
     chroma_group = parser.add_argument_group("Chroma decoding options")
+    chroma_group.add_argument(
+        "--cagc",
+        dest="cagc_fields",
+        type=int,
+        default=0,
+        help=(
+            "Sets the number of fields to use for averaging chroma automatic gain control. Default is 0 (no averaging). "
+            "\nThis is useful for correcting chroma gain issues commonly present in camcorder recordings."
+        ),
+    )
     chroma_group.add_argument(
         "--cafc",
         "--chroma_AFC",
@@ -398,7 +430,7 @@ def main(args=None, use_gui=False):
             " some of the chroma processing."
         ),
     )
-    plot_options = "demodblock, deemphasis, raw_pulses, line_locs, rf_luma, vsync_levels"
+    plot_options = "demodblock, deemphasis, raw_pulses, line_locs, rf_luma, vsync_levels, inverse_eq"
     debug_group.add_argument(
         "--dp",
         "--debug_plot",
@@ -636,6 +668,7 @@ def main(args=None, use_gui=False):
     rf_options["cti_mix"] = args.cti_mix
     rf_options["cti_width"] = args.cti_width
     rf_options["cafc"] = args.cafc
+    rf_options["cagc_fields"] = args.cagc_fields
     rf_options["disable_right_hsync"] = args.disable_right_hsync
     rf_options["fallback_vsync"] = args.fallback_vsync
     rf_options["relaxed_line0"] = args.relaxed_line0
@@ -645,6 +678,8 @@ def main(args=None, use_gui=False):
     rf_options["export_raw_tbc"] = args.export_raw_tbc
     rf_options["tape_speed"] = args.tape_speed
     rf_options["ire0_adjust"] = args.ire0_adjust
+    rf_options["inverse_eq"] = args.inverse_eq
+    rf_options["lti_gain"] = args.lti_gain
     rf_options["detect_chroma_track_phase"] = args.detect_chroma_track_phase
     rf_options["enable_color_killer"] = args.enable_color_killer
     rf_options["disable_burst_hsync"] = args.disable_burst_hsync

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -203,10 +203,10 @@ def main(args=None, use_gui=False):
         help=(
             "Sets the amount of Luma Transient Improvement to apply. `--inverse_eq` is required to be enabled for this to take effect."
             "\n  This performs a subtle sharpening of the luma transients based on data gathered by the inverse eq process."
-            "\n  Default is determined automatically by inverse eq."
-            "\n  * 0   disabled"
-            "\n  * 0.5 half"
-            "\n  * 1   full"
+            "\n  * (omitted) auto (default)"
+            "\n  * 0         disabled"
+            "\n  * 0.5       half"
+            "\n  * 1         full"
         ),
     )
     luma_group.add_argument(

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -761,9 +761,12 @@ class VHSRFDecode(ldd.RFDecode):
                 "fm_audio_notch",
                 "chroma_audio_notch",
                 "chroma_offset",
+                "cagc_fields",
                 "cti_mix",
                 "cti_width",
                 "ire0_adjust",
+                "inverse_eq",
+                "lti_gain",
                 "gnrc_afe",
                 "relaxed_line0",
                 "detect_chroma_track_phase",
@@ -806,9 +809,12 @@ class VHSRFDecode(ldd.RFDecode):
             rf_options.get("fm_audio_notch", 0) or (tape_format == "HI8"),
             self.DecoderParams.get("chroma_audio_notch_freq", 0) > 0,
             int(self.DecoderParams.get("chroma_offset", 5) * (self.freq / 40.0)),
+            rf_options.get("cagc_fields", 0),
             rf_options.get("cti_mix", 1),
             rf_options.get("cti_width", 2),
             ire0_adjust,
+            rf_options.get("inverse_eq", 4),
+            rf_options.get("lti_gain", None),
             rf_options.get("gnrc_afe", False),
             rf_options.get("relaxed_line0", False),
             rf_options.get("detect_chroma_track_phase", False),
@@ -976,7 +982,10 @@ class VHSRFDecode(ldd.RFDecode):
                 window_average=self.SysParams["FPS"] / 2
             ), StackableMA(window_average=self.SysParams["FPS"] / 2)
 
-        self._field_averages = FieldAverage()
+        self._field_averages = FieldAverage(
+            self._options.cagc_fields,
+            self._options.inverse_eq
+        )
 
         # TODO: This should be managed elsewhere.
         self._compute_linelocs_issues = False

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -4,10 +4,9 @@ import numpy as np
 import traceback
 import scipy.signal as sps
 import threading
-from collections import namedtuple
+from collections import namedtuple, deque
 from concurrent.futures import ThreadPoolExecutor
 
-from vhsdecode.addons.ringing_cancellation import apply_tbc_vhs_deemphasis_correction
 
 import lddecode.core as ldd
 
@@ -377,26 +376,6 @@ class VHSDecode(ldd.LDdecode):
 
     def writeout(self, dataset):
         f, fi, (picturey, picturec), audio, efm = dataset
-
-        front_porch_len = 10
-        sync_len = 67
-        back_porch_len = 60
-        gain_scale = 1
-        target_transition = 3.3
-
-        picturey = apply_tbc_vhs_deemphasis_correction(
-            picturey.astype(np.float64),
-            f.lineoffset,
-            f.linecount + f.lineoffset,
-            f.outlinelen,
-            f.blanking_level,
-            f.sync_tip_level,
-            front_porch_len=front_porch_len,
-            sync_len=sync_len,
-            back_porch_len=back_porch_len,
-            target_transition=target_transition,
-            debug=False
-        ).astype(np.int16)
 
         # Remove fields that are currently not used to cut down on space usage.
         # the qt tools will load them as 0 with the current code
@@ -998,6 +977,10 @@ class VHSRFDecode(ldd.RFDecode):
             ), StackableMA(window_average=self.SysParams["FPS"] / 2)
 
         self._field_averages = FieldAverage()
+
+        # state for the group delay processing that happens in FielShared.downscale
+        # TODO: parameterize
+        self.group_delay_state = deque(maxlen=round(self.SysParams["FPS"] * 10))
 
         # TODO: This should be managed elsewhere.
         self._compute_linelocs_issues = False

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -980,7 +980,7 @@ class VHSRFDecode(ldd.RFDecode):
 
         # state for the group delay processing that happens in FielShared.downscale
         # TODO: parameterize
-        self.group_delay_state = deque(maxlen=round(self.SysParams["FPS"] * 10))
+        self.group_delay_state = deque(maxlen=8)#round(self.SysParams["FPS"]))
 
         # TODO: This should be managed elsewhere.
         self._compute_linelocs_issues = False

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -4,7 +4,7 @@ import numpy as np
 import traceback
 import scipy.signal as sps
 import threading
-from collections import namedtuple, deque
+from collections import namedtuple
 from concurrent.futures import ThreadPoolExecutor
 
 
@@ -977,10 +977,6 @@ class VHSRFDecode(ldd.RFDecode):
             ), StackableMA(window_average=self.SysParams["FPS"] / 2)
 
         self._field_averages = FieldAverage()
-
-        # state for the group delay processing that happens in FielShared.downscale
-        # TODO: parameterize
-        self.group_delay_state = deque(maxlen=8)#round(self.SysParams["FPS"]))
 
         # TODO: This should be managed elsewhere.
         self._compute_linelocs_issues = False

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -7,6 +7,8 @@ import threading
 from collections import namedtuple
 from concurrent.futures import ThreadPoolExecutor
 
+from vhsdecode.addons.ringing_cancellation import apply_tbc_vhs_deemphasis_correction
+
 import lddecode.core as ldd
 
 # from lddecode.core import npfft
@@ -375,6 +377,26 @@ class VHSDecode(ldd.LDdecode):
 
     def writeout(self, dataset):
         f, fi, (picturey, picturec), audio, efm = dataset
+
+        front_porch_len = 10
+        sync_len = 67
+        back_porch_len = 60
+        gain_scale = 1
+        target_transition = 3.3
+
+        picturey = apply_tbc_vhs_deemphasis_correction(
+            picturey.astype(np.float64),
+            f.lineoffset,
+            f.linecount + f.lineoffset,
+            f.outlinelen,
+            f.blanking_level,
+            f.sync_tip_level,
+            front_porch_len=front_porch_len,
+            sync_len=sync_len,
+            back_porch_len=back_porch_len,
+            target_transition=target_transition,
+            debug=False
+        ).astype(np.int16)
 
         # Remove fields that are currently not used to cut down on space usage.
         # the qt tools will load them as 0 with the current code


### PR DESCRIPTION
Dependent on #341 

## Ringing Correction
* Removes ringing and other transient distortions from the luma channel
  * This measures the sync pulse rising edge (sync tip -> back porch) and determine the spectral difference between the pulses and the ideal sync pulse shape. This is averaged over 8 fields. A fixed impulse response filter is modeled from this spectral difference, and then is applied over the signal to perform an inverse equalization (i.e. subtracting the spectral difference)

## Luma Transient Improvement
* This increases the slope of the luma transitions based on the measurements and correction amount gathered from the ringing correction stage.
* By default to be very subtle, but it is configurable to produce very sharp and clean luma transitions.