### PR TITLE
Chroma amplitude correction from the luma FM carrier

### DIFF
--- a/cvbsdecode/process.py
+++ b/cvbsdecode/process.py
@@ -865,13 +865,19 @@ class CVBSDecodeInner(ldd.RFDecode):
             plt.show()
         #            exit(0)
 
-        video_out = np.rec.array(
-            [luma, luma05, videoburst],
-            names=["demod", "demod_05", "demod_burst"],
-        )
+        video_out = {
+            "demod": luma,
+            "demod_05": luma05,
+            "demod_burst": videoburst,
+        }
 
         rv["video"] = (
-            video_out[self.blockcut : -self.blockcut_end] if cut else video_out
+            {
+                name: channel[self.blockcut : -self.blockcut_end]
+                for name, channel in video_out.items()
+            }
+            if cut
+            else video_out
         )
 
         return rv

--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -2651,8 +2651,7 @@ class Field:
         audio=0,
         final=False,
         lastfieldwritten=None,
-        shift=0,
-        level_adjust=True
+        shift=0
     ):
         if lineinfo is None:
             lineinfo = self.linelocs
@@ -2720,8 +2719,7 @@ class Field:
             self.lineoffset,
             outwidth,
             wow_level_adjust_smoothing=self.wow_level_adjust_smoothing,
-            shift=shift,
-            apply_level_adjust=level_adjust
+            shift=shift
         )
 
         if self.rf.decode_digital_audio:

--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -2651,7 +2651,8 @@ class Field:
         audio=0,
         final=False,
         lastfieldwritten=None,
-        shift=0
+        shift=0,
+        level_adjust=True
     ):
         if lineinfo is None:
             lineinfo = self.linelocs
@@ -2719,7 +2720,8 @@ class Field:
             self.lineoffset,
             outwidth,
             wow_level_adjust_smoothing=self.wow_level_adjust_smoothing,
-            shift=shift
+            shift=shift,
+            apply_level_adjust=level_adjust
         )
 
         if self.rf.decode_digital_audio:

--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -837,30 +837,28 @@ class RFDecode:
 
         if self.system == "PAL":
             out_videopilot = npfft.ifft(demod_fft * self.Filters["FVideoPilot"]).real
-            video_out = np.rec.array(
-                [
-                    out_video.astype(np.float32),
-                    demod.astype(np.float32),
-                    out_video05.astype(np.float32),
-                    out_videoburst.astype(np.float32),
-                    out_videopilot.astype(np.float32),
-                ],
-                names=[
-                    "demod",
-                    "demod_raw",
-                    "demod_05",
-                    "demod_burst",
-                    "demod_pilot",
-                ],
-            )
+            video_out = {
+                "demod": out_video.astype(np.float32),
+                "demod_raw": demod.astype(np.float32),
+                "demod_05": out_video05.astype(np.float32),
+                "demod_burst": out_videoburst.astype(np.float32),
+                "demod_pilot": out_videopilot.astype(np.float32),
+            }
         else:
-            video_out = np.rec.array(
-                [out_video.astype(np.float32), demod.astype(np.float32), out_video05.astype(np.float32), out_videoburst.astype(np.float32)],
-                names=["demod", "demod_raw", "demod_05", "demod_burst"],
-            )
+            video_out = {
+                "demod": out_video.astype(np.float32),
+                "demod_raw": demod.astype(np.float32),
+                "demod_05": out_video05.astype(np.float32),
+                "demod_burst": out_videoburst.astype(np.float32),
+            }
 
         rv["video"] = (
-            video_out[self.blockcut : -self.blockcut_end] if cut else video_out
+            {
+                name: channel[self.blockcut : -self.blockcut_end]
+                for name, channel in video_out.items()
+            }
+            if cut
+            else video_out
         )
 
         if self.decode_digital_audio:
@@ -1419,7 +1417,19 @@ class DemodCache:
 
         rv = {}
         for k in t.keys():
-            rv[k] = np.concatenate(t[k]) if len(t[k]) else None
+            if not len(t[k]):
+                rv[k] = None
+            elif isinstance(t[k][0], dict):
+                # The video channels are separate arrays rather than one
+                # interleaved record, so each concatenates on its own - a plain
+                # contiguous copy per channel, and every consumer afterwards
+                # reads the channel it wants without walking the others' bytes.
+                rv[k] = {
+                    name: np.concatenate([block[name] for block in t[k]])
+                    for name in t[k][0]
+                }
+            else:
+                rv[k] = np.concatenate(t[k])
 
         if rv["audio"] is not None:
             rv["audio_phase1"] = rv["audio"]

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -143,31 +143,28 @@ sinc_phase_count = 2**16
 
 
 @njit(nogil=True, fastmath=True)
-def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, sinc_lut, lineoffset, outwidth, wow_level_adjust_smoothing = 0, level_adjust_threshold = 15, shift=0.0, apply_level_adjust=True):
+def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, sinc_lut, lineoffset, outwidth, wow_level_adjust_smoothing = 0, level_adjust_threshold = 15, shift=0.0):
     # average out any unusual spikes in wow that happen on a per line basis
     # this indicates an hsync tbc error vs. being normal wow from playback speed variations
     # in this case for level adjusting we just want to fallback to the average wow to avoid a bright or dark line
-    if apply_level_adjust:
-        median = np.median(wowfactors)
-        mad = np.median(np.abs(wowfactors - median)) # median absolute deviation
-        threshold = level_adjust_threshold * mad if mad > 0 else 0.001  # fallback for no variance
+    median = np.median(wowfactors)
+    mad = np.median(np.abs(wowfactors - median)) # median absolute deviation
+    threshold = level_adjust_threshold * mad if mad > 0 else 0.001  # fallback for no variance
 
-        level_adjusts = np.where(
-            np.abs(wowfactors - median) > threshold,
-            median,
-            wowfactors
-        )
+    level_adjusts = np.where(
+        np.abs(wowfactors - median) > threshold,
+        median,
+        wowfactors
+    )
 
-        if wow_level_adjust_smoothing > 0:
-            # removes oscillating brightness variations for video with lots of noise around the hsync pulses, i.e. noisy line locations result in noisy wow calculations
-            # applies a low pass filter that smooths any sudden brightness variations while still being reactive enough to compensate for low frequency wow
-            alpha = 1 / (wow_level_adjust_smoothing * outwidth)
-            one_minus_alpha = 1 - alpha
+    if wow_level_adjust_smoothing > 0:
+        # removes oscillating brightness variations for video with lots of noise around the hsync pulses, i.e. noisy line locations result in noisy wow calculations
+        # applies a low pass filter that smooths any sudden brightness variations while still being reactive enough to compensate for low frequency wow
+        alpha = 1 / (wow_level_adjust_smoothing * outwidth)
+        one_minus_alpha = 1 - alpha
 
-            for i in range(1, len(level_adjusts)):
-                level_adjusts[i] = alpha * level_adjusts[i] + one_minus_alpha * level_adjusts[i-1]
-    else:
-        level_adjusts = np.ones(len(wowfactors))
+        for i in range(1, len(level_adjusts)):
+            level_adjusts[i] = alpha * level_adjusts[i] + one_minus_alpha * level_adjusts[i-1]
 
     half_taps_m1 = (sinc_tap_count // 2) - 1
 

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -143,28 +143,31 @@ sinc_phase_count = 2**16
 
 
 @njit(nogil=True, fastmath=True)
-def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, sinc_lut, lineoffset, outwidth, wow_level_adjust_smoothing = 0, level_adjust_threshold = 15, shift=0.0):
+def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, sinc_lut, lineoffset, outwidth, wow_level_adjust_smoothing = 0, level_adjust_threshold = 15, shift=0.0, apply_level_adjust=True):
     # average out any unusual spikes in wow that happen on a per line basis
     # this indicates an hsync tbc error vs. being normal wow from playback speed variations
     # in this case for level adjusting we just want to fallback to the average wow to avoid a bright or dark line
-    median = np.median(wowfactors)
-    mad = np.median(np.abs(wowfactors - median)) # median absolute deviation
-    threshold = level_adjust_threshold * mad if mad > 0 else 0.001  # fallback for no variance
+    if apply_level_adjust:
+        median = np.median(wowfactors)
+        mad = np.median(np.abs(wowfactors - median)) # median absolute deviation
+        threshold = level_adjust_threshold * mad if mad > 0 else 0.001  # fallback for no variance
 
-    level_adjusts = np.where(
-        np.abs(wowfactors - median) > threshold,
-        median,
-        wowfactors
-    )
+        level_adjusts = np.where(
+            np.abs(wowfactors - median) > threshold,
+            median,
+            wowfactors
+        )
 
-    if wow_level_adjust_smoothing > 0:
-        # removes oscillating brightness variations for video with lots of noise around the hsync pulses, i.e. noisy line locations result in noisy wow calculations
-        # applies a low pass filter that smooths any sudden brightness variations while still being reactive enough to compensate for low frequency wow
-        alpha = 1 / (wow_level_adjust_smoothing * outwidth)
-        one_minus_alpha = 1 - alpha
+        if wow_level_adjust_smoothing > 0:
+            # removes oscillating brightness variations for video with lots of noise around the hsync pulses, i.e. noisy line locations result in noisy wow calculations
+            # applies a low pass filter that smooths any sudden brightness variations while still being reactive enough to compensate for low frequency wow
+            alpha = 1 / (wow_level_adjust_smoothing * outwidth)
+            one_minus_alpha = 1 - alpha
 
-        for i in range(1, len(level_adjusts)):
-            level_adjusts[i] = alpha * level_adjusts[i] + one_minus_alpha * level_adjusts[i-1]
+            for i in range(1, len(level_adjusts)):
+                level_adjusts[i] = alpha * level_adjusts[i] + one_minus_alpha * level_adjusts[i-1]
+    else:
+        level_adjusts = np.ones(len(wowfactors))
 
     half_taps_m1 = (sinc_tap_count // 2) - 1
 

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -13,43 +13,6 @@ from numba.experimental import jitclass
 from functools import cache
 
 
-# Sentinel passed to the up-conversion when no envelope-derived amplitude
-# correction is available; numba needs a concrete array of the same dtype.
-EMPTY_CHROMA_GAIN = np.empty(0, dtype=np.float64)
-
-
-def corrected_burst_amplitudes(
-    chroma_gain, phase_sequence, burstarea, lineoffset, outwidth
-):
-    """Each burst's amplitude, as it will be after the correction is applied.
-
-    The burst is measured before the up-conversion and the correction lands
-    inside it, so the amplitude the automatic gain control would otherwise act
-    on is the one from before. Correcting the measurement here keeps the two in
-    step; the mean over the burst window is what the correction does to that
-    window.
-
-    Returns the measured amplitudes unchanged when the correction is off.
-    """
-    amplitudes = np.array(
-        [burst.amplitude for burst in phase_sequence], dtype=np.float64
-    )
-    if len(chroma_gain) == 0:
-        return amplitudes
-
-    for index in range(len(phase_sequence)):
-        line_start = (phase_sequence[index].line_number - lineoffset) * outwidth
-        window_start = line_start + burstarea[0]
-        window_end = line_start + burstarea[1]
-        if (
-            window_start >= 0
-            and window_end <= len(chroma_gain)
-            and window_end > window_start
-        ):
-            amplitudes[index] *= np.mean(chroma_gain[window_start:window_end])
-    return amplitudes
-
-
 # ---------------------------------------------------------------------------
 # Color-under amplitude correction from the luma carrier's amplitude
 #
@@ -130,15 +93,16 @@ REFERENCE_TRACK_WIDTH = 58.0
 
 
 @njit(cache=True, nogil=True, fastmath=True)
-def _envelope_gain_from_deviation(
+def _transfer_exponent(
     deviation,
     carrier_hz,
     color_under_carrier_hz,
     wavelength_independent,
     trust,
     dropout_fraction,
+    exponent,
 ):
-    """The color-under gain that reverses the luma's measured amplitude noise.
+    """The power the luma's amplitude deviation is raised to, per sample.
 
     The exponent is the transfer from luma amplitude loss to color-under
     amplitude loss: the wavelength ratio for the part of the noise that is
@@ -153,48 +117,110 @@ def _envelope_gain_from_deviation(
     collapsed, scaling the chroma up would restore noise rather than
     saturation, so the correction is withdrawn there.
 
-    One pass, in float32 out: this runs over every sample of every field.
+    Arithmetic only, written into a caller-supplied array: this runs over every
+    sample of every field, and raising the deviation to it is left to the
+    ufunc that can do it eight samples at a time.
     """
     count = len(deviation)
-    gain = np.empty(count, dtype=np.float32)
     half = dropout_fraction * dropout_fraction
+    scale = np.float32(1.0) + half
+    unity = np.float32(1.0)
     for i in range(count):
         value = deviation[i]
         squared = value * value
-        confidence = squared * (1.0 + half) / (squared + half)
+        confidence = squared * scale / (squared + half)
         wavelength_ratio = color_under_carrier_hz / carrier_hz[i]
-        exponent = (
+        transfer = (
             wavelength_independent
-            + (1.0 - wavelength_independent) * wavelength_ratio
+            + (unity - wavelength_independent) * wavelength_ratio
         ) * trust
-        gain[i] = np.exp(-exponent * np.log(value) * confidence)
-    return gain
+        exponent[i] = -transfer * confidence
 
 
-def chroma_envelope_gain(field, shift):
-    """The color-under amplitude correction, on the chroma output grid.
+def _envelope_gain_from_deviation(
+    deviation,
+    carrier_hz,
+    color_under_carrier_hz,
+    wavelength_independent,
+    trust,
+    dropout_fraction,
+):
+    """The color-under gain that reverses the luma's measured amplitude noise.
 
-    Measures the luma carrier's amplitude deviation over the field, scales it
-    across to the color-under by the wavelength ratio, and puts it through the
-    identical time base correction the chroma gets.
-
-    Called beside the chroma's own downscale and with the same shift, so the
-    two come off the resampler aligned by construction. Returns None when there
-    is nothing to correct, which leaves the chroma untouched.
+    `deviation ** exponent` is the whole of it. The exponent is assembled in a
+    compiled loop, which is what that kind of branchless per-sample arithmetic
+    is for, and the exponentiation itself is handed to numpy, whose single
+    precision power loop is vectorised - where the same `exp(-e*log(v)*c)`
+    written inside the compiled loop is not, because numba can only vectorise
+    transcendentals through a vector math library this build has no access to.
+    Same arithmetic, an order of magnitude apart in cost.
     """
+    gain = np.empty(len(deviation), dtype=np.float32)
+    _transfer_exponent(
+        deviation,
+        carrier_hz,
+        np.float32(color_under_carrier_hz),
+        np.float32(wavelength_independent),
+        np.float32(trust),
+        np.float32(dropout_fraction),
+        gain,
+    )
+    return np.power(deviation, gain, out=gain)
+
+
+@njit(cache=True, nogil=True, fastmath=True)
+def _scale_color_under(chroma, gain, amount):
+    """Scale the color-under by the correction, in place, on the RF grid.
+
+    A plain multiply is all that is needed. The color-under has been band
+    passed and has had its block mean subtracted, so it is already zero mean
+    and carries no DC term for a time varying gain to turn into a real
+    component at the subcarrier frequency.
+    """
+    one = np.float32(1.0)
+    for i in range(len(gain)):
+        chroma[i] *= one + (gain[i] - one) * amount
+
+
+def apply_chroma_envelope_gain(field):
+    """Reverse the tape's amplitude noise on the color-under, in place.
+
+    Measure the luma envelope for changes in amplitude that do not follow the
+    demodulated signal. Changes in amplitude that are not correlated to the
+    demodulated luma's frequency are likely noise. This uses the luma's
+    carrier's amplitude as a base to measure amplitude based noise and reverse
+    this noise in the QAM color under.
+
+    Applied on the raw RF sample grid, on the field's own copy of the
+    color-under, before anything has been measured from it. The noise was
+    imposed at that rate, so it is reversed at that rate - and everything that
+    reads the color-under afterwards, the burst measurements included, then
+    reads a signal the tape's amplitude noise has already been taken out of.
+
+    Runs once per field. Returns whether it did anything.
+    """
+    if getattr(field, "chroma_envelope_gain_applied", False):
+        return False
+
     rf = field.rf
     decoder_params = rf.DecoderParams
     if rf.options.chroma_env_gain <= 0 or rf.do_cafc:
-        return None
+        # Under chroma AFC this channel is still raw RF, carrying the ADC's own
+        # offset, and the band pass that makes it zero mean has not run yet.
+        return False
     if (
         "color_under_carrier" not in decoder_params
         or "chroma_bpf_upper" not in decoder_params
     ):
-        return None
+        return False
+
+    video = field.data["video"]
+    if video is None or "demod_burst" not in (video.dtype.names or ()):
+        return False
 
     measured = luma_amplitude.measure_amplitude_deviation(field)
     if measured is None:
-        return None
+        return False
     deviation, carrier_hz = measured
 
     # How far the measurement can be trusted at this track width.
@@ -210,27 +236,11 @@ def chroma_envelope_gain(field, shift):
         rf.dod_options.dod_threshold_p,
     )
 
-    # Through the same resampler as the chroma. `Field.downscale` can only
-    # resample a named channel of the field's record array, so this goes through
-    # `scale_field` directly - with the wow level adjustment switched off, since
-    # that adjustment belongs to demodulated signal channels and imposing it on
-    # a measurement would put the timebase's own wow into the correction.
-    outwidth = field.outlinelen
-    resampled = np.zeros(field.outlinecount * outwidth, dtype=np.float32)
-    interpolated_pixel_locs, wowfactors = field.computewow_scaled()
-    lddu.scale_field(
-        gain,
-        resampled,
-        interpolated_pixel_locs,
-        wowfactors,
-        rf.downscale_sinc_lut,
-        field.lineoffset,
-        outwidth,
-        wow_level_adjust_smoothing=field.wow_level_adjust_smoothing,
-        shift=shift,
-        apply_level_adjust=False,
+    _scale_color_under(
+        video["demod_burst"], gain, np.float32(rf.options.chroma_env_gain)
     )
-    return resampled if len(resampled) else None
+    field.chroma_envelope_gain_applied = True
+    return True
 
 
 BURST_START_LINE=10
@@ -242,13 +252,24 @@ def chroma_to_u16(chroma):
     Scale the chroma output array to a 16-bit value for output.
     """
     S16_ABS_MAX = 32767.0
+    U16_MAX = 65535.0
     N = len(chroma)
 
     out = np.empty(N, dtype=np.uint16)
 
     for i in range(N):
-        out[i] = np.uint16(chroma[i] + S16_ABS_MAX)
-        
+        value = chroma[i] + S16_ABS_MAX
+        # Saturate rather than let the cast wrap. Chroma that runs past the
+        # scale is chroma at its limit, and wrapping sends it to the opposite
+        # limit instead - a sample eight counts below the bottom comes out
+        # eight counts from the top, which reads as the complementary hue at
+        # full saturation rather than as the clipped sample it is.
+        if value < 0.0:
+            value = 0.0
+        elif value > U16_MAX:
+            value = U16_MAX
+        out[i] = np.uint16(value)
+
     return out
 
 @njit(cache=False, nogil=True, fastmath=True)
@@ -260,7 +281,6 @@ def chroma_automatic_gain(
     sync_tip_len,
     decode_average,
     decode_average_count,
-    burst_amplitude,
     smoothing_window=8,
     k=2.0
 ):
@@ -286,15 +306,7 @@ def chroma_automatic_gain(
     # extract gain values and track valid amplitudes
     for i in range(burst_count):
         current_burst = phase_sequence[i]
-        # The burst measurements were taken before the envelope-derived
-        # amplitude correction was applied, so scale them by the gain that
-        # correction actually put on the burst window. Without this the two
-        # controls both act on the same per-line level: the correction lifts a
-        # burst the tape attenuated, and the automatic gain then lifts the whole
-        # line again because it is still reading the uncorrected measurement.
-        current_amp = burst_amplitude[i]
-        if current_amp == 0:
-            current_amp = 1e-8
+        current_amp = current_burst.amplitude if current_burst.amplitude != 0 else 1e-8
 
         raw_gain = burst_abs_ref / current_amp
         raw_gains[i] = raw_gain
@@ -1070,9 +1082,7 @@ def upconvert_chroma_phase_comp(
     color_under_carrier_fs,
     fsc,
     target_phase_even,
-    target_phase_odd,
-    chroma_gain,
-    chroma_gain_amount
+    target_phase_odd
 ):
     deg2rad_scale = np.pi / 180.0
     pi_over_two = np.pi / 2.0
@@ -1090,9 +1100,6 @@ def upconvert_chroma_phase_comp(
     # Pre-generate a local pixel coordinate array to help Numba vectorize
     # Computing on a local range [0, outwidth) helps the compiler reason about alignment
     local_idx = np.arange(outwidth, dtype=np.float64)
-
-    apply_chroma_gain = chroma_gain_amount > 0.0
-    epsilon = np.finfo(np.float64).tiny
 
     for idx in range(num_bursts):
         current_burst = phase_rotation_sequence[idx]
@@ -1134,39 +1141,13 @@ def upconvert_chroma_phase_comp(
         # Slice target and source arrays to provide direct contiguous memory views
         chroma_slice = chroma[linestart:lineend]
 
-        if apply_chroma_gain:
-            # Amplitude correction from the luma FM envelope. The gain has to
-            # act on zero-mean color under: a residual DC offset multiplied by
-            # a time varying gain and then mixed produces a real component at
-            # the subcarrier frequency, which reads as a synthetic burst, i.e.
-            # hue and saturation error correlated with tape damage. Scaling the
-            # deviation from the line's own fitted DC leaves the DC path
-            # untouched, so a gain of one reproduces the uncorrected result
-            # exactly.
-            gain_slice = chroma_gain[linestart:lineend]
+        # No outer dependencies so LLVM can vectorize
+        for k in range(outwidth):
+            # Compute closed-form phase directly (no dependency on previous k)
+            theta_k = theta_0 + alpha * local_idx[k] + beta * (local_idx[k] * local_idx[k])
 
-            # No outer dependencies so LLVM can vectorize
-            for k in range(outwidth):
-                # Compute closed-form phase directly (no dependency on previous k)
-                theta_k = theta_0 + alpha * local_idx[k] + beta * (local_idx[k] * local_idx[k])
-
-                gain_k = gain_slice[k]
-                if gain_k < epsilon:
-                    gain_k = epsilon
-                gain_k = 1.0 + (gain_k - 1.0) * chroma_gain_amount
-
-                # Vectorized trigonometric and arithmetic execution
-                corrected = dc_val + (chroma_slice[k] - dc_val) * gain_k
-                chroma_slice[k] = corrected * -np.cos(theta_k) - dc_val
-        else:
-            # No outer dependencies so LLVM can vectorize
-            for k in range(outwidth):
-                # Compute closed-form phase directly (no dependency on previous k)
-                theta_k = theta_0 + alpha * local_idx[k] + beta * (local_idx[k] * local_idx[k])
-
-                # Vectorized trigonometric and arithmetic execution
-                chroma_slice[k] = chroma_slice[k] * -np.cos(theta_k) - dc_val
-
+            # Vectorized trigonometric and arithmetic execution
+            chroma_slice[k] = chroma_slice[k] * -np.cos(theta_k) - dc_val
 
 @njit(cache=True, nogil=True)
 def burst_deemphasis(chroma, lineoffset, linesout, outwidth, burstarea):
@@ -2119,9 +2100,6 @@ def process_chroma(
         chroma_downscale_shift = chroma_subcarrier_delay_samples * chroma_shift_direction
 
         chroma, _, _ = ldd.Field.downscale(field, channel="demod_burst", shift=chroma_downscale_shift)
-        # The luma amplitude correction rides the identical time base correction,
-        # with the same shift, so it lands on the samples it was measured from.
-        chroma_env_gain = chroma_envelope_gain(field, chroma_downscale_shift)
 
         # If chroma AFC is enabled
         if field.rf.do_cafc:
@@ -2168,10 +2146,8 @@ def process_chroma(
 
         field.rf.chroma_tbc_buffer = chroma
         field.chroma_tbc_buffer = chroma
-        field.chroma_env_gain_buffer = chroma_env_gain
     else:
         chroma = field.chroma_tbc_buffer
-        chroma_env_gain = field.chroma_env_gain_buffer
 
     burstarea = get_burst_area(field)
 
@@ -2206,21 +2182,6 @@ def process_chroma(
         # this uses the burst measurements to interpolate the correct phase of the color under heterodyne
         # phase issues are corrected continiously for each sample using a linear spline interpolated from the burst measurements
         # the mixing is performed on the upsampled signal to avoid aliasing introduced from the up-heterodyne mixing product
-        # Per-sample color-under amplitude correction measured from the luma
-        # FM envelope. Both bands were written by the same head at the same
-        # instant, so head-to-medium separation is shared between them and the
-        # envelope supplies the intra-line gain profile the once-per-line burst
-        # cannot see. An empty array leaves the up-conversion unchanged.
-        # Measure the luma envelope for changes in amplitude that do not follow the demodulated signal
-        # Changes in amplitude that are not correlated to the demodulated luma's frequency are likely noise
-        # This uses the luma's carrier's amplitude as a base to measure amplitude based noise and reverse this noise in the QAM color under
-        #
-        chroma_gain = EMPTY_CHROMA_GAIN
-        chroma_gain_amount = 0.0
-        if chroma_env_gain is not None and len(chroma_env_gain) == len(chroma):
-            chroma_gain = chroma_env_gain.astype(np.float64)
-            chroma_gain_amount = field.rf.options.chroma_env_gain
-
         upconvert_chroma_phase_comp(
             chroma, # modifies this in place
             lineoffset,
@@ -2230,8 +2191,6 @@ def process_chroma(
             field.rf.SysParams["fsc_mhz"] * 1e6,
             target_phase_even,
             target_phase_odd,
-            chroma_gain,
-            chroma_gain_amount,
         )
         uphet = chroma
     else:
@@ -2317,12 +2276,6 @@ def process_chroma(
     else:
         decode_average = 0
 
-    # The burst amplitudes the correction leaves behind, so the automatic gain
-    # control measures the signal it is actually acting on.
-    burst_amplitude = corrected_burst_amplitudes(
-        chroma_gain, field.phase_sequence, burstarea, lineoffset, outwidth
-    )
-
     field_average, chroma_noise_floor = chroma_automatic_gain(
         uphet,
         field.rf.SysParams["burst_abs_ref"],
@@ -2330,8 +2283,7 @@ def process_chroma(
         field.burst_detected_line,
         math.floor(field.usectooutpx(field.rf.SysParams["hsyncPulseUS"])),
         decode_average,
-        decode_average_count,
-        burst_amplitude,
+        decode_average_count
     )
 
     chroma_average_state.append((field_average, chroma_noise_floor))

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -34,6 +34,8 @@ def chroma_automatic_gain(
     phase_sequence,
     burst_detected_line,
     sync_tip_len,
+    decode_average,
+    decode_average_count,
     smoothing_window=8,
     k=2.0
 ):
@@ -43,6 +45,18 @@ def chroma_automatic_gain(
     valid_gains = np.empty(burst_count, dtype=np.float64)
     valid_amps = np.empty(burst_count, dtype=np.float64)
     valid_count = 0
+
+    # scale the reference gain based on the average previous decodes
+    # decode average is the uncorrected average amplitude, burst abs ref is the target reference.
+    #   For example, with a decode average consisting of 8 fields, and this is current processing field 9, 
+    #   Scale the amount of gain applied to use 8/9 the ratio of these values and 1/9 the ratio of the actual measurement
+    if decode_average_count > 0:
+        decode_average_numerator = decode_average_count / (decode_average_count + 1)
+        decode_average_denominator = 1 / (decode_average_count + 1)
+        decode_average_gain = (burst_abs_ref / decode_average) * decode_average_numerator
+    else:
+        decode_average_gain = 0
+        decode_average_denominator = 1
 
     # extract gain values and track valid amplitudes
     for i in range(burst_count):
@@ -63,11 +77,16 @@ def chroma_automatic_gain(
         median_gain = np.median(active_gains)
         mad_gain = np.median(np.abs(active_gains - median_gain))
         max_allowable_gain = median_gain + (k * mad_gain)
+        min_allowable_gain = median_gain - k * mad_gain
     else:
-        max_allowable_gain = 1.0
+        max_allowable_gain = 1
+        min_allowable_gain = 0
 
     # clamp gains
-    clamped_gains = np.minimum(raw_gains, max_allowable_gain)
+    clamped_gains = np.clip(raw_gains, min_allowable_gain, max_allowable_gain)
+
+    # apply gain averaging across fields
+    clamped_gains = decode_average_gain + (clamped_gains * decode_average_denominator)
 
     # calculate smoothing
     smoothed_gains = np.empty(burst_count, dtype=np.float64)
@@ -1717,9 +1736,6 @@ def _process_chroma_secam_method1(field, chroma, linesout, outwidth, burstarea):
         porch_rms_total += lddu.rms(
             uphet[linestart + burstarea[0] : linestart + burstarea[1]]
         )
-    field.rf.field_averages.chroma_level.push(
-        porch_rms_total / (linesout - STARTING_LINE)
-    )
 
     return uphet
 
@@ -2000,15 +2016,31 @@ def process_chroma(
             uphet = comb_c_pal(uphet, outwidth)
 
     # Chroma AGC
-    mean_rms, chroma_noise_floor = chroma_automatic_gain(
+    # average ACG over each field
+    # save a separate gain per field
+    chroma_average_state = (
+        field.rf.field_averages.chroma_level_even
+        if field.field_number % 2 == 0 else
+        field.rf.field_averages.chroma_level_odd
+    )
+
+    decode_average_count = len(chroma_average_state)
+    if decode_average_count > 0:
+        decode_average = np.mean([c[0] for c in chroma_average_state])
+    else:
+        decode_average = 0
+
+    field_average, chroma_noise_floor = chroma_automatic_gain(
         uphet,
         field.rf.SysParams["burst_abs_ref"],
         field.phase_sequence,
         field.burst_detected_line,
-        math.floor(field.usectooutpx(field.rf.SysParams["hsyncPulseUS"]))
+        math.floor(field.usectooutpx(field.rf.SysParams["hsyncPulseUS"])),
+        decode_average,
+        decode_average_count
     )
 
-    field.rf.field_averages.chroma_level.push(mean_rms)
+    chroma_average_state.append((field_average, chroma_noise_floor))
 
     if field.rf.options.cti_mix != 0:
         chroma_transient_improvement(

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -215,7 +215,7 @@ def apply_chroma_envelope_gain(field):
         return False
 
     video = field.data["video"]
-    if video is None or "demod_burst" not in (video.dtype.names or ()):
+    if video is None or "demod_burst" not in video:
         return False
 
     measured = luma_amplitude.measure_amplitude_deviation(field)

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -5,11 +5,235 @@ import lddecode.core as ldd
 import scipy.signal as sps
 import scipy.fft as sps_fft
 from vhsdecode.rust_utils import sosfiltfilt_rust
+from vhsdecode import luma_amplitude
 
 import numba
 from numba import njit
 from numba.experimental import jitclass
 from functools import cache
+
+
+# Sentinel passed to the up-conversion when no envelope-derived amplitude
+# correction is available; numba needs a concrete array of the same dtype.
+EMPTY_CHROMA_GAIN = np.empty(0, dtype=np.float64)
+
+
+def corrected_burst_amplitudes(
+    chroma_gain, phase_sequence, burstarea, lineoffset, outwidth
+):
+    """Each burst's amplitude, as it will be after the correction is applied.
+
+    The burst is measured before the up-conversion and the correction lands
+    inside it, so the amplitude the automatic gain control would otherwise act
+    on is the one from before. Correcting the measurement here keeps the two in
+    step; the mean over the burst window is what the correction does to that
+    window.
+
+    Returns the measured amplitudes unchanged when the correction is off.
+    """
+    amplitudes = np.array(
+        [burst.amplitude for burst in phase_sequence], dtype=np.float64
+    )
+    if len(chroma_gain) == 0:
+        return amplitudes
+
+    for index in range(len(phase_sequence)):
+        line_start = (phase_sequence[index].line_number - lineoffset) * outwidth
+        window_start = line_start + burstarea[0]
+        window_end = line_start + burstarea[1]
+        if (
+            window_start >= 0
+            and window_end <= len(chroma_gain)
+            and window_end > window_start
+        ):
+            amplitudes[index] *= np.mean(chroma_gain[window_start:window_end])
+    return amplitudes
+
+
+# ---------------------------------------------------------------------------
+# Color-under amplitude correction from the luma carrier's amplitude
+#
+# The Luma FM carrier has a mostly constant amplitude at record time, so every
+# deviation from constant is imposed by the tape. The luma carrier and the
+# color-under were written by the same head, onto the same oxide, at the same
+# instant, so head-to-medium separation is shared between them and scales with
+# wavelength. `vhsdecode.luma_amplitude` measures that deviation; everything
+# here scales it across to the color-under and applies it.
+#
+# Measured on the RF sample grid over the assembled field, ahead of the time
+# base correction, so the measurement is free of its wow level adjustment - a
+# timebase artifact, not tape noise. Applied on the output grid, resampled
+# through the same time base correction as the chroma and with the same shift,
+# so it lands on the samples it was measured from, and inside the up-conversion
+# so it cannot feed back into the burst measurements that set chroma phase and
+# line locations.
+
+# How the luma carrier's amplitude noise transfers to the color-under, and how
+# far it can be trusted.
+#
+# Format figures are from the JVC Video Technical Guide VTG82063 section 1:
+# writing speed 5.80 m/s, video track pitch 0.058 mm at SP and 0.019 mm at EP,
+# luma FM sync tip 3.4 MHz and peak white 4.4 MHz, colour-under 629.371 kHz.
+# At that writing speed the luma carrier is recorded at 1.32 to 1.71 um and the
+# colour-under at 9.22 um, so the two bands sit about a factor of six apart in
+# wavelength - which is the whole reason one can be corrected from the other.
+#
+# The transfer. Head-to-medium separation modulates both bands together, and the
+# Wallace relation makes that transfer the ratio of their wavelengths - at a
+# common writing speed, the inverse ratio of their frequencies. Everything else
+# the carrier passed through drops out of it. Gap loss and coating thickness
+# loss do not depend on separation, so they differentiate away, and the transfer
+# for a spacing perturbation is the frequency ratio whatever the tape is made
+# of. That is why the guide's silence on head gap length and coating thickness
+# does not matter here: those terms cancel.
+#
+# But not all of the amplitude noise is spacing. Particulate density varies from
+# one reproduce volume to the next, and that varies the flux at every wavelength
+# equally - it transfers at unity, not at the wavelength ratio. So the measured
+# coupling sits above the pure Wallace value, and what sets it is the fraction
+# of the noise that is wavelength independent:
+#
+#     transfer = fraction + (1 - fraction) * wavelength ratio
+#
+# Calibrated at 0.19, which is where the measured within-field luma-to-chroma
+# coupling of 0.186-0.248 lands once the attenuation of its own regression is
+# taken into account. Bounded by construction: 0 is pure spacing loss, 1 is
+# noise that ignores wavelength entirely.
+WAVELENGTH_INDEPENDENT_NOISE = 0.194
+
+# The trust. A correction driven by a noisy estimate has to be scaled back by
+# the Wiener factor, signal power over signal plus noise power. That noise is
+# particulate - the medium is a finite number of particles - so its power goes
+# as one over the number the head reproduces from, and that count is
+# proportional to track width. Tape signal-to-noise therefore improves by 3 dB
+# per doubling of track width, and the weight is
+#
+#     weight = track width / (track width + half-coupling width)
+#
+# where the half-coupling width is where signal and noise powers are equal.
+# At 18.3 um that puts the amplitude measurement at 5.0 dB at the 58 um SP
+# track and 0.2 dB at the 19.3 um EP track - which is why the correction has to
+# be scaled back so much harder at the slower speeds. It matters: measured
+# optimum amounts were 0.94-1.07 across five SP patterns but 0.62-0.73 across
+# four EP patterns, and running the SP value on EP does not merely
+# under-perform, it makes the picture worse.
+#
+# This and the fraction above are calibrated against those two speeds and
+# reproduce both exactly, so neither is separately identified - two parameters
+# through two points. LP falls out at 0.61 and PAL SP at 0.73; neither has been
+# tested. Note the knee lands within 5% of the EP width itself, which is the
+# usual sign of a fit with no degrees of freedom left over.
+HALF_COUPLING_TRACK_WIDTH = 18.29
+
+# Used only when a format supplies no track width of its own.
+REFERENCE_TRACK_WIDTH = 58.0
+
+
+@njit(cache=True, nogil=True, fastmath=True)
+def _envelope_gain_from_deviation(
+    deviation,
+    carrier_hz,
+    color_under_carrier_hz,
+    wavelength_independent,
+    trust,
+    dropout_fraction,
+):
+    """The color-under gain that reverses the luma's measured amplitude noise.
+
+    The exponent is the transfer from luma amplitude loss to color-under
+    amplitude loss: the wavelength ratio for the part of the noise that is
+    spacing, unity for the part that is not, taken per sample against the luma
+    carrier's own instantaneous frequency because that is what set the luma
+    wavelength at that moment. Scaled back by how far the measurement can be
+    trusted at this track width.
+
+    The confidence weight is the Wiener weight for an estimate whose noise is
+    fixed and whose signal is the measured level, normalised to one at nominal
+    so undamaged material is left exactly as it was. Where the carrier has
+    collapsed, scaling the chroma up would restore noise rather than
+    saturation, so the correction is withdrawn there.
+
+    One pass, in float32 out: this runs over every sample of every field.
+    """
+    count = len(deviation)
+    gain = np.empty(count, dtype=np.float32)
+    half = dropout_fraction * dropout_fraction
+    for i in range(count):
+        value = deviation[i]
+        squared = value * value
+        confidence = squared * (1.0 + half) / (squared + half)
+        wavelength_ratio = color_under_carrier_hz / carrier_hz[i]
+        exponent = (
+            wavelength_independent
+            + (1.0 - wavelength_independent) * wavelength_ratio
+        ) * trust
+        gain[i] = np.exp(-exponent * np.log(value) * confidence)
+    return gain
+
+
+def chroma_envelope_gain(field, shift):
+    """The color-under amplitude correction, on the chroma output grid.
+
+    Measures the luma carrier's amplitude deviation over the field, scales it
+    across to the color-under by the wavelength ratio, and puts it through the
+    identical time base correction the chroma gets.
+
+    Called beside the chroma's own downscale and with the same shift, so the
+    two come off the resampler aligned by construction. Returns None when there
+    is nothing to correct, which leaves the chroma untouched.
+    """
+    rf = field.rf
+    decoder_params = rf.DecoderParams
+    if rf.options.chroma_env_gain <= 0 or rf.do_cafc:
+        return None
+    if (
+        "color_under_carrier" not in decoder_params
+        or "chroma_bpf_upper" not in decoder_params
+    ):
+        return None
+
+    measured = luma_amplitude.measure_amplitude_deviation(field)
+    if measured is None:
+        return None
+    deviation, carrier_hz = measured
+
+    # How far the measurement can be trusted at this track width.
+    track_width = decoder_params.get("video_track_width", REFERENCE_TRACK_WIDTH)
+    trust = track_width / (track_width + HALF_COUPLING_TRACK_WIDTH)
+
+    gain = _envelope_gain_from_deviation(
+        deviation,
+        carrier_hz,
+        decoder_params["color_under_carrier"],
+        WAVELENGTH_INDEPENDENT_NOISE,
+        trust,
+        rf.dod_options.dod_threshold_p,
+    )
+
+    # Through the same resampler as the chroma. `Field.downscale` can only
+    # resample a named channel of the field's record array, so this goes through
+    # `scale_field` directly - with the wow level adjustment switched off, since
+    # that adjustment belongs to demodulated signal channels and imposing it on
+    # a measurement would put the timebase's own wow into the correction.
+    outwidth = field.outlinelen
+    resampled = np.zeros(field.outlinecount * outwidth, dtype=np.float32)
+    interpolated_pixel_locs, wowfactors = field.computewow_scaled()
+    lddu.scale_field(
+        gain,
+        resampled,
+        interpolated_pixel_locs,
+        wowfactors,
+        rf.downscale_sinc_lut,
+        field.lineoffset,
+        outwidth,
+        wow_level_adjust_smoothing=field.wow_level_adjust_smoothing,
+        shift=shift,
+        apply_level_adjust=False,
+    )
+    return resampled if len(resampled) else None
+
+
+BURST_START_LINE=10
 
 
 @njit(cache=True, nogil=True, fastmath=True)
@@ -36,6 +260,7 @@ def chroma_automatic_gain(
     sync_tip_len,
     decode_average,
     decode_average_count,
+    burst_amplitude,
     smoothing_window=8,
     k=2.0
 ):
@@ -61,7 +286,15 @@ def chroma_automatic_gain(
     # extract gain values and track valid amplitudes
     for i in range(burst_count):
         current_burst = phase_sequence[i]
-        current_amp = current_burst.amplitude if current_burst.amplitude != 0 else 1e-8
+        # The burst measurements were taken before the envelope-derived
+        # amplitude correction was applied, so scale them by the gain that
+        # correction actually put on the burst window. Without this the two
+        # controls both act on the same per-line level: the correction lifts a
+        # burst the tape attenuated, and the automatic gain then lifts the whole
+        # line again because it is still reading the uncorrected measurement.
+        current_amp = burst_amplitude[i]
+        if current_amp == 0:
+            current_amp = 1e-8
 
         raw_gain = burst_abs_ref / current_amp
         raw_gains[i] = raw_gain
@@ -837,7 +1070,9 @@ def upconvert_chroma_phase_comp(
     color_under_carrier_fs,
     fsc,
     target_phase_even,
-    target_phase_odd
+    target_phase_odd,
+    chroma_gain,
+    chroma_gain_amount
 ):
     deg2rad_scale = np.pi / 180.0
     pi_over_two = np.pi / 2.0
@@ -855,6 +1090,9 @@ def upconvert_chroma_phase_comp(
     # Pre-generate a local pixel coordinate array to help Numba vectorize
     # Computing on a local range [0, outwidth) helps the compiler reason about alignment
     local_idx = np.arange(outwidth, dtype=np.float64)
+
+    apply_chroma_gain = chroma_gain_amount > 0.0
+    epsilon = np.finfo(np.float64).tiny
 
     for idx in range(num_bursts):
         current_burst = phase_rotation_sequence[idx]
@@ -896,13 +1134,38 @@ def upconvert_chroma_phase_comp(
         # Slice target and source arrays to provide direct contiguous memory views
         chroma_slice = chroma[linestart:lineend]
 
-        # No outer dependencies so LLVM can vectorize
-        for k in range(outwidth):
-            # Compute closed-form phase directly (no dependency on previous k)
-            theta_k = theta_0 + alpha * local_idx[k] + beta * (local_idx[k] * local_idx[k])
-            
-            # Vectorized trigonometric and arithmetic execution
-            chroma_slice[k] = chroma_slice[k] * -np.cos(theta_k) - dc_val
+        if apply_chroma_gain:
+            # Amplitude correction from the luma FM envelope. The gain has to
+            # act on zero-mean color under: a residual DC offset multiplied by
+            # a time varying gain and then mixed produces a real component at
+            # the subcarrier frequency, which reads as a synthetic burst, i.e.
+            # hue and saturation error correlated with tape damage. Scaling the
+            # deviation from the line's own fitted DC leaves the DC path
+            # untouched, so a gain of one reproduces the uncorrected result
+            # exactly.
+            gain_slice = chroma_gain[linestart:lineend]
+
+            # No outer dependencies so LLVM can vectorize
+            for k in range(outwidth):
+                # Compute closed-form phase directly (no dependency on previous k)
+                theta_k = theta_0 + alpha * local_idx[k] + beta * (local_idx[k] * local_idx[k])
+
+                gain_k = gain_slice[k]
+                if gain_k < epsilon:
+                    gain_k = epsilon
+                gain_k = 1.0 + (gain_k - 1.0) * chroma_gain_amount
+
+                # Vectorized trigonometric and arithmetic execution
+                corrected = dc_val + (chroma_slice[k] - dc_val) * gain_k
+                chroma_slice[k] = corrected * -np.cos(theta_k) - dc_val
+        else:
+            # No outer dependencies so LLVM can vectorize
+            for k in range(outwidth):
+                # Compute closed-form phase directly (no dependency on previous k)
+                theta_k = theta_0 + alpha * local_idx[k] + beta * (local_idx[k] * local_idx[k])
+
+                # Vectorized trigonometric and arithmetic execution
+                chroma_slice[k] = chroma_slice[k] * -np.cos(theta_k) - dc_val
 
 
 @njit(cache=True, nogil=True)
@@ -1853,7 +2116,12 @@ def process_chroma(
         # TODO: shift amount may need tuning / needs validation
         chroma_subcarrier_delay_cycles = field.rf.SysParams['fsc_mhz'] * 1e6 / (2.0 * np.pi * field.rf.DecoderParams["color_under_carrier"])
         chroma_subcarrier_delay_samples = chroma_subcarrier_delay_cycles * 4
-        chroma, _, _ = ldd.Field.downscale(field, channel="demod_burst", shift=chroma_subcarrier_delay_samples * chroma_shift_direction)
+        chroma_downscale_shift = chroma_subcarrier_delay_samples * chroma_shift_direction
+
+        chroma, _, _ = ldd.Field.downscale(field, channel="demod_burst", shift=chroma_downscale_shift)
+        # The luma amplitude correction rides the identical time base correction,
+        # with the same shift, so it lands on the samples it was measured from.
+        chroma_env_gain = chroma_envelope_gain(field, chroma_downscale_shift)
 
         # If chroma AFC is enabled
         if field.rf.do_cafc:
@@ -1900,8 +2168,10 @@ def process_chroma(
 
         field.rf.chroma_tbc_buffer = chroma
         field.chroma_tbc_buffer = chroma
+        field.chroma_env_gain_buffer = chroma_env_gain
     else:
         chroma = field.chroma_tbc_buffer
+        chroma_env_gain = field.chroma_env_gain_buffer
 
     burstarea = get_burst_area(field)
 
@@ -1936,6 +2206,21 @@ def process_chroma(
         # this uses the burst measurements to interpolate the correct phase of the color under heterodyne
         # phase issues are corrected continiously for each sample using a linear spline interpolated from the burst measurements
         # the mixing is performed on the upsampled signal to avoid aliasing introduced from the up-heterodyne mixing product
+        # Per-sample color-under amplitude correction measured from the luma
+        # FM envelope. Both bands were written by the same head at the same
+        # instant, so head-to-medium separation is shared between them and the
+        # envelope supplies the intra-line gain profile the once-per-line burst
+        # cannot see. An empty array leaves the up-conversion unchanged.
+        # Measure the luma envelope for changes in amplitude that do not follow the demodulated signal
+        # Changes in amplitude that are not correlated to the demodulated luma's frequency are likely noise
+        # This uses the luma's carrier's amplitude as a base to measure amplitude based noise and reverse this noise in the QAM color under
+        #
+        chroma_gain = EMPTY_CHROMA_GAIN
+        chroma_gain_amount = 0.0
+        if chroma_env_gain is not None and len(chroma_env_gain) == len(chroma):
+            chroma_gain = chroma_env_gain.astype(np.float64)
+            chroma_gain_amount = field.rf.options.chroma_env_gain
+
         upconvert_chroma_phase_comp(
             chroma, # modifies this in place
             lineoffset,
@@ -1945,6 +2230,8 @@ def process_chroma(
             field.rf.SysParams["fsc_mhz"] * 1e6,
             target_phase_even,
             target_phase_odd,
+            chroma_gain,
+            chroma_gain_amount,
         )
         uphet = chroma
     else:
@@ -2030,6 +2317,12 @@ def process_chroma(
     else:
         decode_average = 0
 
+    # The burst amplitudes the correction leaves behind, so the automatic gain
+    # control measures the signal it is actually acting on.
+    burst_amplitude = corrected_burst_amplitudes(
+        chroma_gain, field.phase_sequence, burstarea, lineoffset, outwidth
+    )
+
     field_average, chroma_noise_floor = chroma_automatic_gain(
         uphet,
         field.rf.SysParams["burst_abs_ref"],
@@ -2037,7 +2330,8 @@ def process_chroma(
         field.burst_detected_line,
         math.floor(field.usectooutpx(field.rf.SysParams["hsyncPulseUS"])),
         decode_average,
-        decode_average_count
+        decode_average_count,
+        burst_amplitude,
     )
 
     chroma_average_state.append((field_average, chroma_noise_floor))

--- a/vhsdecode/debug_plot.py
+++ b/vhsdecode/debug_plot.py
@@ -512,3 +512,102 @@ def plot_final_chroma_field(input_chroma, final_chroma) -> None:
         ax2.legend()
         plt.show()
         sys.exit()
+
+
+def plot_luma_noise(
+    envelope,
+    demod,
+    dropouts,
+    threshold,
+    hysteresis,
+    start_rf,
+    end_rf,
+    linelocs,
+    hz_to_ire,
+    dropout_fraction,
+):
+    """Luma carrier amplitude beside the luma it was demodulated from.
+
+    The carrier is frequency modulated, so its amplitude should be constant and
+    everything in the top trace is the tape rather than the picture. That makes
+    it a continuous noise profile: where it dips, the demodulator's output noise
+    rises and the color-under recorded alongside it lost signal at the same
+    instant.
+
+    All three panels cover the whole field on one shared axis, so they line up
+    sample for sample and zooming or panning any of them moves the others with
+    it. Nothing is zoomed in advance - finding where the interesting excursions
+    are is what the plot is for.
+
+    Shaded spans are the dropouts the decoder detected from this same envelope,
+    so the plot shows both what the threshold caught and the shallower
+    excursions it did not.
+    """
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    envelope = np.asarray(envelope, dtype=float)
+    demod = np.asarray(demod, dtype=float)
+    samples = np.arange(start_rf, end_rf)
+    window = envelope[start_rf:end_rf]
+    reference = float(np.median(window)) if len(window) else 1.0
+
+    # the same weight the color-under amplitude correction uses to decide how
+    # far to trust itself, so the plot shows where that correction backs off
+    relative = window / reference if reference > 0 else window
+    squared = relative * relative
+    half = dropout_fraction * dropout_fraction
+    confidence = squared * (1.0 + half) / (squared + half)
+
+    fig, (ax_env, ax_luma, ax_conf) = plt.subplots(
+        3,
+        1,
+        figsize=(14, 9),
+        sharex=True,
+        gridspec_kw={"height_ratios": [3, 3, 1]},
+    )
+
+    ax_env.plot(
+        samples, window, color="tab:blue", linewidth=0.5, label="carrier amplitude"
+    )
+    ax_env.axhline(
+        reference, color="tab:grey", linestyle=":", linewidth=1, label="field median"
+    )
+    ax_env.axhline(
+        threshold, color="tab:red", linestyle="--", linewidth=1,
+        label="dropout threshold",
+    )
+    ax_env.axhline(
+        threshold * hysteresis, color="tab:orange", linestyle="--", linewidth=1,
+        label="recovery (hysteresis)",
+    )
+    ax_env.set_ylabel("carrier amplitude")
+    ax_env.legend(loc="lower left", fontsize="small", ncol=2)
+    ax_env.set_title(
+        "Luma carrier amplitude (noise profile), detected dropouts, "
+        "and the demodulated luma"
+    )
+
+    ax_luma.plot(
+        samples, hz_to_ire(demod[start_rf:end_rf]), color="tab:green",
+        linewidth=0.5, label="demodulated luma",
+    )
+    for level in (0, 100):
+        ax_luma.axhline(level, color="tab:grey", linestyle=":", linewidth=1)
+    ax_luma.set_ylabel("luma (IRE)")
+    ax_luma.legend(loc="lower left", fontsize="small")
+
+    ax_conf.plot(samples, confidence, color="tab:purple", linewidth=0.5)
+    ax_conf.set_ylim(0, 1.05)
+    ax_conf.set_ylabel("correction\nconfidence")
+    ax_conf.set_xlabel("RF sample")
+
+    for start, end in dropouts or []:
+        if end < 0:
+            end = end_rf
+        for ax in (ax_env, ax_luma, ax_conf):
+            ax.axvspan(start, end, color="tab:red", alpha=0.3, linewidth=0)
+
+    ax_env.set_xlim(start_rf, end_rf)
+    fig.tight_layout()
+    plt.show()

--- a/vhsdecode/doc.py
+++ b/vhsdecode/doc.py
@@ -95,6 +95,23 @@ def detect_dropouts_rf(field, dod_options):
     # could be merged.
     dropouts_rf = list(filter(lambda s: s[1] - s[0] > vhs_formats.DOD_MIN_LENGTH, dropouts_rf))
 
+    debug_plot = getattr(field.rf, "debug_plot", None)
+    if debug_plot and debug_plot.is_plot_requested("luma_noise"):
+        from vhsdecode.debug_plot import plot_luma_noise
+
+        plot_luma_noise(
+            env,
+            field.data["video"]["demod"],
+            dropouts_rf,
+            threshold,
+            hysteresis,
+            start_rf,
+            end_rf,
+            field.linelocs,
+            field.rf.hztoire,
+            field.rf.dod_options.dod_threshold_p,
+        )
+
     return map_dropouts_rf_to_tbc(dropouts_rf, start_line, end_line, field.linelocs, field.outlinelen, field.lineoffset)
 
 def map_dropouts_rf_to_tbc(errlist, start_line_idx, end_line_idx, linelocs, outlinelen, lineoffset):

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1122,7 +1122,9 @@ class FieldShared:
         )
 
     def lock_to_burst(self):
+        # required to trigger the chroma downscaling to happen again (if this is run after scaling for some reason)
         self.chroma_tbc_buffer = None
+        self.chroma_env_gain_buffer = None
         (
             self.rf.track_phase,
             self.phase_sequence,

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -10,7 +10,11 @@ import matplotlib.pyplot as plt
 import vhsdecode.sync as sync
 import vhsdecode.formats as formats
 from vhsdecode.doc import detect_dropouts_rf
-from vhsdecode.chroma import decode_chroma, decode_chroma_phase_rotation
+from vhsdecode.chroma import (
+    apply_chroma_envelope_gain,
+    decode_chroma,
+    decode_chroma_phase_rotation,
+)
 
 from vhsdecode.debug_plot import plot_data_and_pulses
 
@@ -1122,9 +1126,17 @@ class FieldShared:
         )
 
     def lock_to_burst(self):
+        # Take the tape's amplitude noise out of the color-under before
+        # anything is measured from it. The luma FM carrier and the color-under
+        # were written by the same head at the same instant, so the luma
+        # envelope measures the loss they shared. It happens here, on the raw RF
+        # sample grid, because this is the last point before the bursts are
+        # measured - so those measurements read a corrected signal rather than
+        # having to be compensated for one afterwards.
+        apply_chroma_envelope_gain(self)
+
         # required to trigger the chroma downscaling to happen again (if this is run after scaling for some reason)
         self.chroma_tbc_buffer = None
-        self.chroma_env_gain_buffer = None
         (
             self.rf.track_phase,
             self.phase_sequence,

--- a/vhsdecode/field_averages.py
+++ b/vhsdecode/field_averages.py
@@ -1,10 +1,15 @@
 from vhsdecode.utils import StackableMA
+from collections import deque
 
 
 class FieldAverage:
-    def __init__(self):
+    def __init__(self, chroma_agc_fields):
         self._rf_level = StackableMA()
-        self._chroma_level = StackableMA()
+
+        self.chroma_level_len = chroma_agc_fields
+        self._chroma_level_even = deque(maxlen=self.chroma_level_len)
+        self._chroma_level_odd = deque(maxlen=self.chroma_level_len)
+
         # self.line_length = StackableMA()
         # self.vsync_dist = StackableMA
 
@@ -12,6 +17,13 @@ class FieldAverage:
     def rf_level(self):
         return self._rf_level
 
+    # even field state for the chroma automatic gain control
     @property
-    def chroma_level(self):
-        return self._chroma_level
+    def chroma_level_even(self):
+        return self._chroma_level_even
+    
+    # odd field state for the chroma automatic gain control
+    @property
+    def chroma_level_odd(self):
+        return self._chroma_level_odd
+

--- a/vhsdecode/format_defs/vhs.py
+++ b/vhsdecode/format_defs/vhs.py
@@ -143,6 +143,11 @@ def get_rfparams_pal_vhs(rfparams_pal: dict, tape_speed: int = 0) -> dict:
     RFParams_PAL_VHS["video_lpf_order"] = 6
 
     # PAL color under carrier is 40H + 1953
+    # Recorded video track width, micrometers. JVC VTG82063 gives PAL LP as
+    # 0.024 mm at 11.70 mm/s against SP's 23.39; the exact ratio is 24.51.
+    # PAL VHS has no EP speed, so LP repeats for any higher index.
+    RFParams_PAL_VHS["video_track_width"] = [49.0, 24.5, 24.5][min(tape_speed, 2)]
+
     RFParams_PAL_VHS["color_under_carrier"] = ((625 * 25) * 40) + 1953
 
     # Upper frequency of bandpass to filter out chroma from the rf signal.
@@ -287,6 +292,11 @@ def get_rfparams_ntsc_vhs(rfparams_ntsc: dict, tape_speed: int = 0) -> dict:
     RFParams_NTSC_VHS["video_lpf_supergauss"] = True
     RFParams_NTSC_VHS["video_lpf_freq"] = 6600000
     RFParams_NTSC_VHS["video_lpf_order"] = 9
+
+    # Recorded video track width, micrometers. JVC VTG82063 section 1: 0.058 mm
+    # at SP, 0.019 mm at EP. The drum turns at one rate whatever the tape speed,
+    # so the pitch follows the tape speed and EP is 58 * 11.12 / 33.35 = 19.34.
+    RFParams_NTSC_VHS["video_track_width"] = [58.0, 29.0, 19.3][tape_speed]
 
     # NTSC color under carrier is 40H
     RFParams_NTSC_VHS["color_under_carrier"] = (525 * (30 / 1.001)) * 40

--- a/vhsdecode/luma_amplitude.py
+++ b/vhsdecode/luma_amplitude.py
@@ -1,0 +1,409 @@
+"""Luma FM carrier amplitude variation.
+
+An FM carrier carries no amplitude information - its amplitude should be
+constant. Every deviation from that constant is imposed by the tape, and is
+measurable continuously at full sample rate on the raw RF, before the time base
+correction has run and before any scaling has been applied.
+
+Two causes of amplitude change, only one of them noise
+------------------------------------------------------
+The received carrier amplitude is not constant, and the reasons split in two.
+
+  Frequency driven.  The carrier sweeps with picture content - sync tip to peak
+  white - and the amplitude response of the path varies across that sweep. The
+  same carrier frequency gives the same amplitude every time, so this is the
+  path's response and not tape noise, and it is not variation to report.
+
+  Random.  Head-to-medium separation modulating the signal. This is the tape's
+  own noise, and it is what the measurement is for.
+
+Separating them is the whole job of this module, and it happens here at the
+measurement rather than at whatever acts on it: the part of the carrier
+amplitude that is a function of the luma's own frequency is divided out once,
+leaving only the amplitude changes worth acting on. Downstream the two are no
+longer separable.
+
+Part of that response is known exactly and is simply divided out - the decoder's
+own RF path, which on formats using the linear ramp boost tilts the band by
+several dB across the carrier sweep on its own. The remainder - tape channel,
+head response, record and playback equalization - is measured by binning the
+flattened amplitude against carrier frequency and fitting a curve.
+
+What comes back is a property of the luma carrier and of the tape, and of
+nothing else. It carries no assumption about what will consume it.
+"""
+
+from collections import namedtuple
+
+import numpy as np
+from numba import njit
+
+
+# What `measure_amplitude_deviation` yields. `deviation` is unity where the
+# carrier holds the amplitude its own frequency predicts, and departs from unity
+# by the tape's multiplicative noise. `carrier_hz` is the instantaneous carrier
+# frequency conditioned the same way the deviation was measured against, so a
+# consumer scaling by wavelength uses the frequency that actually applies.
+AmplitudeDeviation = namedtuple("AmplitudeDeviation", ["deviation", "carrier_hz"])
+
+
+# Order of the curve fitted through the measured amplitude response across the
+# carrier deviation range. This is what keeps the measurement free of the
+# picture: whatever part of the amplitude tracks the luma's own frequency is the
+# path's response, and removing it here is what leaves only tape noise behind.
+#
+# A straight line leaves too much: on a continuous luma ramp the applied gain
+# still correlates with the luma at r = 0.21. A quadratic cuts that to 0.05 for
+# no measurable loss of benefit. Going further does not help and starts to hurt,
+# because the response is fitted per demodulation block and a block spans only
+# about twelve lines - at order three the correlation on colour bars overshoots
+# to -0.07 while the benefit falls.
+RESPONSE_POLYNOMIAL_ORDER = 2
+
+# Points the response curve is described by. Groups of equal population rather
+# than of equal width: the response is a smooth characteristic, and a fixed IRE
+# grid spends most of its bins on levels the picture barely visits while
+# crowding the ones it dwells on. Equal population puts every point at the same
+# confidence and puts them where the picture actually is.
+#
+# A quadratic needs three points; eight leaves margin for one landing badly.
+# Measured, the choice is flat over its neighbourhood - 8, 16, 32 and 140 points
+# all sit within 0.008 of each other on the correction's residual luma
+# correlation, with eight the lowest of them.
+RESPONSE_CURVE_POINTS = 8
+
+# Samples each of those points is measured from. A median's standard error is
+# about 1.25 * sigma / sqrt(m); the amplitude deviation runs about 5% rms and
+# the correction acts at about 1% rms, so determining the curve an order of
+# magnitude finer than it acts needs (1.25 * 0.05 / 0.001)^2, near enough four
+# thousand samples a point. A field carries hundreds of thousands, so the curve
+# is measured from a fraction of it and the correction still applies to every
+# sample. Measured, taking one sample in twenty-one costs 0.0004 of that same
+# residual correlation.
+CURVE_SAMPLES_PER_POINT = 4096
+
+
+@njit(cache=True, nogil=True, fastmath=True)
+def _flatten_by_response(amplitude, carrier_hz, response, frequency_step):
+    """Divide the decoder's own RF response out of the carrier amplitude.
+
+    The response is tabulated on a uniform frequency grid, so the sample's bin
+    is an index rather than a search; this runs over every sample of every
+    field.
+    """
+    count = len(amplitude)
+    # Carrier amplitude is physically positive, so zero
+    # cannot be mistaken for a measurement.
+    flattened = np.zeros(count)
+    last = len(response) - 1
+    for i in range(count):
+        position = carrier_hz[i] / frequency_step
+        if position <= 0.0:
+            value = response[0]
+        elif position >= last:
+            value = response[last]
+        else:
+            lower = int(position)
+            fraction = position - lower
+            value = response[lower] * (1.0 - fraction) + response[lower + 1] * fraction
+        if value > 0.0:
+            flattened[i] = amplitude[i] / value
+    return flattened
+
+
+def rf_path_response(rf):
+    """The decoder's own RF amplitude response, and the grid it is tabulated on.
+
+    `Filters["RFVideo"]` is the magnitude response actually applied to the
+    signal before the carrier amplitude is taken, so consuming it directly keeps
+    this correct for every format and every combination of ramp boost, peaking
+    and notch options.
+    """
+    response = np.abs(rf.Filters["RFVideo"])
+    # The stored response covers the whole spectrum with the negative
+    # frequencies mirrored above Nyquist; only the positive half is meaningful.
+    half = len(response) // 2
+    return response[:half], rf.freq_hz / len(response)
+
+
+def carrier_frequency_bins(sys_params, rf):
+    """Frequency bin edges across the carrier's deviation range, one bin per IRE.
+
+    One bin per IRE because that is the video standard's own quantization of
+    level, and the carrier frequency is a linear function of level.
+
+    Anchored at sync tip - the format's own fixed reference, the one level that
+    is defined rather than pictorial - and taken from the decoder's running
+    parameters, so the anchor sits at the sync tip the signal actually has
+    rather than the one the specification nominates.
+
+    Samples outside this range are dropped rather than clipped into the end
+    bins; see `measure_amplitude_by_frequency`. The range itself stays fixed, so
+    the curve means the same thing from one field to the next - letting it
+    follow the highest sample instead lets a single demodulator excursion set
+    the axis, and the fit is then conditioned differently in every field.
+    """
+    sync_tip_hz = rf.iretohz(sys_params["vsync_ire"])
+    peak_white_hz = rf.iretohz(100)
+    bin_count = int(round((peak_white_hz - sync_tip_hz) / sys_params["hz_ire"]))
+    return sync_tip_hz, peak_white_hz, max(bin_count, RESPONSE_POLYNOMIAL_ORDER + 1)
+
+
+@njit(cache=True, nogil=True, fastmath=True)
+def measure_amplitude_by_frequency(
+    amplitude, carrier_hz, sync_tip_hz, hz_ire, bin_count, group_count, stride
+):
+    """Carrier amplitude against carrier frequency, as points on a curve.
+
+    Returns one point per group: the frequency the group covers, the median
+    amplitude in it, and how many samples it holds. The median is what makes
+    the estimate robust - amplitude noise is not symmetric, dropouts sit in the
+    low tail, so a median tracks the level the carrier normally has at that
+    frequency rather than the average of level and damage.
+
+    The groups are equal-population rather than equal-width. The response is a
+    smooth characteristic that needs only a few points to describe, and a
+    fixed IRE grid spends most of its bins on levels the picture barely visits
+    while crowding the ones it dwells on. Equal population puts every point on
+    the curve at the same confidence, and puts them where the picture actually
+    is.
+
+    `stride` subsamples the field for the curve only; the correction itself
+    still applies to every sample. The curve has three parameters and a field
+    has hundreds of thousands of samples, so it is not short of evidence.
+    """
+    count = len(amplitude)
+    fine = np.zeros(bin_count, dtype=np.int64)
+    index = np.full(count, -1, dtype=np.int64)
+
+    for i in range(0, count, stride):
+        value = amplitude[i]
+        if value <= 0.0:
+            continue
+        bin_number = int(np.floor((carrier_hz[i] - sync_tip_hz) / hz_ire))
+        if bin_number < 0:
+            continue
+        if bin_number >= bin_count:
+            bin_number = bin_count - 1
+        index[i] = bin_number
+        fine[bin_number] += 1
+
+    total = 0
+    for b in range(bin_count):
+        total += fine[b]
+    if total <= 0:
+        return (
+            np.zeros(0), np.zeros(0), np.zeros(0)
+        )
+
+    # merge adjacent fine bins until each group holds its share of the field
+    group_of = np.zeros(bin_count, dtype=np.int64)
+    target = total / group_count
+    group = 0
+    running = 0
+    for b in range(bin_count):
+        group_of[b] = group
+        running += fine[b]
+        if running >= target * (group + 1) and group < group_count - 1:
+            group += 1
+    groups = group + 1
+
+    population = np.zeros(groups)
+    centre = np.zeros(groups)
+    for b in range(bin_count):
+        g = group_of[b]
+        population[g] += fine[b]
+        centre[g] += fine[b] * (sync_tip_hz + (b + 0.5) * hz_ire)
+    for g in range(groups):
+        if population[g] > 0.0:
+            centre[g] /= population[g]
+
+    start = np.zeros(groups + 1, dtype=np.int64)
+    for g in range(groups):
+        start[g + 1] = start[g] + np.int64(population[g])
+    cursor = start[:groups].copy()
+    grouped = np.empty(start[groups], dtype=amplitude.dtype)
+    for i in range(0, count, stride):
+        b = index[i]
+        if b >= 0:
+            g = group_of[b]
+            grouped[cursor[g]] = amplitude[i]
+            cursor[g] += 1
+
+    levels = np.zeros(groups)
+    for g in range(groups):
+        first, last = start[g], start[g + 1]
+        if last > first:
+            levels[g] = np.median(grouped[first:last])
+
+    return levels, population, centre
+
+
+def fit_response_curve(
+    levels,
+    population,
+    centre_hz,
+    sync_tip_hz,
+    peak_white_hz,
+    order=RESPONSE_POLYNOMIAL_ORDER,
+):
+    """Fit the path's amplitude response across the carrier deviation range.
+
+    Fitted in the logarithm, because the response is multiplicative, and in
+    frequency relative to the band the carrier actually visits, because that is
+    where the evidence is - the points span roughly 3.5 to 4.4 MHz, so a basis
+    anchored at zero frequency would be three parameters fitted over a window
+    five times its own width away from the origin, which is degenerate.
+
+    Constrained, though, to what a response can physically do: amplitude falls
+    as the wavelength shortens and never rises. Everything the carrier passed
+    through - head gap, coating thickness, head-to-medium separation, record
+    and playback equalization - takes amplitude away and none of it gives any
+    back. An unconstrained quadratic is free to bend the other way on noise,
+    and a curve that rises with frequency is not a response.
+
+    Returns polynomial coefficients in band-relative frequency, or None if the
+    field does not visit enough distinct levels to determine a curve.
+    """
+    valid = (population > 0) & (levels > 0)
+    if np.count_nonzero(valid) < order + 1:
+        return None
+
+    normalized = _normalize_frequency(centre_hz[valid], sync_tip_hz, peak_white_hz)
+
+    try:
+        coefficients = np.polyfit(
+            normalized,
+            np.log(levels[valid]),
+            order,
+            w=np.sqrt(population[valid]),
+        )
+    except (np.linalg.LinAlgError, ValueError):
+        # Too few distinct levels to determine a curve; the caller leaves the
+        # chroma uncorrected rather than acting on a degenerate response.
+        return None
+
+    if order == 2:
+        # d(ln A)/dx = 2*a*x + b must not be positive anywhere in 0 <= x <= 1
+        quadratic, linear = coefficients[0], coefficients[1]
+        if linear > 0.0:
+            linear = 0.0
+        if 2.0 * quadratic + linear > 0.0:
+            quadratic = -0.5 * linear
+        coefficients[0], coefficients[1] = quadratic, linear
+    return coefficients
+
+
+def _normalize_frequency(carrier_hz, sync_tip_hz, peak_white_hz):
+    """Map the deviation range onto [0, 1] to condition the fit."""
+    span = max(peak_white_hz - sync_tip_hz, np.finfo(np.float64).tiny)
+    return (carrier_hz - sync_tip_hz) / span
+
+
+@njit(cache=True, nogil=True, fastmath=True)
+def _deviation_from_response(
+    flattened, carrier_hz, coefficients, sync_tip_hz, span_hz, low, high
+):
+    """How far the amplitude departs from the response fitted to it.
+
+    One pass over the field: the curve is evaluated, divided out and bounded in
+    place, rather than building an expected-amplitude array to divide by.
+    """
+    count = len(flattened)
+    deviation = np.ones(count)
+    order = len(coefficients)
+    for i in range(count):
+        value = flattened[i]
+        if value <= 0.0:
+            continue
+        normalized = (carrier_hz[i] - sync_tip_hz) / span_hz
+        accumulated = 0.0
+        for c in range(order):
+            accumulated = accumulated * normalized + coefficients[c]
+        expected = np.exp(accumulated)
+        if expected <= 0.0:
+            continue
+        ratio = value / expected
+        if ratio < low:
+            ratio = low
+        elif ratio > high:
+            ratio = high
+        deviation[i] = ratio
+    return deviation
+
+
+def measure_amplitude_deviation(field):
+    '''How far the luma carrier's amplitude departs from the constant it should
+    hold, measured across the whole field on the raw RF sample grid.
+
+    The amplitude is taken as measured, instantaneously, with no band limit:
+    the tape imposes its amplitude noise at whatever rate it imposes it, and a
+    filter here would decide in advance which of that the correction is allowed
+    to see.
+
+    Returns an `AmplitudeDeviation`, or None if the field cannot support a
+    measurement.
+
+    Demodulation happens per block and is not repeated here: this works on the
+    assembled field, so the blocks are concatenated first and the part of the
+    amplitude that follows the carrier's own frequency is removed afterwards,
+    once, over the whole field. The tape imposes its amplitude noise as the
+    field is read, continuously, so the reference it is measured against has to
+    be continuous too - fitting each demodulation block separately puts a step
+    at every block seam, on a carrier amplitude that has none.
+
+    Nothing here knows about the color-under. What comes back is a property of
+    the luma carrier alone - the tape's multiplicative noise, with the path's
+    response to the carrier's own frequency already removed - so it can drive
+    any correction that shares the same head and instant.
+    '''
+    rf = field.rf
+    video = field.data["video"]
+    if video is None or "demod_raw" not in (video.dtype.names or ()):
+        return None
+
+    amplitude = np.asarray(video["envelope"], dtype=np.float64)
+    carrier_hz = np.asarray(video["demod_raw"], dtype=np.float64)
+    if len(amplitude) != len(carrier_hz) or len(amplitude) == 0:
+        return None
+
+    sys_params = rf.SysParams
+    sync_tip_hz, peak_white_hz, bin_count = carrier_frequency_bins(sys_params, rf)
+
+    response, frequency_step = rf_path_response(rf)
+    flattened = _flatten_by_response(amplitude, carrier_hz, response, frequency_step)
+
+    # The part of the amplitude that follows the carrier's own frequency,
+    # measured once over the concatenated field. Demodulation stays per block
+    # and is not repeated here; what is measured is the assembled result, so
+    # neither the curve nor the level it implies has a block boundary in it.
+    stride = max(
+        1, len(flattened) // (RESPONSE_CURVE_POINTS * CURVE_SAMPLES_PER_POINT)
+    )
+    levels, population, centre_hz = measure_amplitude_by_frequency(
+        flattened,
+        carrier_hz,
+        sync_tip_hz,
+        sys_params["hz_ire"],
+        bin_count,
+        RESPONSE_CURVE_POINTS,
+        stride,
+    )
+    coefficients = fit_response_curve(
+        levels, population, centre_hz, sync_tip_hz, peak_white_hz
+    )
+    if coefficients is None:
+        return None
+
+    dropout_fraction = rf.dod_options.dod_threshold_p
+    deviation = _deviation_from_response(
+        flattened,
+        carrier_hz,
+        coefficients,
+        sync_tip_hz,
+        max(peak_white_hz - sync_tip_hz, np.finfo(np.float64).tiny),
+        dropout_fraction,
+        1.0 / dropout_fraction,
+    )
+
+    return AmplitudeDeviation(deviation, carrier_hz)

--- a/vhsdecode/luma_amplitude.py
+++ b/vhsdecode/luma_amplitude.py
@@ -2,8 +2,15 @@
 
 An FM carrier carries no amplitude information - its amplitude should be
 constant. Every deviation from that constant is imposed by the tape, and is
-measurable continuously at full sample rate on the raw RF, before the time base
-correction has run and before any scaling has been applied.
+measurable on the raw RF, before the time base correction has run and before
+any scaling has been applied.
+
+The amplitude is taken as the decoder's own envelope channel, which is
+band limited to 700 kHz by the demodulator's envelope detector - a single pole
+applied forward and backward, so 12 dB per octave. Nothing here narrows it
+further: no smoothing, no additional band limit, no windowing. The tape imposes
+its amplitude noise at whatever rate it imposes it, and a filter here would
+decide in advance which of that the correction is allowed to see.
 
 Two causes of amplitude change, only one of them noise
 ------------------------------------------------------
@@ -29,6 +36,12 @@ several dB across the carrier sweep on its own. The remainder - tape channel,
 head response, record and playback equalization - is measured by binning the
 flattened amplitude against carrier frequency and fitting a curve.
 
+Both parts are functions of the carrier's frequency and of nothing else, so they
+are combined into a single table over frequency and divided out together, once
+per sample. That is what keeps this affordable: the response is exponentiated
+where it is described, over the few thousand points of the table, rather than
+over the million samples it is applied to.
+
 What comes back is a property of the luma carrier and of the tape, and of
 nothing else. It carries no assumption about what will consume it.
 """
@@ -44,6 +57,10 @@ from numba import njit
 # by the tape's multiplicative noise. `carrier_hz` is the instantaneous carrier
 # frequency conditioned the same way the deviation was measured against, so a
 # consumer scaling by wavelength uses the frequency that actually applies.
+#
+# Both are single precision, which is what the demodulator produced them in;
+# widening them here would cost two full copies of the field per field and buy
+# no precision that was ever recorded.
 AmplitudeDeviation = namedtuple("AmplitudeDeviation", ["deviation", "carrier_hz"])
 
 
@@ -88,8 +105,12 @@ def _flatten_by_response(amplitude, carrier_hz, response, frequency_step):
     """Divide the decoder's own RF response out of the carrier amplitude.
 
     The response is tabulated on a uniform frequency grid, so the sample's bin
-    is an index rather than a search; this runs over every sample of every
-    field.
+    is an index rather than a search.
+
+    Only the samples the response curve is fitted from come through here - a
+    few tens of thousands of the field's million. Applying the finished model
+    to the whole field is `_deviation_from_inverse_response`, which divides out
+    this response and the fitted curve together.
     """
     count = len(amplitude)
     # Carrier amplitude is physically positive, so zero
@@ -118,12 +139,21 @@ def rf_path_response(rf):
     signal before the carrier amplitude is taken, so consuming it directly keeps
     this correct for every format and every combination of ramp boost, peaking
     and notch options.
+
+    Fixed for the life of the decoder, so it is derived once and kept on the
+    decoder rather than rebuilt every field.
     """
+    cached = getattr(rf, "_luma_amplitude_response", None)
+    if cached is not None:
+        return cached
+
     response = np.abs(rf.Filters["RFVideo"])
     # The stored response covers the whole spectrum with the negative
     # frequencies mirrored above Nyquist; only the positive half is meaningful.
     half = len(response) // 2
-    return response[:half], rf.freq_hz / len(response)
+    cached = (response[:half], rf.freq_hz / len(response))
+    rf._luma_amplitude_response = cached
+    return cached
 
 
 def carrier_frequency_bins(sys_params, rf):
@@ -151,7 +181,7 @@ def carrier_frequency_bins(sys_params, rf):
 
 @njit(cache=True, nogil=True, fastmath=True)
 def measure_amplitude_by_frequency(
-    amplitude, carrier_hz, sync_tip_hz, hz_ire, bin_count, group_count, stride
+    amplitude, carrier_hz, sync_tip_hz, hz_ire, bin_count, group_count
 ):
     """Carrier amplitude against carrier frequency, as points on a curve.
 
@@ -168,15 +198,16 @@ def measure_amplitude_by_frequency(
     the curve at the same confidence, and puts them where the picture actually
     is.
 
-    `stride` subsamples the field for the curve only; the correction itself
-    still applies to every sample. The curve has three parameters and a field
-    has hundreds of thousands of samples, so it is not short of evidence.
+    The caller passes a subsample of the field, already gathered; the curve has
+    three parameters and even a subsample carries tens of thousands of points,
+    so it is not short of evidence. The correction itself still applies to every
+    sample.
     """
     count = len(amplitude)
     fine = np.zeros(bin_count, dtype=np.int64)
     index = np.full(count, -1, dtype=np.int64)
 
-    for i in range(0, count, stride):
+    for i in range(count):
         value = amplitude[i]
         if value <= 0.0:
             continue
@@ -223,7 +254,7 @@ def measure_amplitude_by_frequency(
         start[g + 1] = start[g] + np.int64(population[g])
     cursor = start[:groups].copy()
     grouped = np.empty(start[groups], dtype=amplitude.dtype)
-    for i in range(0, count, stride):
+    for i in range(count):
         b = index[i]
         if b >= 0:
             g = group_of[b]
@@ -300,31 +331,67 @@ def _normalize_frequency(carrier_hz, sync_tip_hz, peak_white_hz):
     return (carrier_hz - sync_tip_hz) / span
 
 
-@njit(cache=True, nogil=True, fastmath=True)
-def _deviation_from_response(
-    flattened, carrier_hz, coefficients, sync_tip_hz, span_hz, low, high
+def _inverse_response_table(
+    response, frequency_step, coefficients, sync_tip_hz, peak_white_hz
 ):
-    """How far the amplitude departs from the response fitted to it.
+    """The whole modelled response, inverted, on the grid it is tabulated on.
 
-    One pass over the field: the curve is evaluated, divided out and bounded in
-    place, rather than building an expected-amplitude array to divide by.
+    The decoder's own RF path and the curve fitted on top of it are both
+    functions of carrier frequency alone, evaluated on the same uniform grid, so
+    there is no reason to carry them as two divisions per sample. Combining them
+    here turns the correction's per-sample work into a table lookup and a
+    multiply, and confines the exponential to the few thousand points that
+    describe the response rather than the million it is applied to.
+
+    Zero marks a frequency at which the model says nothing usable - the response
+    vanishes, or the extrapolated curve has run out of range. That is the same
+    sentinel the amplitude itself uses, and it leaves the deviation at unity.
     """
-    count = len(flattened)
-    deviation = np.ones(count)
-    order = len(coefficients)
+    grid_hz = np.arange(len(response), dtype=np.float64) * frequency_step
+    normalized = _normalize_frequency(grid_hz, sync_tip_hz, peak_white_hz)
+
+    with np.errstate(over="ignore", under="ignore", divide="ignore", invalid="ignore"):
+        modelled = response * np.exp(np.polyval(coefficients, normalized))
+        # Narrowed here rather than after, so a reciprocal that is finite in
+        # double and infinite in single is caught by the same test as the rest.
+        inverse = np.reciprocal(modelled).astype(np.float32)
+
+    inverse[~np.isfinite(inverse)] = 0.0
+    inverse[modelled <= 0.0] = 0.0
+    return inverse
+
+
+@njit(cache=True, nogil=True, fastmath=True)
+def _deviation_from_inverse_response(
+    amplitude, carrier_hz, inverse_response, frequency_step, low, high
+):
+    """How far the amplitude departs from the response modelled for it.
+
+    One pass over the field, and no transcendental in it: the modelled response
+    was inverted where it was tabulated, so what is left per sample is an
+    interpolation, a multiply and a bound.
+    """
+    count = len(amplitude)
+    deviation = np.empty(count, dtype=np.float32)
+    last = len(inverse_response) - 1
+    one = np.float32(1.0)
+    zero = np.float32(0.0)
     for i in range(count):
-        value = flattened[i]
-        if value <= 0.0:
-            continue
-        normalized = (carrier_hz[i] - sync_tip_hz) / span_hz
-        accumulated = 0.0
-        for c in range(order):
-            accumulated = accumulated * normalized + coefficients[c]
-        expected = np.exp(accumulated)
-        if expected <= 0.0:
-            continue
-        ratio = value / expected
-        if ratio < low:
+        position = carrier_hz[i] / frequency_step
+        if position <= zero:
+            inverse = inverse_response[0]
+        elif position >= last:
+            inverse = inverse_response[last]
+        else:
+            lower = np.int32(position)
+            fraction = position - np.float32(lower)
+            base = inverse_response[lower]
+            inverse = base + (inverse_response[lower + 1] - base) * fraction
+        ratio = amplitude[i] * inverse
+        if ratio <= zero:
+            # no measurement here, or no usable model - leave the sample alone
+            ratio = one
+        elif ratio < low:
             ratio = low
         elif ratio > high:
             ratio = high
@@ -335,11 +402,6 @@ def _deviation_from_response(
 def measure_amplitude_deviation(field):
     '''How far the luma carrier's amplitude departs from the constant it should
     hold, measured across the whole field on the raw RF sample grid.
-
-    The amplitude is taken as measured, instantaneously, with no band limit:
-    the tape imposes its amplitude noise at whatever rate it imposes it, and a
-    filter here would decide in advance which of that the correction is allowed
-    to see.
 
     Returns an `AmplitudeDeviation`, or None if the field cannot support a
     measurement.
@@ -352,6 +414,11 @@ def measure_amplitude_deviation(field):
     be continuous too - fitting each demodulation block separately puts a step
     at every block seam, on a carrier amplitude that has none.
 
+    The response curve is fitted from a subsample and applied to every sample.
+    The curve has three parameters and the subsample carries tens of thousands
+    of points, so the fit is not the limiting factor; walking the whole field
+    twice to determine it would be.
+
     Nothing here knows about the color-under. What comes back is a property of
     the luma carrier alone - the tape's multiplicative noise, with the path's
     response to the carrier's own frequency already removed - so it can drive
@@ -362,32 +429,35 @@ def measure_amplitude_deviation(field):
     if video is None or "demod_raw" not in (video.dtype.names or ()):
         return None
 
-    amplitude = np.asarray(video["envelope"], dtype=np.float64)
-    carrier_hz = np.asarray(video["demod_raw"], dtype=np.float64)
+    # Read as recorded. Both channels are already single precision, so these are
+    # views onto the field's record array rather than copies of it.
+    amplitude = video["envelope"]
+    carrier_hz = video["demod_raw"]
     if len(amplitude) != len(carrier_hz) or len(amplitude) == 0:
         return None
 
     sys_params = rf.SysParams
     sync_tip_hz, peak_white_hz, bin_count = carrier_frequency_bins(sys_params, rf)
-
     response, frequency_step = rf_path_response(rf)
-    flattened = _flatten_by_response(amplitude, carrier_hz, response, frequency_step)
 
     # The part of the amplitude that follows the carrier's own frequency,
     # measured once over the concatenated field. Demodulation stays per block
     # and is not repeated here; what is measured is the assembled result, so
     # neither the curve nor the level it implies has a block boundary in it.
     stride = max(
-        1, len(flattened) // (RESPONSE_CURVE_POINTS * CURVE_SAMPLES_PER_POINT)
+        1, len(amplitude) // (RESPONSE_CURVE_POINTS * CURVE_SAMPLES_PER_POINT)
     )
+    sampled_amplitude = np.asarray(amplitude[::stride], dtype=np.float64)
+    sampled_carrier_hz = np.asarray(carrier_hz[::stride], dtype=np.float64)
     levels, population, centre_hz = measure_amplitude_by_frequency(
-        flattened,
-        carrier_hz,
+        _flatten_by_response(
+            sampled_amplitude, sampled_carrier_hz, response, frequency_step
+        ),
+        sampled_carrier_hz,
         sync_tip_hz,
         sys_params["hz_ire"],
         bin_count,
         RESPONSE_CURVE_POINTS,
-        stride,
     )
     coefficients = fit_response_curve(
         levels, population, centre_hz, sync_tip_hz, peak_white_hz
@@ -396,14 +466,15 @@ def measure_amplitude_deviation(field):
         return None
 
     dropout_fraction = rf.dod_options.dod_threshold_p
-    deviation = _deviation_from_response(
-        flattened,
+    deviation = _deviation_from_inverse_response(
+        amplitude,
         carrier_hz,
-        coefficients,
-        sync_tip_hz,
-        max(peak_white_hz - sync_tip_hz, np.finfo(np.float64).tiny),
-        dropout_fraction,
-        1.0 / dropout_fraction,
+        _inverse_response_table(
+            response, frequency_step, coefficients, sync_tip_hz, peak_white_hz
+        ),
+        np.float32(frequency_step),
+        np.float32(dropout_fraction),
+        np.float32(1.0 / dropout_fraction),
     )
 
     return AmplitudeDeviation(deviation, carrier_hz)

--- a/vhsdecode/luma_amplitude.py
+++ b/vhsdecode/luma_amplitude.py
@@ -426,7 +426,7 @@ def measure_amplitude_deviation(field):
     '''
     rf = field.rf
     video = field.data["video"]
-    if video is None or "demod_raw" not in (video.dtype.names or ()):
+    if video is None or "demod_raw" not in video:
         return None
 
     # Read as recorded. Both channels are already single precision, so these are

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -330,6 +330,16 @@ def main(args=None, use_gui=False):
         help="Detects and corrects color-under heterodyne rotation change around head-switching area. Corrects chroma artifacts around head-switching area for color-under formats. (Experimental feature)",
     )
     chroma_group.add_argument(
+        "--chroma_env_gain",
+        dest="chroma_env_gain",
+        type=float,
+        default=1,
+        help=(
+            "Corrects color-under amplitude from the luma FM envelope (color-under only). Wet/dry mix of the correction, 0 disables it. Default is 1. (Experimental feature)"
+            "\n  The luma FM carrier and the color-under chroma were written by the same head at the same instant, so head-to-medium separation loss is shared between them and scales with wavelength. The luma envelope therefore measures, at full sample rate, the intra-line amplitude profile that the once-per-line color burst cannot see, and restores saturation through dropouts and modulation noise. Amplifies chroma noise in the regions it corrects."
+        ),
+    )
+    chroma_group.add_argument(
         "--cti_mix",
         dest="cti_mix",
         type=float,
@@ -408,7 +418,7 @@ def main(args=None, use_gui=False):
             " some of the chroma processing."
         ),
     )
-    plot_options = "demodblock, deemphasis, raw_pulses, line_locs, rf_luma, vsync_levels"
+    plot_options = "demodblock, deemphasis, raw_pulses, line_locs, rf_luma, vsync_levels, luma_noise"
     debug_group.add_argument(
         "--dp",
         "--debug_plot",
@@ -647,6 +657,7 @@ def main(args=None, use_gui=False):
     rf_options["cti_width"] = args.cti_width
     rf_options["cafc"] = args.cafc
     rf_options["cagc_fields"] = args.cagc_fields
+    rf_options["chroma_env_gain"] = args.chroma_env_gain
     rf_options["disable_right_hsync"] = args.disable_right_hsync
     rf_options["fallback_vsync"] = args.fallback_vsync
     rf_options["relaxed_line0"] = args.relaxed_line0

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -292,6 +292,16 @@ def main(args=None, use_gui=False):
     )
     chroma_group = parser.add_argument_group("Chroma decoding options")
     chroma_group.add_argument(
+        "--cagc",
+        dest="cagc_fields",
+        type=int,
+        default=0,
+        help=(
+            "Sets the number of fields to use for averaging chroma automatic gain control. Default is 0 (no averaging). "
+            "\nThis is useful for correcting chroma gain issues commonly present in camcorder recordings."
+        ),
+    )
+    chroma_group.add_argument(
         "--cafc",
         "--chroma_AFC",
         dest="cafc",
@@ -636,6 +646,7 @@ def main(args=None, use_gui=False):
     rf_options["cti_mix"] = args.cti_mix
     rf_options["cti_width"] = args.cti_width
     rf_options["cafc"] = args.cafc
+    rf_options["cagc_fields"] = args.cagc_fields
     rf_options["disable_right_hsync"] = args.disable_right_hsync
     rf_options["fallback_vsync"] = args.fallback_vsync
     rf_options["relaxed_line0"] = args.relaxed_line0

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -1478,27 +1478,28 @@ class VHSRFDecode(ldd.RFDecode):
             # "demod_raw" is the name lddecode's own demodblock already uses for
             # this signal. Only carried when the correction is enabled, so the
             # extra channel costs nothing otherwise.
-            video_out = np.rec.array(
-                [
-                    out_video, demod.astype(np.float32), out_video05, out_chroma,
-                    env,
-                ],
-                names=[
-                    "demod",
-                    "demod_raw",
-                    "demod_05",
-                    "demod_burst",
-                    "envelope",
-                ],
-            )
+            video_out = {
+                "demod": out_video,
+                "demod_raw": demod.astype(np.float32),
+                "demod_05": out_video05,
+                "demod_burst": out_chroma,
+                "envelope": env,
+            }
         else:
-            video_out = np.rec.array(
-                [out_video, out_video05, out_chroma, env],
-                names=["demod", "demod_05", "demod_burst", "envelope"],
-            )
+            video_out = {
+                "demod": out_video,
+                "demod_05": out_video05,
+                "demod_burst": out_chroma,
+                "envelope": env,
+            }
 
         rv["video"] = (
-            video_out[self.blockcut : -self.blockcut_end] if cut else video_out
+            {
+                name: channel[self.blockcut : -self.blockcut_end]
+                for name, channel in video_out.items()
+            }
+            if cut
+            else video_out
         )
 
         demod_end_time = time.time()

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -7,6 +7,7 @@ import threading
 from collections import namedtuple
 from concurrent.futures import ThreadPoolExecutor
 
+
 import lddecode.core as ldd
 
 # from lddecode.core import npfft
@@ -760,6 +761,7 @@ class VHSRFDecode(ldd.RFDecode):
                 "fm_audio_notch",
                 "chroma_audio_notch",
                 "chroma_offset",
+                "cagc_fields",
                 "cti_mix",
                 "cti_width",
                 "ire0_adjust",
@@ -805,6 +807,7 @@ class VHSRFDecode(ldd.RFDecode):
             rf_options.get("fm_audio_notch", 0) or (tape_format == "HI8"),
             self.DecoderParams.get("chroma_audio_notch_freq", 0) > 0,
             int(self.DecoderParams.get("chroma_offset", 5) * (self.freq / 40.0)),
+            rf_options.get("cagc_fields", 0),
             rf_options.get("cti_mix", 1),
             rf_options.get("cti_width", 2),
             ire0_adjust,
@@ -975,7 +978,9 @@ class VHSRFDecode(ldd.RFDecode):
                 window_average=self.SysParams["FPS"] / 2
             ), StackableMA(window_average=self.SysParams["FPS"] / 2)
 
-        self._field_averages = FieldAverage()
+        self._field_averages = FieldAverage(
+            self._options.cagc_fields
+        )
 
         # TODO: This should be managed elsewhere.
         self._compute_linelocs_issues = False

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -762,6 +762,7 @@ class VHSRFDecode(ldd.RFDecode):
                 "chroma_audio_notch",
                 "chroma_offset",
                 "cagc_fields",
+                "chroma_env_gain",
                 "cti_mix",
                 "cti_width",
                 "ire0_adjust",
@@ -808,6 +809,7 @@ class VHSRFDecode(ldd.RFDecode):
             self.DecoderParams.get("chroma_audio_notch_freq", 0) > 0,
             int(self.DecoderParams.get("chroma_offset", 5) * (self.freq / 40.0)),
             rf_options.get("cagc_fields", 0),
+            rf_options.get("chroma_env_gain", 0),
             rf_options.get("cti_mix", 1),
             rf_options.get("cti_width", 2),
             ire0_adjust,
@@ -1467,10 +1469,33 @@ class VHSRFDecode(ldd.RFDecode):
             out_video = demod
 
         # demod_burst is a bit misleading, but keeping the naming for compatability.
-        video_out = np.rec.array(
-            [out_video, out_video05, out_chroma, env],
-            names=["demod", "demod_05", "demod_burst", "envelope"],
-        )
+        if self.options.chroma_env_gain > 0:
+            # The color-under amplitude correction models the carrier amplitude
+            # as a function of the instantaneous carrier frequency, so it needs
+            # the demodulated frequency before de-emphasis - the de-emphasised
+            # output understates deviation above the de-emphasis corner, which
+            # is well inside the bandwidth the envelope is measured over.
+            # "demod_raw" is the name lddecode's own demodblock already uses for
+            # this signal. Only carried when the correction is enabled, so the
+            # extra channel costs nothing otherwise.
+            video_out = np.rec.array(
+                [
+                    out_video, demod.astype(np.float32), out_video05, out_chroma,
+                    env,
+                ],
+                names=[
+                    "demod",
+                    "demod_raw",
+                    "demod_05",
+                    "demod_burst",
+                    "envelope",
+                ],
+            )
+        else:
+            video_out = np.rec.array(
+                [out_video, out_video05, out_chroma, env],
+                names=["demod", "demod_05", "demod_burst", "envelope"],
+            )
 
         rv["video"] = (
             video_out[self.blockcut : -self.blockcut_end] if cut else video_out


### PR DESCRIPTION
# Features

* Chroma amplitude correction from the luma FM carrier (see below)
  *  `--chroma_env_gain <amount>` | Default `1` | Wet/dry mix of the correction. `0` disables it. **On by default.**
  * `--dp luma_noise` plots the carrier amplitude, the demodulated luma, and the correction's confidence weight
* Chroma automatic gain control averaging over multiple fields.
  *  `--cagc <fields>` | Default `0` | Averages the chroma automatic gain control over N fields. Useful for camcorder recordings.
  * The averaging is split into even and odd fields, since it's likely that chroma levels differ at record time between the two field paths.
* _performance_: Use numpy arrays to store the video data.
  * Previously this was using a packed record type which significantly harms sequential access to the data that stores all the demodulated data into a dictionary of arrays.
  * This is a huge performance win. On my machine, it is about 50% faster now, i.e. 6fps -> ~10fps

# Fixes
* Fix `chroma_to_u16` overflow so that clipping saturates rather than overflows.
  * TODO: Perhaps a warning should be emitted for this scenario.

---

## Chroma amplitude correction from the luma FM carrier

Corrects color-under amplitude using the luma FM carrier's envelope as a reference, recovering saturation through dropouts and modulation noise observed in the luma channel.

### Premise

An FM carrier should hold constant amplitude, so every departure from constant is imposed by the tape. The luma FM carrier and the color-under were written by the same head, onto the same oxide, at the same instant — head-to-medium separation loss is shared between them and scales with wavelength. The luma envelope therefore measures, at full sample rate, the amplitude damage the color burst only samples once per line.


### How it works

The luma channel is used as a reference to correct amplitude noise in the color under signal. This can be done since the luma is ideally a fixed amplitude (FM encoded). This means that any noise or changes in this amplitude represent noise introduced after it was written to the tape (tape noise, dropouts, other noise sources).

#### Measuring the luma noise
The demodulated luma represents the instantaneous frequency of the luma signal. An interesting property emerges from this frequency measurement because of the high frequency roll off of magnetic tape. The amplitude of the recorded luma is altered depending on the carrier frequency. By subtracting out the amplitude that correlates with the instantaneous frequency, we can isolate only the noise from the luma channel. This subtraction gives us the differential between the expected luma and the measured luma because the expected luma a fixed amplitude.

#### Applying the correction to the chroma
The correction is very simple since all that is needed is to inverse the luma's noise profile onto the chroma channel. This removes all of the noise that was measured in the luma channel.

### Results

This performs very well, and I don't see any downsides in all of my tests. Examples coming soon.