### PR TITLE
fix(hifi): declare libnuma bitmask pointer types for ctypes

### DIFF
--- a/vhsdecode/hifi/utils.py
+++ b/vhsdecode/hifi/utils.py
@@ -116,6 +116,15 @@ class NUMA:
                 ctypes.c_size_t,
                 ctypes.c_int,
             ]
+            # these take/return struct bitmask*; without an explicit restype
+            # ctypes assumes c_int and truncates the pointer to 32 bits
+            libnuma.numa_allocate_nodemask.restype = ctypes.c_void_p
+            libnuma.numa_bitmask_clearall.argtypes = [ctypes.c_void_p]
+            libnuma.numa_bitmask_clearall.restype = ctypes.c_void_p
+            libnuma.numa_bitmask_setbit.argtypes = [ctypes.c_void_p, ctypes.c_uint]
+            libnuma.numa_bitmask_setbit.restype = ctypes.c_void_p
+            libnuma.numa_run_on_node_mask.argtypes = [ctypes.c_void_p]
+            libnuma.numa_run_on_node_mask.restype = ctypes.c_int
 
             cls._libnuma = libnuma
             return libnuma


### PR DESCRIPTION
Fixes #349.

`NUMA.bind_process()` calls four libnuma bitmask functions whose prototypes were never declared on the `CDLL` handle:

```python
mask = cls._libnuma.numa_allocate_nodemask()   # returns struct bitmask *
cls._libnuma.numa_bitmask_clearall(mask)
cls._libnuma.numa_bitmask_setbit(mask, node)
cls._libnuma.numa_run_on_node_mask(mask)
```

Without an explicit `restype`, ctypes assumes `c_int`, so the 64-bit `struct bitmask *` returned by `numa_allocate_nodemask()` is truncated to 32 bits and sign-extended. `numa_bitmask_clearall()` then dereferences that address and the process dies with SIGSEGV — before any audio is decoded, and not catchable by the surrounding `except Exception`.

This makes `hifi-decode` unusable on any Linux system with `libnuma.so.1` present, including single-NUMA-node machines where the binding is a no-op anyway. macOS and Windows are unaffected because `ctypes.CDLL("libnuma.so.1")` raises there and `_available()` short-circuits.

Declaring the types is enough; no logic changes.

### Verification

Before, on Arch / Python 3.14.6 / numactl 2.0.19, single NUMA node:

```
$ python -c "from vhsdecode.hifi.utils import NUMA; NUMA.bind_process(0)"
Segmentation fault (core dumped)
```

After:

```
$ python -c "from vhsdecode.hifi.utils import NUMA; print(NUMA.bind_process(0))"
True
```

A real 10 GB PAL HiFi capture that reproducibly segfaulted within ~2 s now decodes normally at 3.6x, and the resulting audio is unchanged from a pre-#331 decode of the same capture.

Marked as draft: I only have a single-node machine here, so the multi-node path (`numa_run_on_node_mask` actually binding to something other than node 0) is untested. If someone with a dual-socket box can confirm, I will mark it ready.
