### PR TITLE
SECAM VHS Method 1 IF clamp and ME-SECAM block-anchored band-pass filter

### DIFF
--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -1972,13 +1972,21 @@ def process_chroma(
     # Mixing the signals will produce waves at the difference and sum of the
     # frequencies. We only want the difference wave which is at the correct color
     # carrier frequency here.
-    uphet = filter_chroma_fft(
-        uphet,
-        field.rf.SysParams["fsc_mhz"] * 1e6,
-        field.rf.DecoderParams["color_under_carrier"],
-        1.3e6, # lower chroma bandwidth (roughly this for PAL / NTSC)
-        80.0   # heterodyne up-mixing attenuation
-    )
+    if field.rf.color_system == "MESECAM":
+        # The restored SECAM FM block is anchored at conversion_lo -
+        # color_under (4.328125 MHz), not fsc, so the fsc-anchored FFT mask
+        # sits ~106 kHz high on it and loses the tight top edge that
+        # suppresses high-side FM splatter from saturated transitions. Keep
+        # the block-anchored Butterworth here.
+        uphet = sosfiltfilt_rust(field.rf.Filters["FChromaFinal"], uphet)
+    else:
+        uphet = filter_chroma_fft(
+            uphet,
+            field.rf.SysParams["fsc_mhz"] * 1e6,
+            field.rf.DecoderParams["color_under_carrier"],
+            1.3e6, # lower chroma bandwidth (roughly this for PAL / NTSC)
+            80.0   # heterodyne up-mixing attenuation
+        )
 
     if do_chroma_deemphasis:
         b, a = field.rf.Filters["chroma_deemphasis"]

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -1148,6 +1148,28 @@ def upconvert_secam_method1(
     envelope = np.abs(analytic)
     phase = np.unwrap(np.angle(analytic))
 
+    # Clamp under-carrier deviation to SECAM's legal window before x4
+    # multiplication.
+    # BT.470-6 Table 2 item 2.12 and BT.1700 Part C Table 4 item 10e limit the
+    # carrier to 3.900-4.756 MHz: the per-component deviation maxima
+    # (D′B -350/+506 kHz, D′R -506/+350 kHz) mirror across the carrier pair, so
+    # both components share the corridor (fOB/4 - 87.5 kHz to fOR/4 + 87.5 kHz
+    # in the under-carrier domain). The studio or broadcast limiter ideally
+    # clipped the pre-corrected color difference to these bounds, so anything
+    # outside the window is noise or a tape channel-truncation transient; x4
+    # multiply would scale such excursions x4 and downstream de-emphasis smears
+    # them into streaks at saturated transitions ("fire"). Clipping
+    # instantaneous frequency and reintegrating keeps the carrier segment
+    # smooth: clipped spans become constant-frequency stretches.
+    f_under = np.gradient(phase) * (samp_rate / (2.0 * np.pi))
+    np.clip(
+        f_under,
+        SECAM_FOB / 4 - 350e3 / 4,
+        SECAM_FOR / 4 + 350e3 / 4,
+        out=f_under,
+    )
+    phase = np.cumsum(f_under) * (2.0 * np.pi / samp_rate)
+
     # Restored instantaneous frequency for the bell shaping. Central
     # difference plus a short moving average keeps sample-level phase noise
     # from ending up as amplitude noise; the bell curve itself is smooth so


### PR DESCRIPTION
### Checklist
- [X] I have searched the open pull requests to confirm this change has not already been submitted.
- [X] My branch is up to date with the target branch.
- [X] I have tested my changes and all existing tests pass.
- [X] I have updated documentation where necessary.
- [X] My code follows the project's coding standards (see [CONTRIBUTING.md](CONTRIBUTING.md)).

### Description
Two quality improvements for time-base-corrected SECAM output, one a fix for a regression in ME-SECAM filtering, the other a clamp on SECAM Method 1 intermediate chroma bandwidth.

#### ME-SECAM filter regression
9dadc1ca added a super-Gaussian FFT mask anchored on fSC, but the restored SECAM FM block sits ~106 kHz below it. The mask also dropped the tight +0.55 MHz top edge that suppressed high-side FM splatter at saturated
transitions.

#### SECAM VHS method 1 clamping to studio-range/broadcast-safe SECAM
The VHS color-under channel truncates FM sidebands of pre-emphasized edges, the resulting instantaneous-frequency transients swing outside SECAM's legal deviation range, the x4 phase multiplication scales them up fourfold, and every downstream SECAM decoder's de-emphasis then smears them into streaks. These excursions are provably not signal, so they can be removed at the one stage where they are still small: the under-carrier domain, before the 4x multiply.

### Motivation
I performed a new battery of visual quality testing against SECAM VHS method 1 and ME-SECAM samples with upcoming chroma decoding tooling.

### Changes Made
- Restore the block-anchored `FChromaFinal` Butterworth for ME-SECAM. PAL and NTSC keep the fancy super-Gaussian FFT mask.
- Clamp the instantaneous frequency of the color-under 1/4 carrier of SECAM VHS method 1 recordings to be within the original signal's legal range.

### Testing
- [X] All existing tests pass (`pytest --output-on-failure`)
- [X] Tested manually with: SECAM and ME-SECAM RF samples
- [ ] New tests added for: <!-- describe what was tested, or N/A -->

### Screenshots (if applicable)
Before IF clamping:
<img width="922" height="576" alt="SECAM1 Before IF Clamp" src="https://github.com/user-attachments/assets/e9b3e691-dc87-4cbd-8260-09c0080e5d1c" />
After IF clamping:
<img width="922" height="576" alt="SECAM1 After IF Clamp" src="https://github.com/user-attachments/assets/754b5e52-629b-4ffe-ab03-fa5bda858612" />

### Additional Notes
For specification of the broadcast-safe studio-legal SECAM bandwidth constraints used in the clamping:
* [ITU-R BT.1700-0](https://www.itu.int/rec/R-REC-BT.1700/recommendation.asp?lang=en&parent=R-REC-BT.1700-0-200502-I)
* [ITU-R BT.470-6](https://www.itu.int/rec/R-REC-BT.470/recommendation.asp?lang=en&parent=R-REC-BT.470-6-199811-S)
