### PR TITLE
Add SECAM (method 1) option to launcher GUI.

### DIFF
--- a/vhsdecode/decode_launcher.py
+++ b/vhsdecode/decode_launcher.py
@@ -106,6 +106,7 @@ SYSTEM_OPTIONS_DECODE = [
     "NTSCJ",
     "PAL",
     "PAL_M",
+    "SECAM",
     "MESECAM",
     "405",
     "819",
@@ -178,6 +179,7 @@ FILENAME_SYSTEM_HINTS: list[tuple[tuple[str, ...], str]] = [
     (("ntsc",), "NTSC"),
     (("pal_m", "pal-m", "palm"), "PAL_M"),
     (("mesecam",), "MESECAM"),
+    (("secam",), "SECAM"),
     (("pal",), "PAL"),
 ]
 


### PR DESCRIPTION
### Checklist

<!--
✅ Please make sure that you have completed the following steps before submitting the pull request:
-->

- [X] I have searched the open pull requests to confirm this change has not already been submitted.
- [X] My branch is up to date with the target branch.
- [X] I have tested my changes and all existing tests pass.
- [X] I have updated documentation where necessary.
- [X] My code follows the project's coding standards (see [CONTRIBUTING.md](CONTRIBUTING.md)).

### Description
Adds _SECAM_ to the system dropdown in decode-launcher.

### Motivation
oyvindln/vhs-decode#337 added support for decoding VHS SECAM (French recording method, method 1) and re-encoding as studio SECAM in the Y/C-separated TBC outputs. It was added to the CLI and vhs-decode-gui, but not added to decode-launcher.

### Testing
- [X] All existing tests pass (`pytest --output-on-failure`)
- [X] Tested manually with: trying out samples from various systems including SECAM, MESCAM, NTSC, PAL.
- [ ] New tests added for: <!-- describe what was tested, or N/A -->

### Screenshots (if applicable)
<img width="719" height="411" alt="decode-launcher SECAM option" src="https://github.com/user-attachments/assets/9238dac2-9223-4de5-91d9-dfbbac742713" />